### PR TITLE
Add Hidden flag on chart dataset

### DIFF
--- a/Source/Extensions/Blazorise.Charts/ChartData.cs
+++ b/Source/Extensions/Blazorise.Charts/ChartData.cs
@@ -101,6 +101,12 @@ namespace Blazorise.Charts
         /// </summary>
         [DataMember]
         public int Order { get; set; }
+
+        /// <summary>
+        /// If true, makes the dataset hidden.
+        /// </summary>
+        [DataMember]
+        public bool Hidden { get; set; }
     }
 
     /// <remarks>


### PR DESCRIPTION
resolves #1611 ChartJS (LineChart)Dataset: the ability to add series (Datasets) that are initially not displayed (hidden)