### PR TITLE
move BaseAfterRenderComponent to Blazorise namespace

### DIFF
--- a/Source/Blazorise/Base/BaseAfterRenderComponent.cs
+++ b/Source/Blazorise/Base/BaseAfterRenderComponent.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 #endregion
 
-namespace Blazorise.Base
+namespace Blazorise
 {
     /// <summary>
     /// Base render component that implements render-queue logic.

--- a/Source/Blazorise/Base/BaseComponent.cs
+++ b/Source/Blazorise/Base/BaseComponent.cs
@@ -1,7 +1,6 @@
 ﻿#region Using directives
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Blazorise.Base;
 using Blazorise.Utilities;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;

--- a/Source/Extensions/Blazorise.DataGrid/BaseDataGridComponent.cs
+++ b/Source/Extensions/Blazorise.DataGrid/BaseDataGridComponent.cs
@@ -1,6 +1,5 @@
 ﻿#region Using directives
 using System;
-using Blazorise.Base;
 using Blazorise.Utilities;
 using Microsoft.AspNetCore.Components;
 #endregion


### PR DESCRIPTION
Hello, all Blazorise base components are using `Blazorise` namespace except BaseAfterRenderComponent which uses `Blazorise.Base`. So, just a small refactor for consistency.