### PR TITLE
Make Bulma provider classes public

### DIFF
--- a/Source/Blazorise.Bulma/BulmaClassProvider.cs
+++ b/Source/Blazorise.Bulma/BulmaClassProvider.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace Blazorise.Bulma
 {
-    class BulmaClassProvider : ClassProvider
+    public class BulmaClassProvider : ClassProvider
     {
         #region TextEdit
 

--- a/Source/Blazorise.Bulma/BulmaStyleProvider.cs
+++ b/Source/Blazorise.Bulma/BulmaStyleProvider.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace Blazorise.Bulma
 {
-    class BulmaStyleProvider : StyleProvider
+    public class BulmaStyleProvider : StyleProvider
     {
         #region Modal
 


### PR DESCRIPTION
To be able to derive custom provider from existing Bulma provider.