### PR TITLE
Rule for NaN json serializer

### DIFF
--- a/Source/Extensions/Blazorise.Charts/ChartData.cs
+++ b/Source/Extensions/Blazorise.Charts/ChartData.cs
@@ -65,6 +65,7 @@ namespace Blazorise.Charts
         /// List of data items.
         /// </summary>
         [DataMember( EmitDefaultValue = false )]
+        [JsonNumberHandling( JsonNumberHandling.AllowNamedFloatingPointLiterals )]
         public List<T> Data { get; set; }
 
         /// <summary>


### PR DESCRIPTION
fixes #2395 Line charts throw error if dateset contains NaN data value