### PR TITLE
GenerateInputStyles fix

### DIFF
--- a/Source/Blazorise.AntDesign/AntDesignThemeGenerator.cs
+++ b/Source/Blazorise.AntDesign/AntDesignThemeGenerator.cs
@@ -337,50 +337,53 @@ namespace Blazorise.AntDesign
                 GenerateInputSliderStyles( sb, theme, options );
             }
 
-            sb
-                .Append( $".flatpickr-months .flatpickr-month:hover svg," )
-                .Append( $".flatpickr-months .flatpickr-next-month:hover svg," )
-                .Append( $".flatpickr-months .flatpickr-prev-month:hover svg" )
-                .Append( "{" )
-                .Append( $"fill: { Var( ThemeVariables.Color( "primary" ) )} !important;" )
-                .AppendLine( "}" );
+            if ( !string.IsNullOrEmpty( theme.ColorOptions?.Primary ) )
+            {
+                sb
+                    .Append( $".flatpickr-months .flatpickr-month:hover svg," )
+                    .Append( $".flatpickr-months .flatpickr-next-month:hover svg," )
+                    .Append( $".flatpickr-months .flatpickr-prev-month:hover svg" )
+                    .Append( "{" )
+                    .Append( $"fill: { Var( ThemeVariables.Color( "primary" ) )} !important;" )
+                    .AppendLine( "}" );
 
-            sb
-                .Append( $".flatpickr-day.selected, .flatpickr-day.startRange, .flatpickr-day.endRange, .flatpickr-day.selected.inRange, .flatpickr-day.startRange.inRange, .flatpickr-day.endRange.inRange, .flatpickr-day.selected:focus, .flatpickr-day.startRange:focus, .flatpickr-day.endRange:focus, .flatpickr-day.selected:hover, .flatpickr-day.startRange:hover, .flatpickr-day.endRange:hover, .flatpickr-day.selected.prevMonthDay, .flatpickr-day.startRange.prevMonthDay, .flatpickr-day.endRange.prevMonthDay, .flatpickr-day.selected.nextMonthDay, .flatpickr-day.startRange.nextMonthDay, .flatpickr-day.endRange.nextMonthDay" ).Append( "{" )
-                .Append( $"background: { Var( ThemeVariables.Color( "primary" ) )};" )
-                .Append( $"border-color: { Var( ThemeVariables.Color( "primary" ) )};" )
-                .AppendLine( "}" );
+                sb
+                    .Append( $".flatpickr-day.selected, .flatpickr-day.startRange, .flatpickr-day.endRange, .flatpickr-day.selected.inRange, .flatpickr-day.startRange.inRange, .flatpickr-day.endRange.inRange, .flatpickr-day.selected:focus, .flatpickr-day.startRange:focus, .flatpickr-day.endRange:focus, .flatpickr-day.selected:hover, .flatpickr-day.startRange:hover, .flatpickr-day.endRange:hover, .flatpickr-day.selected.prevMonthDay, .flatpickr-day.startRange.prevMonthDay, .flatpickr-day.endRange.prevMonthDay, .flatpickr-day.selected.nextMonthDay, .flatpickr-day.startRange.nextMonthDay, .flatpickr-day.endRange.nextMonthDay" ).Append( "{" )
+                    .Append( $"background: { Var( ThemeVariables.Color( "primary" ) )};" )
+                    .Append( $"border-color: { Var( ThemeVariables.Color( "primary" ) )};" )
+                    .AppendLine( "}" );
 
-            sb
-                .Append( $".flatpickr-day:hover" ).Append( "{" )
-                .Append( $"background: { ToHex( Lighten( Var( ThemeVariables.Color( "primary" ) ), 90f ) )};" )
-                .AppendLine( "}" );
+                sb
+                    .Append( $".flatpickr-day:hover" ).Append( "{" )
+                    .Append( $"background: { ToHex( Lighten( Var( ThemeVariables.Color( "primary" ) ), 90f ) )};" )
+                    .AppendLine( "}" );
 
-            sb
-                .Append( $".flatpickr-day.selected.startRange + .endRange:not(:nth-child(7n+1)), .flatpickr-day.startRange.startRange + .endRange:not(:nth-child(7n+1)), .flatpickr-day.endRange.startRange + .endRange:not(:nth-child(7n+1))" ).Append( "{" )
-                .Append( $"box-shadow: -10px 0 0 { Var( ThemeVariables.Color( "primary" ) )};" )
-                .AppendLine( "}" );
+                sb
+                    .Append( $".flatpickr-day.selected.startRange + .endRange:not(:nth-child(7n+1)), .flatpickr-day.startRange.startRange + .endRange:not(:nth-child(7n+1)), .flatpickr-day.endRange.startRange + .endRange:not(:nth-child(7n+1))" ).Append( "{" )
+                    .Append( $"box-shadow: -10px 0 0 { Var( ThemeVariables.Color( "primary" ) )};" )
+                    .AppendLine( "}" );
 
-            sb
-                .Append( $".flatpickr-day.today" ).Append( "{" )
-                .Append( $"border-color: { Var( ThemeVariables.Color( "primary" ) )};" )
-                .AppendLine( "}" );
+                sb
+                    .Append( $".flatpickr-day.today" ).Append( "{" )
+                    .Append( $"border-color: { Var( ThemeVariables.Color( "primary" ) )};" )
+                    .AppendLine( "}" );
 
-            sb
-                .Append( $".flatpickr-day.today:hover" ).Append( "{" )
-                .Append( $"background: { Var( ThemeVariables.Color( "primary" ) )};" )
-                .Append( $"border-color: { Var( ThemeVariables.Color( "primary" ) )};" )
-                .AppendLine( "}" );
+                sb
+                    .Append( $".flatpickr-day.today:hover" ).Append( "{" )
+                    .Append( $"background: { Var( ThemeVariables.Color( "primary" ) )};" )
+                    .Append( $"border-color: { Var( ThemeVariables.Color( "primary" ) )};" )
+                    .AppendLine( "}" );
 
-            sb
-                .Append( $".flatpickr-monthSelect-month:hover,.flatpickr-monthSelect-month:focus" ).Append( "{" )
-                .Append( $"background: { ToHex( Lighten( Var( ThemeVariables.Color( "primary" ) ), 90f ) )};" )
-                .AppendLine( "}" );
+                sb
+                    .Append( $".flatpickr-monthSelect-month:hover,.flatpickr-monthSelect-month:focus" ).Append( "{" )
+                    .Append( $"background: { ToHex( Lighten( Var( ThemeVariables.Color( "primary" ) ), 90f ) )};" )
+                    .AppendLine( "}" );
 
-            sb
-                .Append( $".flatpickr-monthSelect-month.selected" ).Append( "{" )
-                .Append( $"background: { Var( ThemeVariables.Color( "primary" ) )};" )
-                .AppendLine( "}" );
+                sb
+                    .Append( $".flatpickr-monthSelect-month.selected" ).Append( "{" )
+                    .Append( $"background: { Var( ThemeVariables.Color( "primary" ) )};" )
+                    .AppendLine( "}" );
+            }
         }
 
         protected virtual void GenerateInputCheckEditStyles( StringBuilder sb, Theme theme, ThemeInputOptions options )

