### PR TITLE
ButtonRow incorrect mediaquery breakpoint

### DIFF
--- a/Source/Extensions/Blazorise.DataGrid/_DataGridPagination.razor
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridPagination.razor
@@ -4,7 +4,7 @@
     @if ( ButtonRowTemplate != null && ParentDataGrid.IsButtonRowVisible )
     {
         <Column ColumnSize="ColumnSize.IsAuto" Display="Blazorise.Display.Flex.Row">
-            <Field Display="Blazorise.Display.None.InlineBlock.OnDesktop">
+            <Field Display="Blazorise.Display.InlineBlock">
                 @{
                     var newButtonString = Localizer.Localize( ParentDataGrid.Localizers?.NewButtonLocalizer, "New" );
                     var editButtonString = Localizer.Localize( ParentDataGrid.Localizers?.EditButtonLocalizer, "Edit" );


### PR DESCRIPTION
fixes #2393 DataGrid Button row disappears on small screens