### PR TITLE
Solution to Bug 2474

### DIFF
--- a/Source/Blazorise/Components/Modal/Modal.razor.cs
+++ b/Source/Blazorise/Components/Modal/Modal.razor.cs
@@ -211,7 +211,14 @@ namespace Blazorise
                 {
                     ExecuteAfterRender( async () =>
                     {
-                        await FocusableComponents.First().FocusAsync();
+                        //TODO: This warrants further investigation
+                        //Even with the Count>0 check above, sometimes FocusableComponents.First() fails intermittently with an InvalidOperationException: Sequence contains no elements
+                        //This null check helps prevent the application from crashing unexpectedly, until a more indepth solution can be found.
+                        var firstFocusableComponent = FocusableComponents.FirstOrDefault();
+                        if ( firstFocusableComponent != null )
+                        {
+                            await firstFocusableComponent.FocusAsync();
+                        }
                     } );
                 }
             }


### PR DESCRIPTION
https://github.com/Megabit/Blazorise/issues/2474

blazor.server.js:25 [2021-06-14T14:11:23.977Z] Error: System.AggregateException: One or more errors occurred. (Sequence contains no elements)
 ---> System.InvalidOperationException: Sequence contains no elements
   at System.Linq.ThrowHelper.ThrowNoElementsException()
   at System.Linq.Enumerable.First[TSource](IEnumerable`1 source)
   at Blazorise.Modal.<HandleVisibilityStyles>b__14_1()
   at Blazorise.Base.BaseAfterRenderComponent.OnAfterRenderAsync(Boolean firstRender)
   at Blazorise.BaseComponent.OnAfterRenderAsync(Boolean firstRender)
   --- End of inner exception stack trace ---
  