--- a/Source/Blazorise.Bootstrap/BootstrapThemeGenerator.cs
+++ b/Source/Blazorise.Bootstrap/BootstrapThemeGenerator.cs
@@ -291,61 +291,64 @@ namespace Blazorise.Bootstrap
                 GenerateInputCheckEditStyles( sb, theme, options );
             }
 
-            sb
-                .Append( $".flatpickr-months .flatpickr-month:hover svg," )
-                .Append( $".flatpickr-months .flatpickr-next-month:hover svg," )
-                .Append( $".flatpickr-months .flatpickr-prev-month:hover svg" )
-                .Append( "{" )
-                .Append( $"fill: { Var( ThemeVariables.Color( "primary" ) )} !important;" )
-                .AppendLine( "}" );
+            if ( !string.IsNullOrEmpty( theme.ColorOptions?.Primary ) )
+            {
+                sb
+                    .Append( $".flatpickr-months .flatpickr-month:hover svg," )
+                    .Append( $".flatpickr-months .flatpickr-next-month:hover svg," )
+                    .Append( $".flatpickr-months .flatpickr-prev-month:hover svg" )
+                    .Append( "{" )
+                    .Append( $"fill: { Var( ThemeVariables.Color( "primary" ) )} !important;" )
+                    .AppendLine( "}" );
 
-            sb
-                .Append( $".flatpickr-day.selected, .flatpickr-day.startRange, .flatpickr-day.endRange, .flatpickr-day.selected.inRange, .flatpickr-day.startRange.inRange, .flatpickr-day.endRange.inRange, .flatpickr-day.selected:focus, .flatpickr-day.startRange:focus, .flatpickr-day.endRange:focus, .flatpickr-day.selected:hover, .flatpickr-day.startRange:hover, .flatpickr-day.endRange:hover, .flatpickr-day.selected.prevMonthDay, .flatpickr-day.startRange.prevMonthDay, .flatpickr-day.endRange.prevMonthDay, .flatpickr-day.selected.nextMonthDay, .flatpickr-day.startRange.nextMonthDay, .flatpickr-day.endRange.nextMonthDay" ).Append( "{" )
-                .Append( $"background: { Var( ThemeVariables.Color( "primary" ) )};" )
-                .Append( $"border-color: { Var( ThemeVariables.Color( "primary" ) )};" )
-                .AppendLine( "}" );
+                sb
+                    .Append( $".flatpickr-day.selected, .flatpickr-day.startRange, .flatpickr-day.endRange, .flatpickr-day.selected.inRange, .flatpickr-day.startRange.inRange, .flatpickr-day.endRange.inRange, .flatpickr-day.selected:focus, .flatpickr-day.startRange:focus, .flatpickr-day.endRange:focus, .flatpickr-day.selected:hover, .flatpickr-day.startRange:hover, .flatpickr-day.endRange:hover, .flatpickr-day.selected.prevMonthDay, .flatpickr-day.startRange.prevMonthDay, .flatpickr-day.endRange.prevMonthDay, .flatpickr-day.selected.nextMonthDay, .flatpickr-day.startRange.nextMonthDay, .flatpickr-day.endRange.nextMonthDay" ).Append( "{" )
+                    .Append( $"background: { Var( ThemeVariables.Color( "primary" ) )};" )
+                    .Append( $"border-color: { Var( ThemeVariables.Color( "primary" ) )};" )
+                    .AppendLine( "}" );
 
-            sb
-                .Append( $".flatpickr-day:hover" ).Append( "{" )
-                .Append( $"background: { ToHex( Lighten( Var( ThemeVariables.Color( "primary" ) ), 90f ) )};" )
-                .AppendLine( "}" );
+                sb
+                    .Append( $".flatpickr-day:hover" ).Append( "{" )
+                    .Append( $"background: { ToHex( Lighten( Var( ThemeVariables.Color( "primary" ) ), 90f ) )};" )
+                    .AppendLine( "}" );
 
-            sb
-                .Append( $".flatpickr-day.selected.startRange + .endRange:not(:nth-child(7n+1)), .flatpickr-day.startRange.startRange + .endRange:not(:nth-child(7n+1)), .flatpickr-day.endRange.startRange + .endRange:not(:nth-child(7n+1))" ).Append( "{" )
-                .Append( $"box-shadow: -10px 0 0 { Var( ThemeVariables.Color( "primary" ) )};" )
-                .AppendLine( "}" );
+                sb
+                    .Append( $".flatpickr-day.selected.startRange + .endRange:not(:nth-child(7n+1)), .flatpickr-day.startRange.startRange + .endRange:not(:nth-child(7n+1)), .flatpickr-day.endRange.startRange + .endRange:not(:nth-child(7n+1))" ).Append( "{" )
+                    .Append( $"box-shadow: -10px 0 0 { Var( ThemeVariables.Color( "primary" ) )};" )
+                    .AppendLine( "}" );
 
-            sb
-                .Append( $".flatpickr-day.today" ).Append( "{" )
-                .Append( $"border-color: { Var( ThemeVariables.Color( "primary" ) )};" )
-                .AppendLine( "}" );
+                sb
+                    .Append( $".flatpickr-day.today" ).Append( "{" )
+                    .Append( $"border-color: { Var( ThemeVariables.Color( "primary" ) )};" )
+                    .AppendLine( "}" );
 
-            sb
-                .Append( $".flatpickr-day.today:hover" ).Append( "{" )
-                .Append( $"background: { Var( ThemeVariables.Color( "primary" ) )};" )
-                .Append( $"border-color: { Var( ThemeVariables.Color( "primary" ) )};" )
-                .AppendLine( "}" );
+                sb
+                    .Append( $".flatpickr-day.today:hover" ).Append( "{" )
+                    .Append( $"background: { Var( ThemeVariables.Color( "primary" ) )};" )
+                    .Append( $"border-color: { Var( ThemeVariables.Color( "primary" ) )};" )
+                    .AppendLine( "}" );
 
-            sb
-                .Append( $".flatpickr-monthSelect-month:hover,.flatpickr-monthSelect-month:focus" ).Append( "{" )
-                .Append( $"background: { ToHex( Lighten( Var( ThemeVariables.Color( "primary" ) ), 90f ) )};" )
-                .AppendLine( "}" );
+                sb
+                    .Append( $".flatpickr-monthSelect-month:hover,.flatpickr-monthSelect-month:focus" ).Append( "{" )
+                    .Append( $"background: { ToHex( Lighten( Var( ThemeVariables.Color( "primary" ) ), 90f ) )};" )
+                    .AppendLine( "}" );
 
-            sb
-                .Append( $".flatpickr-monthSelect-month.selected" ).Append( "{" )
-                .Append( $"background: { Var( ThemeVariables.Color( "primary" ) )};" )
-                .AppendLine( "}" );
+                sb
+                    .Append( $".flatpickr-monthSelect-month.selected" ).Append( "{" )
+                    .Append( $"background: { Var( ThemeVariables.Color( "primary" ) )};" )
+                    .AppendLine( "}" );
 
-            //sb
-            //    .Append( $".flatpickr-time .flatpickr-am-pm" ).Append( "{" )
-            //    .Append( $"color: { Var( ThemeVariables.Color( "primary" ) )};" )
-            //    .AppendLine( "}" );
+                //sb
+                //    .Append( $".flatpickr-time .flatpickr-am-pm" ).Append( "{" )
+                //    .Append( $"color: { Var( ThemeVariables.Color( "primary" ) )};" )
+                //    .AppendLine( "}" );
 
-            //sb
-            //    .Append( $".flatpickr-time .flatpickr-am-pm:focus, .flatpickr-time input:focus" ).Append( "{" )
-            //    .Append( $"background: { ToHex( Transparency( Var( ThemeVariables.Color( "primary" ) ), 16 ) )};" )
-            //    .Append( $"color: { Var( ThemeVariables.Color( "primary" ) )};" )
-            //    .AppendLine( "}" );
+                //sb
+                //    .Append( $".flatpickr-time .flatpickr-am-pm:focus, .flatpickr-time input:focus" ).Append( "{" )
+                //    .Append( $"background: { ToHex( Transparency( Var( ThemeVariables.Color( "primary" ) ), 16 ) )};" )
+                //    .Append( $"color: { Var( ThemeVariables.Color( "primary" ) )};" )
+                //    .AppendLine( "}" );
+            }
         }
 
         protected virtual void GenerateInputCheckEditStyles( StringBuilder sb, Theme theme, ThemeInputOptions options )

