### PR TITLE
Simplify usage of progress component

### DIFF
--- a/Demos/Blazorise.Demo/Pages/Tests/ProgressBarsPage.razor
+++ b/Demos/Blazorise.Demo/Pages/Tests/ProgressBarsPage.razor
@@ -9,23 +9,13 @@
                 <CardText>Default progress bar.</CardText>
             </CardBody>
             <CardBody>
-                <Progress Margin="Margin.Is3.FromBottom">
-                    <ProgressBar />
-                </Progress>
-                <Progress Margin="Margin.Is3.FromBottom">
-                    <ProgressBar Value="50" />
-                </Progress>
-                <Progress Margin="Margin.Is3.FromBottom">
-                    <ProgressBar Value="50" />
-                </Progress>
-                <Progress Margin="Margin.Is3.FromBottom">
-                    <ProgressBar Value="75" />
-                </Progress>
-                <Progress Margin="Margin.Is3.FromBottom">
-                    <ProgressBar Value="100" />
-                </Progress>
-                <Progress Margin="Margin.Is3.FromBottom">
-                    <ProgressBar Value="25">25%</ProgressBar>
+                <Progress Margin="Margin.Is3.FromBottom" />
+                <Progress Value="50" Margin="Margin.Is3.FromBottom" />
+                <Progress Value="50" Margin="Margin.Is3.FromBottom" />
+                <Progress Value="75" Margin="Margin.Is3.FromBottom" />
+                <Progress Value="100" Margin="Margin.Is3.FromBottom" />
+                <Progress Value="25" Margin="Margin.Is3.FromBottom">
+                    25%
                 </Progress>
             </CardBody>
         </Card>
@@ -39,18 +29,10 @@
                 <CardText>Progress bars use some of the same button and alert classes for consistent styles.</CardText>
             </CardBody>
             <CardBody>
-                <Progress Margin="Margin.Is3.FromBottom">
-                    <ProgressBar Color="Color.Success" Value="25" />
-                </Progress>
-                <Progress Margin="Margin.Is3.FromBottom">
-                    <ProgressBar Color="Color.Info" Value="50" />
-                </Progress>
-                <Progress Margin="Margin.Is3.FromBottom">
-                    <ProgressBar Color="Color.Warning" Value="75" />
-                </Progress>
-                <Progress Margin="Margin.Is3.FromBottom">
-                    <ProgressBar Color="Color.Danger" Value="100" />
-                </Progress>
+                <Progress Color="Color.Success" Value="25" Margin="Margin.Is3.FromBottom" />
+                <Progress Color="Color.Info" Value="50" Margin="Margin.Is3.FromBottom" />
+                <Progress Color="Color.Warning" Value="75" Margin="Margin.Is3.FromBottom" />
+                <Progress Color="Color.Danger" Value="100" Margin="Margin.Is3.FromBottom" />
                 <Progress Margin="Margin.Is3.FromBottom">
                     <ProgressBar Value="15" />
                     <ProgressBar Color="Color.Success" Value="30" />
@@ -71,24 +53,12 @@
             </CardBody>
             <CardBody>
                 <CardBody>
-                    <Progress Margin="Margin.Is3.FromBottom">
-                        <ProgressBar Striped="true" Value="10" />
-                    </Progress>
-                    <Progress Margin="Margin.Is3.FromBottom">
-                        <ProgressBar Color="Color.Success" Striped="true" Value="25" />
-                    </Progress>
-                    <Progress Margin="Margin.Is3.FromBottom">
-                        <ProgressBar Color="Color.Info" Striped="true" Value="50" />
-                    </Progress>
-                    <Progress Margin="Margin.Is3.FromBottom">
-                        <ProgressBar Color="Color.Warning" Striped="true" Value="75" />
-                    </Progress>
-                    <Progress Margin="Margin.Is3.FromBottom">
-                        <ProgressBar Color="Color.Danger" Striped="true" Value="100" />
-                    </Progress>
-                    <Progress Margin="Margin.Is3.FromBottom">
-                        <ProgressBar Striped="true" Animated="true" Value="75" />
-                    </Progress>
+                    <Progress Striped="true" Value="10" Margin="Margin.Is3.FromBottom" />
+                    <Progress Color="Color.Success" Striped="true" Value="25" Margin="Margin.Is3.FromBottom" />
+                    <Progress Color="Color.Info" Striped="true" Value="50" Margin="Margin.Is3.FromBottom" />
+                    <Progress Color="Color.Warning" Striped="true" Value="75" Margin="Margin.Is3.FromBottom" />
+                    <Progress Color="Color.Danger" Striped="true" Value="100" Margin="Margin.Is3.FromBottom" />
+                    <Progress Striped="true" Animated="true" Value="75" Margin="Margin.Is3.FromBottom" />
                 </CardBody>
             </CardBody>
         </Card>
@@ -102,24 +72,12 @@
                 <CardText>Your awesome text goes here.</CardText>
             </CardBody>
             <CardBody>
-                <Progress Margin="Margin.Is3.FromBottom" Size="Size.ExtraSmall">
-                    <ProgressBar Color="Color.Success" Value="15" />
-                </Progress>
-                <Progress Margin="Margin.Is3.FromBottom" Size="Size.Small">
-                    <ProgressBar Color="Color.Info" Value="20" />
-                </Progress>
-                <Progress Margin="Margin.Is3.FromBottom">
-                    <ProgressBar Color="Color.Primary" Value="35" />
-                </Progress>
-                <Progress Margin="Margin.Is3.FromBottom" Size="Size.Medium">
-                    <ProgressBar Color="Color.Info" Value="50" />
-                </Progress>
-                <Progress Margin="Margin.Is3.FromBottom" Size="Size.Large">
-                    <ProgressBar Color="Color.Warning" Value="75" />
-                </Progress>
-                <Progress Margin="Margin.Is3.FromBottom" Size="Size.ExtraLarge">
-                    <ProgressBar Color="Color.Danger" Value="100" />
-                </Progress>
+                <Progress Color="Color.Success" Value="15" Margin="Margin.Is3.FromBottom" Size="Size.ExtraSmall" />
+                <Progress Color="Color.Info" Value="20" Margin="Margin.Is3.FromBottom" Size="Size.Small" />
+                <Progress Color="Color.Primary" Value="35" Margin="Margin.Is3.FromBottom" />
+                <Progress Color="Color.Info" Value="50" Margin="Margin.Is3.FromBottom" Size="Size.Medium" />
+                <Progress Color="Color.Warning" Value="75" Margin="Margin.Is3.FromBottom" Size="Size.Large" />
+                <Progress Color="Color.Danger" Value="100" Margin="Margin.Is3.FromBottom" Size="Size.ExtraLarge" />
             </CardBody>
         </Card>
     </Column>

--- a/Demos/Blazorise.Demo/Pages/Tests/ProgressBarsPage.razor
+++ b/Demos/Blazorise.Demo/Pages/Tests/ProgressBarsPage.razor
@@ -40,21 +40,21 @@
             </CardBody>
             <CardBody>
                 <Progress Margin="Margin.Is3.FromBottom">
-                    <ProgressBar Background="Background.Success" Value="25" />
+                    <ProgressBar Color="Color.Success" Value="25" />
                 </Progress>
                 <Progress Margin="Margin.Is3.FromBottom">
-                    <ProgressBar Background="Background.Info" Value="50" />
+                    <ProgressBar Color="Color.Info" Value="50" />
                 </Progress>
                 <Progress Margin="Margin.Is3.FromBottom">
-                    <ProgressBar Background="Background.Warning" Value="75" />
+                    <ProgressBar Color="Color.Warning" Value="75" />
                 </Progress>
                 <Progress Margin="Margin.Is3.FromBottom">
-                    <ProgressBar Background="Background.Danger" Value="100" />
+                    <ProgressBar Color="Color.Danger" Value="100" />
                 </Progress>
                 <Progress Margin="Margin.Is3.FromBottom">
                     <ProgressBar Value="15" />
