### PR TITLE
Fix DataGrid cell text alignment

### DIFF
--- a/Source/Extensions/Blazorise.DataGrid/_DataGridRowEdit.razor
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridRowEdit.razor
@@ -92,6 +92,7 @@ else if ( EditMode == DataGridEditMode.Inline )
                                          Item="@Item"
                                          Class="@column.CellClass?.Invoke(Item)"
                                          Style="@column.BuildCellStyle(Item)"
+                                         TextAlignment="@column.TextAlignment"
                                          EditState="DataGridEditState.Edit"
                                          Save="@SaveWithValidation"
                                          Cancel="@Cancel"
@@ -103,12 +104,13 @@ else if ( EditMode == DataGridEditMode.Inline )
                 @if ( ParentDataGrid.MultiSelect )
                 {
                     <TableRowCell Class="@column.CellClass?.Invoke(Item)"
-                                  Style="@column.BuildCellStyle(Item)"></TableRowCell>
+                                  Style="@column.BuildCellStyle(Item)"
+                                  TextAlignment="@column.TextAlignment"></TableRowCell>
                 }
             }
             else if ( column.Displayable )
             {
-                <TableRowCell Style="@column.BuildCellStyle(Item)">
+                <TableRowCell Class="@column.CellClass?.Invoke(Item)" Style="@column.BuildCellStyle(Item)" TextAlignment="@column.TextAlignment">
                     @if ( ParentDataGrid.IsCommandVisible && column.CellValueIsEditable )
                     {
                         <_DataGridCell TItem="TItem" Column="@column" Item="@Item" CellEditContext="@CellValues[column.ElementId]" ShowValidationFeedback="@ParentDataGrid.ShowValidationFeedback" />


### PR DESCRIPTION
fixed #2413 DataGrid inline edit mode forgets text alignment settings