--- a/Source/Blazorise.Bulma/BulmaThemeGenerator.cs
+++ b/Source/Blazorise.Bulma/BulmaThemeGenerator.cs
@@ -191,50 +191,53 @@ namespace Blazorise.Bulma
                 GenerateInputCheckEditStyles( sb, theme, options );
             }
 
-            sb
-                .Append( $".flatpickr-months .flatpickr-month:hover svg," )
-                .Append( $".flatpickr-months .flatpickr-next-month:hover svg," )
-                .Append( $".flatpickr-months .flatpickr-prev-month:hover svg" )
-                .Append( "{" )
-                .Append( $"fill: { Var( ThemeVariables.Color( "primary" ) )} !important;" )
-                .AppendLine( "}" );
+            if ( !string.IsNullOrEmpty( theme.ColorOptions?.Primary ) )
+            {
+                sb
+                    .Append( $".flatpickr-months .flatpickr-month:hover svg," )
+                    .Append( $".flatpickr-months .flatpickr-next-month:hover svg," )
+                    .Append( $".flatpickr-months .flatpickr-prev-month:hover svg" )
+                    .Append( "{" )
+                    .Append( $"fill: { Var( ThemeVariables.Color( "primary" ) )} !important;" )
+                    .AppendLine( "}" );
 
-            sb
-                .Append( $".flatpickr-day.selected, .flatpickr-day.startRange, .flatpickr-day.endRange, .flatpickr-day.selected.inRange, .flatpickr-day.startRange.inRange, .flatpickr-day.endRange.inRange, .flatpickr-day.selected:focus, .flatpickr-day.startRange:focus, .flatpickr-day.endRange:focus, .flatpickr-day.selected:hover, .flatpickr-day.startRange:hover, .flatpickr-day.endRange:hover, .flatpickr-day.selected.prevMonthDay, .flatpickr-day.startRange.prevMonthDay, .flatpickr-day.endRange.prevMonthDay, .flatpickr-day.selected.nextMonthDay, .flatpickr-day.startRange.nextMonthDay, .flatpickr-day.endRange.nextMonthDay" ).Append( "{" )
-                .Append( $"background: { Var( ThemeVariables.Color( "primary" ) )};" )
-                .Append( $"border-color: { Var( ThemeVariables.Color( "primary" ) )};" )
-                .AppendLine( "}" );
+                sb
+                    .Append( $".flatpickr-day.selected, .flatpickr-day.startRange, .flatpickr-day.endRange, .flatpickr-day.selected.inRange, .flatpickr-day.startRange.inRange, .flatpickr-day.endRange.inRange, .flatpickr-day.selected:focus, .flatpickr-day.startRange:focus, .flatpickr-day.endRange:focus, .flatpickr-day.selected:hover, .flatpickr-day.startRange:hover, .flatpickr-day.endRange:hover, .flatpickr-day.selected.prevMonthDay, .flatpickr-day.startRange.prevMonthDay, .flatpickr-day.endRange.prevMonthDay, .flatpickr-day.selected.nextMonthDay, .flatpickr-day.startRange.nextMonthDay, .flatpickr-day.endRange.nextMonthDay" ).Append( "{" )
+                    .Append( $"background: { Var( ThemeVariables.Color( "primary" ) )};" )
+                    .Append( $"border-color: { Var( ThemeVariables.Color( "primary" ) )};" )
+                    .AppendLine( "}" );
 
-            sb
-                .Append( $".flatpickr-day:hover" ).Append( "{" )
-                .Append( $"background: { ToHex( Lighten( Var( ThemeVariables.Color( "primary" ) ), 90f ) )};" )
-                .AppendLine( "}" );
+                sb
+                    .Append( $".flatpickr-day:hover" ).Append( "{" )
+                    .Append( $"background: { ToHex( Lighten( Var( ThemeVariables.Color( "primary" ) ), 90f ) )};" )
+                    .AppendLine( "}" );
 
-            sb
-                .Append( $".flatpickr-day.selected.startRange + .endRange:not(:nth-child(7n+1)), .flatpickr-day.startRange.startRange + .endRange:not(:nth-child(7n+1)), .flatpickr-day.endRange.startRange + .endRange:not(:nth-child(7n+1))" ).Append( "{" )
-                .Append( $"box-shadow: -10px 0 0 { Var( ThemeVariables.Color( "primary" ) )};" )
-                .AppendLine( "}" );
+                sb
+                    .Append( $".flatpickr-day.selected.startRange + .endRange:not(:nth-child(7n+1)), .flatpickr-day.startRange.startRange + .endRange:not(:nth-child(7n+1)), .flatpickr-day.endRange.startRange + .endRange:not(:nth-child(7n+1))" ).Append( "{" )
+                    .Append( $"box-shadow: -10px 0 0 { Var( ThemeVariables.Color( "primary" ) )};" )
+                    .AppendLine( "}" );
 
-            sb
-                .Append( $".flatpickr-day.today" ).Append( "{" )
-                .Append( $"border-color: { Var( ThemeVariables.Color( "primary" ) )};" )
-                .AppendLine( "}" );
+                sb
+                    .Append( $".flatpickr-day.today" ).Append( "{" )
+                    .Append( $"border-color: { Var( ThemeVariables.Color( "primary" ) )};" )
+                    .AppendLine( "}" );
 
-            sb
-                .Append( $".flatpickr-day.today:hover" ).Append( "{" )
-                .Append( $"background: { Var( ThemeVariables.Color( "primary" ) )};" )
-                .Append( $"border-color: { Var( ThemeVariables.Color( "primary" ) )};" )
-                .AppendLine( "}" );
+                sb
+                    .Append( $".flatpickr-day.today:hover" ).Append( "{" )
+                    .Append( $"background: { Var( ThemeVariables.Color( "primary" ) )};" )
+                    .Append( $"border-color: { Var( ThemeVariables.Color( "primary" ) )};" )
+                    .AppendLine( "}" );
 
-            sb
-                .Append( $".flatpickr-monthSelect-month:hover,.flatpickr-monthSelect-month:focus" ).Append( "{" )
-                .Append( $"background: { ToHex( Lighten( Var( ThemeVariables.Color( "primary" ) ), 90f ) )};" )
-                .AppendLine( "}" );
+                sb
+                    .Append( $".flatpickr-monthSelect-month:hover,.flatpickr-monthSelect-month:focus" ).Append( "{" )
+                    .Append( $"background: { ToHex( Lighten( Var( ThemeVariables.Color( "primary" ) ), 90f ) )};" )
+                    .AppendLine( "}" );
 
-            sb
-                .Append( $".flatpickr-monthSelect-month.selected" ).Append( "{" )
-                .Append( $"background: { Var( ThemeVariables.Color( "primary" ) )};" )
-                .AppendLine( "}" );
+                sb
+                    .Append( $".flatpickr-monthSelect-month.selected" ).Append( "{" )
+                    .Append( $"background: { Var( ThemeVariables.Color( "primary" ) )};" )
+                    .AppendLine( "}" );
+            }
         }
 
         protected virtual void GenerateInputCheckEditStyles( StringBuilder sb, Theme theme, ThemeInputOptions options )


### PR DESCRIPTION
Hi, in the latest preview of Blazorise there is a small bug, caused by the addition of flatpicker styles in `ThemeGenerator`. When there is no Primary color defined in `Theme.ColorOptions` an exception is thrown.

![Capture](https://user-images.githubusercontent.com/34100964/119635812-b631a280-be1c-11eb-9339-633bc6801438.PNG)

This PR fixes this problem by checking if `theme.ColorOptions?.Primary` is null or empty before trying to apply the theme styles.