-                    <ProgressBar Background="Background.Success" Value="30" />
-                    <ProgressBar Background="Background.Info" Value="20" />
+                    <ProgressBar Color="Color.Success" Value="30" />
+                    <ProgressBar Color="Color.Info" Value="20" />
                 </Progress>
             </CardBody>
         </Card>
@@ -75,16 +75,16 @@
                         <ProgressBar Striped="true" Value="10" />
                     </Progress>
                     <Progress Margin="Margin.Is3.FromBottom">
-                        <ProgressBar Background="Background.Success" Striped="true" Value="25" />
+                        <ProgressBar Color="Color.Success" Striped="true" Value="25" />
                     </Progress>
                     <Progress Margin="Margin.Is3.FromBottom">
-                        <ProgressBar Background="Background.Info" Striped="true" Value="50" />
+                        <ProgressBar Color="Color.Info" Striped="true" Value="50" />
                     </Progress>
                     <Progress Margin="Margin.Is3.FromBottom">
-                        <ProgressBar Background="Background.Warning" Striped="true" Value="75" />
+                        <ProgressBar Color="Color.Warning" Striped="true" Value="75" />
                     </Progress>
                     <Progress Margin="Margin.Is3.FromBottom">
-                        <ProgressBar Background="Background.Danger" Striped="true" Value="100" />
+                        <ProgressBar Color="Color.Danger" Striped="true" Value="100" />
                     </Progress>
                     <Progress Margin="Margin.Is3.FromBottom">
                         <ProgressBar Striped="true" Animated="true" Value="75" />
@@ -103,22 +103,22 @@
             </CardBody>
             <CardBody>
                 <Progress Margin="Margin.Is3.FromBottom" Size="Size.ExtraSmall">
-                    <ProgressBar Background="Background.Success" Value="15" />
+                    <ProgressBar Color="Color.Success" Value="15" />
                 </Progress>
                 <Progress Margin="Margin.Is3.FromBottom" Size="Size.Small">
-                    <ProgressBar Background="Background.Info" Value="20" />
+                    <ProgressBar Color="Color.Info" Value="20" />
                 </Progress>
                 <Progress Margin="Margin.Is3.FromBottom">
-                    <ProgressBar Background="Background.Primary" Value="35" />
+                    <ProgressBar Color="Color.Primary" Value="35" />
                 </Progress>
                 <Progress Margin="Margin.Is3.FromBottom" Size="Size.Medium">
-                    <ProgressBar Background="Background.Info" Value="50" />
+                    <ProgressBar Color="Color.Info" Value="50" />
                 </Progress>
                 <Progress Margin="Margin.Is3.FromBottom" Size="Size.Large">
-                    <ProgressBar Background="Background.Warning" Value="75" />
+                    <ProgressBar Color="Color.Warning" Value="75" />
                 </Progress>
                 <Progress Margin="Margin.Is3.FromBottom" Size="Size.ExtraLarge">
-                    <ProgressBar Background="Background.Danger" Value="100" />
+                    <ProgressBar Color="Color.Danger" Value="100" />
                 </Progress>
             </CardBody>
         </Card>

--- a/Source/Blazorise.AntDesign/AntDesignClassProvider.cs
+++ b/Source/Blazorise.AntDesign/AntDesignClassProvider.cs
@@ -791,6 +791,14 @@ namespace Blazorise.AntDesign
 
         public override string ProgressSize( Size size ) => $"progress-{ToSize( size )}";
 
+        public override string ProgressColor( Color color ) => null;
+
+        public override string ProgressStriped() => null;
+
+        public override string ProgressAnimated() => null;
+
+        public override string ProgressWidth( int width ) => null;
+
         public override string ProgressBar() => "ant-progress-bg b-ant-progress-text";
 
         public override string ProgressBarSize( Size size ) => $"ant-progress-bg-{ToSize( size )}";

--- a/Source/Blazorise.AntDesign/AntDesignClassProvider.cs
+++ b/Source/Blazorise.AntDesign/AntDesignClassProvider.cs
@@ -793,11 +793,13 @@ namespace Blazorise.AntDesign
 
         public override string ProgressBar() => "ant-progress-bg b-ant-progress-text";
 
-        public override string ProgressBarSize( Size size ) => null;
+        public override string ProgressBarSize( Size size ) => $"ant-progress-bg-{ToSize( size )}";
 
-        public override string ProgressBarStriped() => "progress-bar-striped";
+        public override string ProgressBarColor( Color color ) => $"bg-{ToColor( color )}";
 
-        public override string ProgressBarAnimated() => "progress-bar-animated";
+        public override string ProgressBarStriped() => "ant-progress-bar-striped";
+
+        public override string ProgressBarAnimated() => "ant-progress-bar-animated";
 
         public override string ProgressBarWidth( int width ) => null;
 

--- a/Source/Blazorise.AntDesign/AntDesignStyleProvider.cs
+++ b/Source/Blazorise.AntDesign/AntDesignStyleProvider.cs
@@ -25,18 +25,18 @@ namespace Blazorise.AntDesign
 
         public override string ProgressBarValue( int value ) => $"width: {value}%";
 
-        public override string ProgressBarSize( Size size )
-        {
-            return size switch
-            {
-                Size.ExtraSmall => $"height: .25rem",
-                Size.Small => $"height: .5rem",
-                Size.Medium => $"height: 1.25rem",
-                Size.Large => $"height: 1.5rem",
-                Size.ExtraLarge => $"height: 2rem",
-                _ => $"height: 1rem",
-            };
-        }
+        public override string ProgressBarSize( Size size ) => null;
+        //{
+        //    return size switch
+        //    {
+        //        Size.ExtraSmall => $"height: .25rem",
+        //        Size.Small => $"height: .5rem",
+        //        Size.Medium => $"height: 1.25rem",
+        //        Size.Large => $"height: 1.5rem",
+        //        Size.ExtraLarge => $"height: 2rem",
+        //        _ => $"height: 1rem",
+        //    };
+        //}
 
         #endregion
 

--- a/Source/Blazorise.AntDesign/Progress.razor
+++ b/Source/Blazorise.AntDesign/Progress.razor
@@ -1,10 +1,21 @@
 ﻿@inherits Blazorise.Progress
 <CascadingValue Value="@this" IsFixed="true">
-    <div id="@ElementId" class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
-        <div class="ant-progress-outer">
-            <div class="ant-progress-inner">
-                @ChildContent
+    <CascadingValue Value="@State">
+        <div id="@ElementId" class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
+            <div class="ant-progress-outer">
+                <div class="ant-progress-inner">
+                    @if ( !HasProgressBar )
+                    {
+                        <div class="@ProgressBarClassNames" style="@ProgressBarStyleNames" role="progressbar" aria-valuenow="@Percentage" aria-valuemin="@Min" aria-valuemax="@Max" @attributes="@Attributes">
+                            @ChildContent
+                        </div>
+                    }
+                    else
+                    {
+                        @ChildContent
+                    }
+                </div>
             </div>
         </div>
-    </div>
+    </CascadingValue>
 </CascadingValue>

--- a/Source/Blazorise.AntDesign/Styles/_mixins.scss
+++ b/Source/Blazorise.AntDesign/Styles/_mixins.scss
@@ -46,3 +46,9 @@
         @content;
     }
 }
+
+// Gradients
+
+@mixin gradient-striped($color: rgba($white, .15), $angle: 45deg) {
+    background-image: linear-gradient($angle, $color 25%, transparent 25%, transparent 50%, $color 50%, $color 75%, transparent 75%, transparent);
+}

--- a/Source/Blazorise.AntDesign/Styles/_progress.scss
+++ b/Source/Blazorise.AntDesign/Styles/_progress.scss
@@ -1,4 +1,62 @@
-﻿.ant-progress-inner {
+﻿.ant-progress {
+    > .ant-progress-outer {
+        > .ant-progress-inner {
+            .ant-progress-bg {
+                height: 1rem;
+
+                &:first-child {
+                    border-top-right-radius: 0;
+                    border-bottom-right-radius: 0;
+                }
+
+                &:not(:first-child) {
+                    border-radius: 0;
+                }
+
+                &-xs {
+                    height: .25rem;
+                }
+
+                &-sm {
+                    height: .5rem;
+                }
+
+                &-md {
+                    height: 1.25rem;
+                }
+
+                &-lg {
+                    height: 1.5rem;
+                }
+
+                &-xl {
+                    height: 2rem;
+                }
+            }
+        }
+    }
+}
+
+.ant-progress-bar-striped {
+    @include gradient-striped();
+    background-size: 1rem 1rem;
+}
+
+@keyframes progress-bar-stripes {
+    from {
+        background-position: 1rem 0;
+    }
+
+    to {
+        background-position: 0 0;
+    }
+}
+
+.ant-progress-bar-animated {
+    animation: progress-bar-stripes 1s linear infinite;
+}
+
+.ant-progress-inner {
     display: inline-flex;
 }
 

--- a/Source/Blazorise.AntDesign/wwwroot/blazorise.antdesign.css
+++ b/Source/Blazorise.AntDesign/wwwroot/blazorise.antdesign.css
@@ -1975,6 +1975,37 @@ li.ant-list-item-actionable {
     margin-right: 0;
     line-height: 48px; }
 
+.ant-progress > .ant-progress-outer > .ant-progress-inner .ant-progress-bg {
+    height: 1rem; }
+    .ant-progress > .ant-progress-outer > .ant-progress-inner .ant-progress-bg:first-child {
+        border-top-right-radius: 0;
+        border-bottom-right-radius: 0; }
+    .ant-progress > .ant-progress-outer > .ant-progress-inner .ant-progress-bg:not(:first-child) {
+        border-radius: 0; }
+    .ant-progress > .ant-progress-outer > .ant-progress-inner .ant-progress-bg-xs {
+        height: .25rem; }
+    .ant-progress > .ant-progress-outer > .ant-progress-inner .ant-progress-bg-sm {
+        height: .5rem; }
+    .ant-progress > .ant-progress-outer > .ant-progress-inner .ant-progress-bg-md {
+        height: 1.25rem; }
+    .ant-progress > .ant-progress-outer > .ant-progress-inner .ant-progress-bg-lg {
+        height: 1.5rem; }
+    .ant-progress > .ant-progress-outer > .ant-progress-inner .ant-progress-bg-xl {
+        height: 2rem; }
+
+.ant-progress-bar-striped {
+    background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+    background-size: 1rem 1rem; }
+
+@keyframes progress-bar-stripes {
+    from {
+        background-position: 1rem 0; }
+    to {
+        background-position: 0 0; } }
+
+.ant-progress-bar-animated {
+    animation: progress-bar-stripes 1s linear infinite; }
+
 .ant-progress-inner {
     display: inline-flex; }
 

--- a/Source/Blazorise.Bootstrap/BootstrapClassProvider.cs
+++ b/Source/Blazorise.Bootstrap/BootstrapClassProvider.cs
@@ -780,11 +780,13 @@ namespace Blazorise.Bootstrap
 
         public override string ProgressBarSize( Size size ) => null;
 
+        public override string ProgressBarColor( Color color ) => $"bg-{ToColor( color )}";
+
         public override string ProgressBarStriped() => "progress-bar-striped";
 
         public override string ProgressBarAnimated() => "progress-bar-animated";
 
-        public override string ProgressBarWidth( int width ) => $"w-{width}";
+        public override string ProgressBarWidth( int width ) => null;
 
         #endregion
 

--- a/Source/Blazorise.Bootstrap/BootstrapClassProvider.cs
+++ b/Source/Blazorise.Bootstrap/BootstrapClassProvider.cs
@@ -776,6 +776,14 @@ namespace Blazorise.Bootstrap
 
         public override string ProgressSize( Size size ) => $"progress-{ToSize( size )}";
 
+        public override string ProgressColor( Color color ) => null;
+
+        public override string ProgressStriped() => null;
+
+        public override string ProgressAnimated() => null;
+
+        public override string ProgressWidth( int width ) => null;
+
         public override string ProgressBar() => "progress-bar";
 
         public override string ProgressBarSize( Size size ) => null;

--- a/Source/Blazorise.Bulma/BulmaClassProvider.cs
+++ b/Source/Blazorise.Bulma/BulmaClassProvider.cs
@@ -792,11 +792,19 @@ namespace Blazorise.Bulma
 
         #region Progress
 
-        public override string Progress() => "progress-wrapper";
+        public override string Progress() => "progress";
 
         public override string ProgressSize( Size size ) => $"is-{ToSize( size )}";
 
-        public override string ProgressBar() => "progress";
+        public override string ProgressColor( Color color ) => $"is-{ToColor( color )}";
+
+        public override string ProgressStriped() => "progress-striped";
+
+        public override string ProgressAnimated() => "progress-animated";
+
+        public override string ProgressWidth( int width ) => null;
+
+        public override string ProgressBar() => "progress-bar";
 
         public override string ProgressBarSize( Size size ) => $"is-{ToSize( size )}";
 

--- a/Source/Blazorise.Bulma/BulmaClassProvider.cs
+++ b/Source/Blazorise.Bulma/BulmaClassProvider.cs
@@ -792,19 +792,21 @@ namespace Blazorise.Bulma
 
         #region Progress
 
-        public override string Progress() => "progress";
+        public override string Progress() => "progress-wrapper";
 
         public override string ProgressSize( Size size ) => $"is-{ToSize( size )}";
 
         public override string ProgressBar() => "progress";
 
-        public override string ProgressBarSize( Size size ) => null;
+        public override string ProgressBarSize( Size size ) => $"is-{ToSize( size )}";
 
-        public override string ProgressBarStriped() => "progress-bar-striped";
+        public override string ProgressBarColor( Color color ) => $"is-{ToColor( color )}";
 
-        public override string ProgressBarAnimated() => "progress-bar-animated";
+        public override string ProgressBarStriped() => "progress-striped";
 
-        public override string ProgressBarWidth( int width ) => $"w-{width}";
+        public override string ProgressBarAnimated() => "progress-animated";
+
+        public override string ProgressBarWidth( int width ) => null;
 
         #endregion
 

--- a/Source/Blazorise.Bulma/BulmaStyleProvider.cs
+++ b/Source/Blazorise.Bulma/BulmaStyleProvider.cs
@@ -23,7 +23,7 @@ namespace Blazorise.Bulma
 
         #region ProgressBar
 
-        public override string ProgressBarValue( int value ) => null;//$"width: {value}%;";
+        public override string ProgressBarValue( int value ) => $"width: {value}%;";
 
         public override string ProgressBarSize( Size size ) => null;
 

--- a/Source/Blazorise.Bulma/BulmaStyleProvider.cs
+++ b/Source/Blazorise.Bulma/BulmaStyleProvider.cs
@@ -23,7 +23,7 @@ namespace Blazorise.Bulma
 
         #region ProgressBar
 
-        public override string ProgressBarValue( int value ) => $"width: {value}%";
+        public override string ProgressBarValue( int value ) => null;//$"width: {value}%;";
 
         public override string ProgressBarSize( Size size ) => null;
 

--- a/Source/Blazorise.Bulma/Config.cs
+++ b/Source/Blazorise.Bulma/Config.cs
@@ -64,6 +64,8 @@ namespace Blazorise.Bulma
             { typeof( Blazorise.NumericEdit<> ), typeof( Bulma.NumericEdit<> ) },
             { typeof( Blazorise.Pagination ), typeof( Bulma.Pagination ) },
             { typeof( Blazorise.PaginationLink ), typeof( Bulma.PaginationLink ) },
+            { typeof( Blazorise.Progress ), typeof( Bulma.Progress ) },
+            { typeof( Blazorise.ProgressBar ), typeof( Bulma.ProgressBar ) },
             { typeof( Blazorise.Steps ), typeof( Bulma.Steps ) },
             { typeof( Blazorise.Step ), typeof( Bulma.Step ) },
         };

--- a/Source/Blazorise.Bulma/Progress.razor
+++ b/Source/Blazorise.Bulma/Progress.razor
@@ -1,0 +1,6 @@
+﻿@inherits Blazorise.Progress
+<CascadingValue Value="@this" IsFixed="true">
+    <div class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
+        @ChildContent
+    </div>
+</CascadingValue>

--- a/Source/Blazorise.Bulma/Progress.razor
+++ b/Source/Blazorise.Bulma/Progress.razor
@@ -1,6 +1,19 @@
 ﻿@inherits Blazorise.Progress
 <CascadingValue Value="@this" IsFixed="true">
-    <div class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
-        @ChildContent
-    </div>
+    <CascadingValue Value="@State">
+        @if ( HasProgressBar )
+        {
+            <div class="progress-bars-wrapper">
+                @ChildContent
+            </div>
+        }
+        else
+        {
+            <div class="progress-wrapper">
+                <progress class="@ClassNames" style="@StyleNames" value="@Percentage" min="@Min" max="@Max" @attributes="@Attributes">
+                    @ChildContent
+                </progress>
+            </div>
+        }
+    </CascadingValue>
 </CascadingValue>

--- a/Source/Blazorise.Bulma/ProgressBar.razor
+++ b/Source/Blazorise.Bulma/ProgressBar.razor
@@ -1,4 +1,13 @@
 ﻿@inherits Blazorise.ProgressBar
-<progress class="@ClassNames" style="@StyleNames" value="@Percentage" min="@Min" max="@Max" @attributes="@Attributes">
-    @ChildContent
-</progress>
+<div class="@ClassNames" style="@StyleNames" role="progressbar" aria-valuenow="@Percentage" aria-valuemin="@Min" aria-valuemax="@Max" @attributes="@Attributes">
+    <p class="progress-value">
+        @if ( ChildContent != null )
+        {
+            @ChildContent
+        }
+        else
+        {
+            @Value
+        }
+    </p>
+</div>

--- a/Source/Blazorise.Bulma/ProgressBar.razor
+++ b/Source/Blazorise.Bulma/ProgressBar.razor
@@ -1,0 +1,4 @@
+﻿@inherits Blazorise.ProgressBar
+<progress class="@ClassNames" style="@StyleNames" value="@Percentage" min="@Min" max="@Max" @attributes="@Attributes">
+    @ChildContent
+</progress>

--- a/Source/Blazorise.Bulma/Styles/_mixins.scss
+++ b/Source/Blazorise.Bulma/Styles/_mixins.scss
@@ -176,3 +176,9 @@
 @mixin border-bottom-left-radius($radius) {
     border-bottom-left-radius: valid-radius($radius);
 }
+
+// Gradients
+
+@mixin gradient-striped($color: rgba($white, .15), $angle: 45deg) {
+    background-image: linear-gradient($angle, $color 25%, transparent 25%, transparent 50%, $color 50%, $color 75%, transparent 75%, transparent);
+}

--- a/Source/Blazorise.Bulma/Styles/_progress.scss
+++ b/Source/Blazorise.Bulma/Styles/_progress.scss
@@ -9,3 +9,51 @@
         }
     }
 }
+
+
+
+@-webkit-keyframes animate-stripes {
+    100% {
+        background-position: -40px 0px;
+    }
+}
+
+@keyframes animate-stripes {
+    100% {
+        background-position: -40px 0px;
+    }
+}
+
+.progress-wrapper {
+    position: relative;
+    display: flex;
+
+    .progress {
+        &:first-child {
+            border-top-right-radius: 0;
+            border-bottom-right-radius: 0;
+        }
+
+        &:not(:first-child) {
+            border-radius: 0;
+        }
+
+        &.is-extra-small {
+            height: $size-extra-small;
+        }
+
+        &.is-extra-large {
+            height: $size-extra-large;
+        }
+
+        &[value].progress-animated::-webkit-progress-value {
+            -webkit-animation: animate-stripes 5s linear infinite;
+            animation: animate-stripes 5s linear infinite;
+        }
+
+        &[value].progress-striped::-webkit-progress-value {
+            @include gradient-striped();
+            background-size: 1rem 1rem;
+        }
+    }
+}

--- a/Source/Blazorise.Bulma/Styles/_progress.scss
+++ b/Source/Blazorise.Bulma/Styles/_progress.scss
@@ -29,15 +29,6 @@
     display: flex;
 
     .progress {
-        &:first-child {
-            border-top-right-radius: 0;
-            border-bottom-right-radius: 0;
-        }
-
-        &:not(:first-child) {
-            border-radius: 0;
-        }
-
         &.is-extra-small {
             height: $size-extra-small;
         }
@@ -54,6 +45,157 @@
         &[value].progress-striped::-webkit-progress-value {
             @include gradient-striped();
             background-size: 1rem 1rem;
+        }
+    }
+}
+
+$progress-bar-background-color: $border-light !default
+$progress-value-background-color: $text !default
+$progress-border-radius: $radius-rounded !default
+
+$progress-indeterminate-duration: 1.5s !default
+
+@mixin progress-size() {
+    &.is-extra-small {
+        + .progress-value, .progress-value {
+            font-size: calc(#{$size-extra-small} / 1.5);
+            line-height: $size-extra-small;
+        }
+    }
+
+    &.is-small {
+        + .progress-value, .progress-value {
+            font-size: calc(#{$size-small} / 1.5);
+            line-height: $size-small;
+        }
+    }
+
+    &.is-medium {
+        + .progress-value, .progress-value {
+            font-size: calc(#{$size-medium} / 1.5);
+            line-height: $size-medium;
+        }
+    }
+
+    &.is-large {
+        + .progress-value, .progress-value {
+            font-size: calc(#{$size-large} / 1.5);
+            line-height: $size-large;
+        }
+    }
+
+    &.is-extra-large {
+        + .progress-value, .progress-value {
+            font-size: calc(#{$size-extra-large} / 1.5);
+            line-height: $size-extra-large;
+        }
+    }
+}
+
+.progress-bars-wrapper {
+    position: relative;
+    overflow: hidden;
+
+    &:not(:last-child) {
+        margin-bottom: 1.5rem;
+    }
+
+    .progress-value {
+        position: absolute;
+        top: 0;
+        left: 50%;
+        transform: translateX(-50%);
+        font-size: calc(#{$size-normal} / 1.5);
+        line-height: $size-normal;
+        font-weight: $weight-bold;
+        color: findColorInvert($progress-bar-background-color);
+        white-space: nowrap;
+    }
+
+    .progress-bar {
+        margin-bottom: 0;
+
+        @include progress-size();
+
+        &::-webkit-progress-value {
+            transition: width 0.5s ease;
+        }
+
+        &.is-more-than-half {
+            + .progress-value {
+                color: findColorInvert($progress-value-background-color);
+            }
+
+            @each $name, $value in $theme-colors {
+                $color: $value;
+                $color-invert: color-yiq($value);
+
+                &.is-#{$name} {
+                    + .progress-value {
+                        color: $color-invert;
+                    }
+                }
+            }
+        }
+    }
+
+    &:not(:last-child) {
+        margin-bottom: 1.5rem;
+    }
+
+    -moz-appearance: none;
+    -webkit-appearance: none;
+    border: none;
+    border-radius: $progress-border-radius;
+    display: block;
+    height: $size-normal;
+    overflow: hidden;
+    padding: 0;
+    width: 100%;
+
+    &::-webkit-progress-bar {
+        background-color: $progress-bar-background-color;
+    }
+
+    &::-webkit-progress-value {
+        background-color: $progress-value-background-color;
+    }
+
+    &::-moz-progress-bar {
+        background-color: $progress-value-background-color;
+    }
+
+    &::-ms-fill {
+        background-color: $progress-value-background-color;
+        border: none;
+    }
+
+    white-space: nowrap;
+    background-color: $progress-bar-background-color;
+    border-radius: $progress-border-radius;
+
+    .progress-bar {
+        position: relative;
+        display: inline-block;
+        vertical-align: top;
+        height: 100%;
+        background-color: $progress-value-background-color;
+
+        .progress-value {
+            color: findColorInvert($progress-value-background-color);
+        }
+
+        @each $name, $value in $theme-colors {
+            $color: $value;
+            $color-invert: color-yiq($value);
+
+            &.is-#{$name} {
+                background-color: $color;
+
+                .progress-value {
+                    color: $color-invert;
+                }
+            }
         }
     }
 }

--- a/Source/Blazorise.Bulma/Styles/_variables.scss
+++ b/Source/Blazorise.Bulma/Styles/_variables.scss
@@ -142,6 +142,11 @@ $speed-slower: 250ms !default;
 $border-width: 1px;
 $border-color: #adb5bd;
 
+$border: $grey-lighter !default;
+$border-hover: $grey-light !default;
+$border-light: $grey-lightest !default;
+$border-light-hover: $grey-light !default;
+
 // Components
 
 $border-radius: .25rem !default;

--- a/Source/Blazorise.Bulma/wwwroot/blazorise.bulma.css
+++ b/Source/Blazorise.Bulma/wwwroot/blazorise.bulma.css
@@ -3796,6 +3796,33 @@ li.list-group-item-action {
 .b-page-progress .b-page-progress-indicator.b-page-progress-indicator-link {
     background-color: #3273dc; }
 
+@-webkit-keyframes animate-stripes {
+    100% {
+        background-position: -40px 0px; } }
+
+@keyframes animate-stripes {
+    100% {
+        background-position: -40px 0px; } }
+
+.progress-wrapper {
+    position: relative;
+    display: flex; }
+    .progress-wrapper .progress:first-child {
+        border-top-right-radius: 0;
+        border-bottom-right-radius: 0; }
+    .progress-wrapper .progress:not(:first-child) {
+        border-radius: 0; }
+    .progress-wrapper .progress.is-extra-small, .progress-wrapper .field.has-addons.are-extra-small > .control > .progress.button {
+        height: 0.65rem; }
+    .progress-wrapper .progress.is-extra-large, .progress-wrapper .field.has-addons.are-extra-large > .control > .progress.button {
+        height: 2rem; }
+    .progress-wrapper .progress[value].progress-animated::-webkit-progress-value {
+        -webkit-animation: animate-stripes 5s linear infinite;
+        animation: animate-stripes 5s linear infinite; }
+    .progress-wrapper .progress[value].progress-striped::-webkit-progress-value {
+        background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+        background-size: 1rem 1rem; }
+
 /*https://github.com/jgthms/bulma/issues/451#issuecomment-331758839*/
 .rating:not(.rating-disabled):not(.rating-readonly):hover .rating-item {
     cursor: pointer; }

--- a/Source/Blazorise.Bulma/wwwroot/blazorise.bulma.css
+++ b/Source/Blazorise.Bulma/wwwroot/blazorise.bulma.css
@@ -3807,11 +3807,6 @@ li.list-group-item-action {
 .progress-wrapper {
     position: relative;
     display: flex; }
-    .progress-wrapper .progress:first-child {
-        border-top-right-radius: 0;
-        border-bottom-right-radius: 0; }
-    .progress-wrapper .progress:not(:first-child) {
-        border-radius: 0; }
     .progress-wrapper .progress.is-extra-small, .progress-wrapper .field.has-addons.are-extra-small > .control > .progress.button {
         height: 0.65rem; }
     .progress-wrapper .progress.is-extra-large, .progress-wrapper .field.has-addons.are-extra-large > .control > .progress.button {
@@ -3822,6 +3817,128 @@ li.list-group-item-action {
     .progress-wrapper .progress[value].progress-striped::-webkit-progress-value {
         background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
         background-size: 1rem 1rem; }
+
+.progress-bars-wrapper {
+    position: relative;
+    overflow: hidden;
+    -moz-appearance: none;
+    -webkit-appearance: none;
+    border: none;
+    border-radius: 290486px;
+    display: block;
+    height: 1rem;
+    overflow: hidden;
+    padding: 0;
+    width: 100%;
+    white-space: nowrap;
+    background-color: #ededed;
+    border-radius: 290486px; }
+    .progress-bars-wrapper:not(:last-child) {
+        margin-bottom: 1.5rem; }
+    .progress-bars-wrapper .progress-value {
+        position: absolute;
+        top: 0;
+        left: 50%;
+        transform: translateX(-50%);
+        font-size: calc(1rem / 1.5);
+        line-height: 1rem;
+        font-weight: 700;
+        color: findColorInvert(#ededed);
+        white-space: nowrap; }
+    .progress-bars-wrapper .progress-bar {
+        margin-bottom: 0; }
+        .progress-bars-wrapper .progress-bar.is-extra-small + .progress-value, .progress-bars-wrapper .field.has-addons.are-extra-small > .control > .progress-bar.button + .progress-value, .progress-bars-wrapper .progress-bar.is-extra-small .progress-value, .progress-bars-wrapper .field.has-addons.are-extra-small > .control > .progress-bar.button .progress-value {
+            font-size: calc(0.65rem / 1.5);
+            line-height: 0.65rem; }
+        .progress-bars-wrapper .progress-bar.is-small + .progress-value, .progress-bars-wrapper .field.has-addons.are-small > .control > .progress-bar.button + .progress-value, .progress-bars-wrapper .progress-bar.is-small .progress-value, .progress-bars-wrapper .field.has-addons.are-small > .control > .progress-bar.button .progress-value {
+            font-size: calc(0.75rem / 1.5);
+            line-height: 0.75rem; }
+        .progress-bars-wrapper .progress-bar.is-medium + .progress-value, .progress-bars-wrapper .field.has-addons.are-medium > .control > .progress-bar.button + .progress-value, .progress-bars-wrapper .progress-bar.is-medium .progress-value, .progress-bars-wrapper .field.has-addons.are-medium > .control > .progress-bar.button .progress-value {
+            font-size: calc(1.25rem / 1.5);
+            line-height: 1.25rem; }
+        .progress-bars-wrapper .progress-bar.is-large + .progress-value, .progress-bars-wrapper .field.has-addons.are-large > .control > .progress-bar.button + .progress-value, .progress-bars-wrapper .progress-bar.is-large .progress-value, .progress-bars-wrapper .field.has-addons.are-large > .control > .progress-bar.button .progress-value {
+            font-size: calc(1.5rem / 1.5);
+            line-height: 1.5rem; }
+        .progress-bars-wrapper .progress-bar.is-extra-large + .progress-value, .progress-bars-wrapper .field.has-addons.are-extra-large > .control > .progress-bar.button + .progress-value, .progress-bars-wrapper .progress-bar.is-extra-large .progress-value, .progress-bars-wrapper .field.has-addons.are-extra-large > .control > .progress-bar.button .progress-value {
+            font-size: calc(2rem / 1.5);
+            line-height: 2rem; }
+        .progress-bars-wrapper .progress-bar::-webkit-progress-value {
+            transition: width 0.5s ease; }
+        .progress-bars-wrapper .progress-bar.is-more-than-half + .progress-value {
+            color: findColorInvert(#4a4a4a); }
+        .progress-bars-wrapper .progress-bar.is-more-than-half.is-primary + .progress-value {
+            color: #fff; }
+        .progress-bars-wrapper .progress-bar.is-more-than-half.is-secondary + .progress-value {
+            color: #fff; }
+        .progress-bars-wrapper .progress-bar.is-more-than-half.is-success + .progress-value {
+            color: #212529; }
+        .progress-bars-wrapper .progress-bar.is-more-than-half.is-info + .progress-value {
+            color: #fff; }
+        .progress-bars-wrapper .progress-bar.is-more-than-half.is-warning + .progress-value {
+            color: #212529; }
+        .progress-bars-wrapper .progress-bar.is-more-than-half.is-danger + .progress-value {
+            color: #fff; }
+        .progress-bars-wrapper .progress-bar.is-more-than-half.is-light + .progress-value {
+            color: #212529; }
+        .progress-bars-wrapper .progress-bar.is-more-than-half.is-dark + .progress-value {
+            color: #fff; }
+        .progress-bars-wrapper .progress-bar.is-more-than-half.is-link + .progress-value {
+            color: #fff; }
+    .progress-bars-wrapper:not(:last-child) {
+        margin-bottom: 1.5rem; }
+    .progress-bars-wrapper::-webkit-progress-bar {
+        background-color: #ededed; }
+    .progress-bars-wrapper::-webkit-progress-value {
+        background-color: #4a4a4a; }
+    .progress-bars-wrapper::-moz-progress-bar {
+        background-color: #4a4a4a; }
+    .progress-bars-wrapper::-ms-fill {
+        background-color: #4a4a4a;
+        border: none; }
+    .progress-bars-wrapper .progress-bar {
+        position: relative;
+        display: inline-block;
+        vertical-align: top;
+        height: 100%;
+        background-color: #4a4a4a; }
+        .progress-bars-wrapper .progress-bar .progress-value {
+            color: findColorInvert(#4a4a4a); }
+        .progress-bars-wrapper .progress-bar.is-primary {
+            background-color: #00d1b2; }
+            .progress-bars-wrapper .progress-bar.is-primary .progress-value {
+                color: #fff; }
+        .progress-bars-wrapper .progress-bar.is-secondary {
+            background-color: #6c757d; }
+            .progress-bars-wrapper .progress-bar.is-secondary .progress-value {
+                color: #fff; }
+        .progress-bars-wrapper .progress-bar.is-success {
+            background-color: #48c774; }
+            .progress-bars-wrapper .progress-bar.is-success .progress-value {
+                color: #212529; }
+        .progress-bars-wrapper .progress-bar.is-info {
+            background-color: #238cd1; }
+            .progress-bars-wrapper .progress-bar.is-info .progress-value {
+                color: #fff; }
+        .progress-bars-wrapper .progress-bar.is-warning {
+            background-color: #ffd83d; }
+            .progress-bars-wrapper .progress-bar.is-warning .progress-value {
+                color: #212529; }
+        .progress-bars-wrapper .progress-bar.is-danger {
+            background-color: #ef2e55; }
+            .progress-bars-wrapper .progress-bar.is-danger .progress-value {
+                color: #fff; }
+        .progress-bars-wrapper .progress-bar.is-light {
+            background-color: #f5f5f5; }
+            .progress-bars-wrapper .progress-bar.is-light .progress-value {
+                color: #212529; }
+        .progress-bars-wrapper .progress-bar.is-dark {
+            background-color: #363636; }
+            .progress-bars-wrapper .progress-bar.is-dark .progress-value {
+                color: #fff; }
+        .progress-bars-wrapper .progress-bar.is-link {
+            background-color: #3273dc; }
+            .progress-bars-wrapper .progress-bar.is-link .progress-value {
+                color: #fff; }
 
 /*https://github.com/jgthms/bulma/issues/451#issuecomment-331758839*/
 .rating:not(.rating-disabled):not(.rating-readonly):hover .rating-item {

--- a/Source/Blazorise/Components/Progress/Progress.razor
+++ b/Source/Blazorise/Components/Progress/Progress.razor
@@ -1,7 +1,18 @@
 ﻿@namespace Blazorise
 @inherits BaseComponent
 <CascadingValue Value="@this" IsFixed="true">
-    <div class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
-        @ChildContent
-    </div>
+    <CascadingValue Value="@State">
+        <div class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
+            @if ( !HasProgressBar )
+            {
+                <div class="@ProgressBarClassNames" style="@ProgressBarStyleNames" role="progressbar" aria-valuenow="@Percentage" aria-valuemin="@Min" aria-valuemax="@Max" @attributes="@Attributes">
+                    @ChildContent
+                </div>
+            }
+            else
+            {
+                @ChildContent
+            }
+        </div>
+    </CascadingValue>
 </CascadingValue>

--- a/Source/Blazorise/Components/Progress/Progress.razor.cs
+++ b/Source/Blazorise/Components/Progress/Progress.razor.cs
@@ -1,4 +1,5 @@
 ﻿#region Using directives
+using Blazorise.States;
 using Blazorise.Utilities;
 using Microsoft.AspNetCore.Components;
 #endregion
@@ -12,7 +13,33 @@ namespace Blazorise
     {
         #region Members
 
-        private Size size = Size.None;
+        /// <summary>
+        /// Holds the state of the <see cref="Progress"/> component.
+        /// </summary>
+        private ProgressState state = new()
+        {
+            Color = Color.Primary,
+            Min = 0,
+            Max = 100,
+        };
+
+        /// <summary>
+        /// Flag that indicates if <see cref="Progress"/> contains the <see cref="ProgressBar"/> component.
+        /// </summary>
+        private bool hasProgressBar;
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// A default <see cref="Progress"/> constructor.
+        /// </summary>
+        public Progress()
+        {
+            ProgressBarClassBuilder = new ClassBuilder( BuildProgressBarClasses );
+            ProgressBarStyleBuilder = new StyleBuilder( BuildProgressBarStyles );
+        }
 
         #endregion
 
@@ -23,8 +50,68 @@ namespace Blazorise
         {
             builder.Append( ClassProvider.Progress() );
             builder.Append( ClassProvider.ProgressSize( Size ), Size != Size.None );
+            builder.Append( ClassProvider.ProgressColor( Color ), Color != Color.None );
+            builder.Append( ClassProvider.ProgressStriped(), Striped );
+            builder.Append( ClassProvider.ProgressAnimated(), Animated );
 
             base.BuildClasses( builder );
+        }
+
+        /// <summary>
+        /// Builds the classnames for a pregress bar.
+        /// </summary>
+        /// <param name="builder">Class builder used to append the classnames.</param>
+        private void BuildProgressBarClasses( ClassBuilder builder )
+        {
+            builder.Append( ClassProvider.ProgressBar() );
+            builder.Append( ClassProvider.ProgressBarColor( Color ), Color != Color.None );
+            builder.Append( ClassProvider.ProgressBarWidth( Percentage ?? 0 ) );
+            builder.Append( ClassProvider.ProgressBarStriped(), Striped );
+            builder.Append( ClassProvider.ProgressBarAnimated(), Animated );
+
+            if ( Size != Size.None )
+                builder.Append( ClassProvider.ProgressBarSize( Size ) );
+        }
+
+        /// <summary>
+        /// Builds the styles for a pregress bar.
+        /// </summary>
+        /// <param name="builder">Styles builder used to append the styles.</param>
+        private void BuildProgressBarStyles( StyleBuilder builder )
+        {
+            if ( Percentage != null )
+                builder.Append( StyleProvider.ProgressBarValue( Percentage ?? 0 ) );
+
+            builder.Append( StyleProvider.ProgressBarSize( Size ) );
+        }
+
+        /// <inheritdoc/>
+        protected internal override void DirtyClasses()
+        {
+            ProgressBarClassBuilder.Dirty();
+
+            base.DirtyClasses();
+        }
+
+        /// <inheritdoc/>
+        protected override void DirtyStyles()
+        {
+            ProgressBarStyleBuilder.Dirty();
+
+            base.DirtyStyles();
+        }
+
+        /// <summary>
+        /// Notifies the progress that one of the child componens is a progressbar.
+        /// </summary>
+        internal void NotifyHasMessage()
+        {
+            hasProgressBar = true;
+
+            DirtyClasses();
+            DirtyStyles();
+
+            InvokeAsync( StateHasChanged );
         }
 
         #endregion
@@ -32,17 +119,149 @@ namespace Blazorise
         #region Properties
 
         /// <summary>
+        /// Indicates if <see cref="Progress"/> contains the <see cref="ProgressBar"/> component.
+        /// </summary>
+        protected bool HasProgressBar => hasProgressBar;
+
+        /// <summary>
+        /// Gets the progress state.
+        /// </summary>
+        protected ProgressState State => state;
+
+        /// <summary>
+        /// Calculates the percentage based on the current value and max parameters.
+        /// </summary>
+        protected int? Percentage
+            => Max == 0 ? 0 : (int?)( Value / (float?)Max * 100f );
+
+        /// <summary>
+        /// Gets the classnames of the progress bar.
+        /// </summary>
+        protected string ProgressBarClassNames
+            => ProgressBarClassBuilder.Class;
+
+        /// <summary>
+        /// Gets the stylenames of the progress bar.
+        /// </summary>
+        protected string ProgressBarStyleNames
+            => ProgressBarStyleBuilder.Styles;
+
+        /// <summary>
+        /// Progress bar class builder.
+        /// </summary>
+        protected ClassBuilder ProgressBarClassBuilder { get; private set; }
+
+        /// <summary>
+        /// Progress bar style builder.
+        /// </summary>
+        protected StyleBuilder ProgressBarStyleBuilder { get; private set; }
+
+        /// <summary>
+        /// Defines the progress bar color.
+        /// </summary>
+        [Parameter]
+        public Color Color
+        {
+            get => state.Color;
+            set
+            {
+                state = state with { Color = value };
+
+                DirtyClasses();
+            }
+        }
+
+        /// <summary>
         /// Size of the progress bar.
         /// </summary>
         [Parameter]
         public Size Size
         {
-            get => size;
+            get => state.Size;
             set
             {
-                size = value;
+                state = state with { Size = value };
 
                 DirtyClasses();
+            }
+        }
+
+        /// <summary>
+        /// Set to true to make the progress bar stripped.
+        /// </summary>
+        [Parameter]
+        public bool Striped
+        {
+            get => state.Striped;
+            set
+            {
+                state = state with { Striped = value };
+
+                DirtyClasses();
+            }
+        }
+
+        /// <summary>
+        /// Set to true to make the progress bar animated.
+        /// </summary>
+        [Parameter]
+        public bool Animated
+        {
+            get => state.Animated;
+            set
+            {
+                state = state with { Animated = value };
+
+                DirtyClasses();
+            }
+        }
+
+        /// <summary>
+        /// Minimum value of the progress bar.
+        /// </summary>
+        [Parameter]
+        public int Min
+        {
+            get => state.Min;
+            set
+            {
+                state = state with { Min = value };
+
+                DirtyClasses();
+            }
+        }
+
+        /// <summary>
+        /// Maximum value of the progress bar.
+        /// </summary>
+        [Parameter]
+        public int Max
+        {
+            get => state.Max;
+            set
+            {
+                state = state with { Max = value };
+
+                DirtyClasses();
+            }
+        }
+
+        /// <summary>
+        /// The progress value.
+        /// </summary>
+        [Parameter]
+        public int? Value
+        {
+            get => state.Value;
+            set
+            {
+                if ( state.Value == value )
+                    return;
+
+                state = state with { Value = value };
+
+                DirtyClasses();
+                DirtyStyles();
             }
         }
 

--- a/Source/Blazorise/Components/Progress/ProgressBar.razor
+++ b/Source/Blazorise/Components/Progress/ProgressBar.razor
@@ -1,5 +1,12 @@
 ﻿@namespace Blazorise
 @inherits BaseComponent
 <div class="@ClassNames" style="@StyleNames" role="progressbar" aria-valuenow="@Percentage" aria-valuemin="@Min" aria-valuemax="@Max" @attributes="@Attributes">
-    @ChildContent
+    @if ( ChildContent != null )
+    {
+        @ChildContent
+    }
+    else
+    {
+        @Value
+    }
 </div>

--- a/Source/Blazorise/Components/Progress/ProgressBar.razor.cs
+++ b/Source/Blazorise/Components/Progress/ProgressBar.razor.cs
@@ -25,6 +25,14 @@ namespace Blazorise
         #region Methods
 
         /// <inheritdoc/>
+        protected override void OnInitialized()
+        {
+            ParentProgress?.NotifyHasMessage();
+
+            base.OnInitialized();
+        }
+
+        /// <inheritdoc/>
         protected override void BuildClasses( ClassBuilder builder )
         {
             builder.Append( ClassProvider.ProgressBar() );
@@ -68,9 +76,8 @@ namespace Blazorise
         /// <summary>
         /// Calculates the percentage based on the current value and max parameters.
         /// </summary>
-        protected int? Percentage => Max == 0
-            ? 0
-            : (int?)( Value / (float?)Max * 100f );
+        protected int? Percentage
+            => Max == 0 ? 0 : (int?)( Value / (float?)Max * 100f );
 
         /// <summary>
         /// Defines the progress bar color.

--- a/Source/Blazorise/Components/Progress/ProgressBar.razor.cs
+++ b/Source/Blazorise/Components/Progress/ProgressBar.razor.cs
@@ -12,6 +12,8 @@ namespace Blazorise
     {
         #region Members
 
+        private Color color = Color.Primary;
+
         private bool striped;
 
         private bool animated;
@@ -26,9 +28,13 @@ namespace Blazorise
         protected override void BuildClasses( ClassBuilder builder )
         {
             builder.Append( ClassProvider.ProgressBar() );
+            builder.Append( ClassProvider.ProgressBarColor( Color ), Color != Color.None );
             builder.Append( ClassProvider.ProgressBarWidth( Percentage ?? 0 ) );
             builder.Append( ClassProvider.ProgressBarStriped(), Striped );
             builder.Append( ClassProvider.ProgressBarAnimated(), Animated );
+
+            if ( ParentProgress?.Size != Size.None )
+                builder.Append( ClassProvider.ProgressBarSize( ParentProgress.Size ) );
 
             base.BuildClasses( builder );
         }
@@ -62,7 +68,24 @@ namespace Blazorise
         /// <summary>
         /// Calculates the percentage based on the current value and max parameters.
         /// </summary>
-        protected int? Percentage => Max == 0 ? 0 : (int)( Value.GetValueOrDefault() / (float)Max * 100f );
+        protected int? Percentage => Max == 0
+            ? 0
+            : (int?)( Value / (float?)Max * 100f );
+
+        /// <summary>
+        /// Defines the progress bar color.
+        /// </summary>
+        [Parameter]
+        public Color Color
+        {
+            get => color;
+            set
+            {
+                color = value;
+
+                DirtyClasses();
+            }
+        }
 
         /// <summary>
         /// Set to true to make the progress bar stripped.

--- a/Source/Blazorise/Interfaces/IClassProvider.cs
+++ b/Source/Blazorise/Interfaces/IClassProvider.cs
@@ -735,6 +735,14 @@ namespace Blazorise
 
         string ProgressSize( Size size );
 
+        string ProgressColor( Color color );
+
+        string ProgressStriped();
+
+        string ProgressAnimated();
+
+        string ProgressWidth( int width );
+
         string ProgressBar();
 
         string ProgressBarSize( Size size );

--- a/Source/Blazorise/Interfaces/IClassProvider.cs
+++ b/Source/Blazorise/Interfaces/IClassProvider.cs
@@ -739,6 +739,8 @@ namespace Blazorise
 
         string ProgressBarSize( Size size );
 
+        string ProgressBarColor( Color color );
+
         string ProgressBarStriped();
 
         string ProgressBarAnimated();

--- a/Source/Blazorise/Providers/ClassProvider.cs
+++ b/Source/Blazorise/Providers/ClassProvider.cs
@@ -747,6 +747,8 @@ namespace Blazorise
 
         public abstract string ProgressBarSize( Size size );
 
+        public abstract string ProgressBarColor( Color color );
+
         public abstract string ProgressBarStriped();
 
         public abstract string ProgressBarAnimated();

--- a/Source/Blazorise/Providers/ClassProvider.cs
+++ b/Source/Blazorise/Providers/ClassProvider.cs
@@ -743,6 +743,14 @@ namespace Blazorise
 
         public abstract string ProgressSize( Size size );
 
+        public abstract string ProgressColor( Color color );
+
+        public abstract string ProgressStriped();
+
+        public abstract string ProgressAnimated();
+
+        public abstract string ProgressWidth( int width );
+
         public abstract string ProgressBar();
 
         public abstract string ProgressBarSize( Size size );

--- a/Source/Blazorise/Providers/EmptyClassProvider.cs
+++ b/Source/Blazorise/Providers/EmptyClassProvider.cs
@@ -747,6 +747,8 @@ namespace Blazorise.Providers
 
         public string ProgressBarSize( Size size ) => null;
 
+        public string ProgressBarColor( Color color ) => null;
+
         public string ProgressBarStriped() => null;
 
         public string ProgressBarAnimated() => null;

--- a/Source/Blazorise/Providers/EmptyClassProvider.cs
+++ b/Source/Blazorise/Providers/EmptyClassProvider.cs
@@ -743,6 +743,14 @@ namespace Blazorise.Providers
 
         public string ProgressSize( Size size ) => null;
 
+        public string ProgressColor( Color color ) => null;
+
+        public string ProgressStriped() => null;
+
+        public string ProgressAnimated() => null;
+
+        public string ProgressWidth( int width ) => null;
+
         public string ProgressBar() => null;
 
         public string ProgressBarSize( Size size ) => null;

--- a/Source/Blazorise/States/ProgressState.cs
+++ b/Source/Blazorise/States/ProgressState.cs
@@ -1,0 +1,43 @@
+﻿namespace Blazorise.States
+{
+    /// <summary>
+    /// Holds the information about the current state of the <see cref="Progress"/> component.
+    /// </summary>
+    public record ProgressState
+    {
+        /// <summary>
+        /// Defines the progress bar color.
+        /// </summary>
+        public Color Color { get; init; }
+
+        /// <summary>
+        /// Size of the progress bar.
+        /// </summary>
+        public Size Size { get; init; }
+
+        /// <summary>
+        /// Set to true to make the progress bar stripped.
+        /// </summary>
+        public bool Striped { get; init; }
+
+        /// <summary>
+        /// Set to true to make the progress bar animated.
+        /// </summary>
+        public bool Animated { get; init; }
+
+        /// <summary>
+        /// Minimum value of the progress bar.
+        /// </summary>
+        public int Min { get; init; }
+
+        /// <summary>
+        /// Maximum value of the progress bar.
+        /// </summary>
+        public int Max { get; init; }
+
+        /// <summary>
+        /// The progress value.
+        /// </summary>
+        public int? Value { get; init; }
+    }
+}

--- a/docs/_docs/components/progress.md
+++ b/docs/_docs/components/progress.md
@@ -10,7 +10,7 @@ Use our progress component for displaying simple or complex progress bars, featu
 
 ## Structure
 
-- `<Progress>` main component for stacked progress bars
+- `<Progress>` main component for single progress value or wrapper for multiple bars
   - `<ProgressBar>` progress bar for single progress value
 
 ## Basic
@@ -25,9 +25,7 @@ Progress components are built with two components.
 Put that all together, and you have the following examples.
 
 ```html
-<Progress>
-    <ProgressBar Value="25" />
-</Progress>
+<Progress Value="25" />
 ```
 
 <iframe src="/examples/progress/basic/" frameborder="0" scrolling="no" style="width:100%;height:50px;"></iframe>
@@ -39,8 +37,8 @@ Include multiple `ProgressBar` sub-components in a `Progress` component to build
 ```html
 <Progress>
     <ProgressBar Value="15" />
-    <ProgressBar Background="Background.Success" Value="30" />
-    <ProgressBar Background="Background.Info" Value="20" />
+    <ProgressBar Color="Color.Success" Value="30" />
+    <ProgressBar Color="Color.Info" Value="20" />
 </Progress>
 ```
 
@@ -74,7 +72,12 @@ To make an indeterminate progress bar, simply remove `Value` or make it a `null`
 
 | Name                  | Type                                                                   | Default          | Description                                                                                      |
 |-----------------------|------------------------------------------------------------------------|------------------|--------------------------------------------------------------------------------------------------|
-| Size                  | [Size]({{ "/docs/helpers/sizes/#size" | relative_url }})               | `None`   	    | Progress size variations.                                                                        |
+| Size                  | [Size]({{ "/docs/helpers/sizes/#size" | relative_url }})               | `None`   	      | Progress size variations.                                                                        |
+| Min                   | int                                                                    | 0                | Minimum value of the progress bar.                                                               |
+| Max                   | int                                                                    | 100              | Maximum value of the progress bar.                                                               |
+| Color                 | [Color]({{ "/docs/helpers/colors/#color" | relative_url }})            | `Primary`        | Defines the progress bar color variant.                                                          |
+| Striped               | bool                                                                   | false            | Set to true to make the progress bar stripped.                                                   |
+| Animated              | bool                                                                   | false            | Set to true to make the progress bar animated.                                                   |
 
 ### ProgressBar
 
@@ -83,7 +86,7 @@ To make an indeterminate progress bar, simply remove `Value` or make it a `null`
 | Value                 | `int?`                                                                 | null   	        | The progress value.                                                                              |
 | Min                   | int                                                                    | 0                | Minimum value of the progress bar.                                                               |
 | Max                   | int                                                                    | 100              | Maximum value of the progress bar.                                                               |
-| Background            | [Background]({{ "/docs/helpers/colors/#background" | relative_url }})  | `None`           | Defines the progress bar background color.                                                       |
+| Color                 | [Color]({{ "/docs/helpers/colors/#color" | relative_url }})            | `Primary`        | Defines the progress bar color variant.                                                          |
 | Striped               | bool                                                                   | false            | Set to true to make the progress bar stripped.                                                   |
 | Animated              | bool                                                                   | false            | Set to true to make the progress bar animated.                                                   |
 

--- a/docs/_posts/2021-03-24-release-notes-094.md
+++ b/docs/_posts/2021-03-24-release-notes-094.md
@@ -18,6 +18,10 @@ tags:
   - `Alignment` to `TextAlignment`
   - `Transform` to `TextTransform`
   - `Weight` to `TextWeight`
+- For `Progress` component
+  - Use only `Progress` component because `ProgressBar` is now needed only for multiple stacked bars, eg. `<Progress Value="50" />`
+  - Instead of `Background` parameter use the `Color` parameter
+  
 
 ## Highlights 🚀
 
@@ -46,6 +50,26 @@ One example of how new Flex utility works:
     ...
 </Div>
 ```
+
+### Simplified Progress component
+
+We have worked hard to make the `Progress` bar simpler to use to keep your fingers rested. Hey, every letter counts :)
+
+Previously the progress component was used like:
+
+```html
+<Progress>
+  <ProgressBar Value="50" />
+</Progress>
+```
+
+and now you only need to write the following(for a single value progress).
+
+```html
+<Progress Value="50">
+```
+
+The old way of using the `Progress` is now reserved for stacked bars when you need to show multiple values.
 
 ### Typography utilities
 


### PR DESCRIPTION
resolves #1622 Simplify usage of progress component

**Done**

- Progress can now be used without ProgressBar
- Background replaced with Color
- Fixed Bulma and AntDesign
- Added support for Bulma multiple value bars
- Update demo and docs