### PR TITLE
Adds EnableStep parameter on NumericEdit

### DIFF
--- a/Source/Blazorise.Bootstrap/NumericEdit.razor
+++ b/Source/Blazorise.Bootstrap/NumericEdit.razor
@@ -1,6 +1,6 @@
 ﻿@typeparam TValue
 @inherits Blazorise.NumericEdit<TValue>
-@if ( IsShowSpinButtons )
+@if ( IsShowStepButtons )
 {
     <div class="b-numeric">
         <input @ref="ElementRef" id="@ElementId" inputmode="numeric" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" size="@VisibleCharacters" step="@Step" pattern="@Pattern" tabindex="@TabIndex" value="@CurrentValueAsString" @onchange="@OnChangeHandler" @oninput="@OnInputHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />

--- a/Source/Blazorise/BlazoriseOptions.cs
+++ b/Source/Blazorise/BlazoriseOptions.cs
@@ -79,9 +79,14 @@ namespace Blazorise
         public int ThemeCacheSize { get; set; } = 10;
 
         /// <summary>
-        /// If true, the spin buttons on <see cref="NumericEdit{TValue}"/>. will be visible.
+        /// If true, the spin buttons on <see cref="NumericEdit{TValue}"/> will be visible.
         /// </summary>
-        public bool ShowSpinButtons { get; set; } = true;
+        public bool ShowNumericStepButtons { get; set; } = true;
+
+        /// <summary>
+        /// If true, enables change of <see cref="NumericEdit{TValue}"/> by pressing on step buttons or by keyboard up/down keys.
+        /// </summary>
+        public bool? EnableNumericStep { get; set; }
 
         /// <summary>
         /// Gets the service provider.

--- a/Source/Blazorise/Components/NumericEdit/NumericEdit.razor.cs
+++ b/Source/Blazorise/Components/NumericEdit/NumericEdit.razor.cs
@@ -213,7 +213,7 @@ namespace Blazorise
         /// <returns>Returns the awaitable task.</returns>
         protected virtual Task OnSpinUpClicked()
         {
-            if ( ReadOnly || Disabled )
+            if ( !IsEnableStep || ReadOnly || Disabled )
                 return Task.CompletedTask;
 
             return ProcessNumber( AddStep( CurrentValue, 1 ) );
@@ -225,7 +225,7 @@ namespace Blazorise
         /// <returns>Returns the awaitable task.</returns>
         protected virtual Task OnSpinDownClicked()
         {
-            if ( ReadOnly || Disabled )
+            if ( !IsEnableStep || ReadOnly || Disabled )
                 return Task.CompletedTask;
 
             return ProcessNumber( AddStep( CurrentValue, -1 ) );
@@ -287,8 +287,14 @@ namespace Blazorise
         /// <summary>
         /// True if spin buttons can be shown.
         /// </summary>
-        protected bool IsShowSpinButtons
-            => ShowSpinButtons.GetValueOrDefault( Options?.ShowSpinButtons ?? true ) && !( ReadOnly || Disabled );
+        protected bool IsShowStepButtons
+            => ShowStepButtons.GetValueOrDefault( Options?.ShowNumericStepButtons ?? true ) && !( ReadOnly || Disabled ) && IsEnableStep;
+
+        /// <summary>
+        /// True if value can be changed with stepper.
+        /// </summary>
+        protected bool IsEnableStep
+            => EnableStep.GetValueOrDefault( Options?.EnableNumericStep ?? true );
 
         /// <summary>
         /// Gets the culture info defined on the input field.
@@ -364,9 +370,14 @@ namespace Blazorise
         [Parameter] public int? VisibleCharacters { get; set; }
 
         /// <summary>
-        /// Sets the visibility of spin buttons.
+        /// If true, step buttons will be visible.
         /// </summary>
-        [Parameter] public bool? ShowSpinButtons { get; set; }
+        [Parameter] public bool? ShowStepButtons { get; set; }
+
+        /// <summary>
+        /// If true, enables change of numeric value by pressing on step buttons or by keyboard up/down keys.
+        /// </summary>
+        [Parameter] public bool? EnableStep { get; set; }
 
         #endregion
     }

--- a/Source/Extensions/Blazorise.DataGrid/DataGridNumericColumn.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGridNumericColumn.cs
@@ -37,5 +37,15 @@ namespace Blazorise.DataGrid
         /// https://www.w3schools.com/tags/ref_language_codes.asp
         /// </remarks>
         [Parameter] public string Culture { get; set; }
+
+        /// <summary>
+        /// If true, step buttons will be visible.
+        /// </summary>
+        [Parameter] public bool? ShowStepButtons { get; set; }
+
+        /// <summary>
+        /// If true, enables change of numeric value by pressing on step buttons or by keyboard up/down keys.
+        /// </summary>
+        [Parameter] public bool? EnableStep { get; set; }
     }
 }

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridCell.razor
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridCell.razor
@@ -13,7 +13,7 @@ else
         <Validation HandlerType="@ValidationHandlerType" Validator="@Validator" UsePattern="@HasValidationPattern">
             @if ( Column is DataGridNumericColumn<TItem> numericColumn )
             {
-                <_DataGridCellEditValidation Column="@Column" Item="@Item" ValidationItem="@ValidationItem" Field="@Column.Field" ValueType="@valueType" CellEditContext="CellEditContext" Readonly="@Column.Readonly" CellValueChanged="@CellValueChanged" ShowValidationFeedback="@ShowValidationFeedback" ValidationPattern="@ValidationPattern" Step="@numericColumn.Step" Decimals="@numericColumn.Decimals" DecimalsSeparator="@numericColumn.DecimalsSeparator" Culture="@numericColumn.Culture" />
+                <_DataGridCellEditValidation Column="@Column" Item="@Item" ValidationItem="@ValidationItem" Field="@Column.Field" ValueType="@valueType" CellEditContext="CellEditContext" Readonly="@Column.Readonly" CellValueChanged="@CellValueChanged" ShowValidationFeedback="@ShowValidationFeedback" ValidationPattern="@ValidationPattern" Step="@numericColumn.Step" Decimals="@numericColumn.Decimals" DecimalsSeparator="@numericColumn.DecimalsSeparator" Culture="@numericColumn.Culture" ShowStepButtons="@numericColumn.ShowStepButtons" EnableStep="@numericColumn.EnableStep" />
             }
             else
             {
@@ -25,7 +25,7 @@ else
     {
         @if ( Column is DataGridNumericColumn<TItem> numericColumn )
         {
-            <_DataGridCellEdit Column="@Column" Item="@Item" ValidationItem="@ValidationItem" Field="@Column.Field" ValueType="@valueType" CellEditContext="CellEditContext" Readonly="@Column.Readonly" CellValueChanged="@CellValueChanged" Step="@numericColumn.Step" Decimals="@numericColumn.Decimals" DecimalsSeparator="@numericColumn.DecimalsSeparator" Culture="@numericColumn.Culture" />
+            <_DataGridCellEdit Column="@Column" Item="@Item" ValidationItem="@ValidationItem" Field="@Column.Field" ValueType="@valueType" CellEditContext="CellEditContext" Readonly="@Column.Readonly" CellValueChanged="@CellValueChanged" Step="@numericColumn.Step" Decimals="@numericColumn.Decimals" DecimalsSeparator="@numericColumn.DecimalsSeparator" Culture="@numericColumn.Culture" ShowStepButtons="@numericColumn.ShowStepButtons" EnableStep="@numericColumn.EnableStep" />
         }
         else
         {

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridCellEdit.razor
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridCellEdit.razor
@@ -6,43 +6,43 @@
 }
 else if ( ValueType == typeof( decimal ) )
 {
-    <NumericEdit TValue="decimal" Value="@((decimal)CellEditContext.CellValue)" ValueChanged="@OnEditValueChanged" ReadOnly="@Readonly" Step="@Step" Decimals="@Decimals" DecimalsSeparator="@DecimalsSeparator" Culture="@Culture" />
+    <NumericEdit TValue="decimal" Value="@((decimal)CellEditContext.CellValue)" ValueChanged="@OnEditValueChanged" ReadOnly="@Readonly" Step="@Step" Decimals="@Decimals" DecimalsSeparator="@DecimalsSeparator" Culture="@Culture" ShowStepButtons="@ShowStepButtons" EnableStep="@EnableStep" />
 }
 else if ( ValueType == typeof( decimal? ) )
 {
-    <NumericEdit TValue="decimal?" Value="@((decimal?)CellEditContext.CellValue)" ValueChanged="@OnEditValueChanged" ReadOnly="@Readonly" Step="@Step" Decimals="@Decimals" DecimalsSeparator="@DecimalsSeparator" Culture="@Culture" />
+    <NumericEdit TValue="decimal?" Value="@((decimal?)CellEditContext.CellValue)" ValueChanged="@OnEditValueChanged" ReadOnly="@Readonly" Step="@Step" Decimals="@Decimals" DecimalsSeparator="@DecimalsSeparator" Culture="@Culture" ShowStepButtons="@ShowStepButtons" EnableStep="@EnableStep" />
 }
 else if ( ValueType == typeof( double ) )
 {
-    <NumericEdit TValue="double" Value="@((double)CellEditContext.CellValue)" ValueChanged="@OnEditValueChanged" ReadOnly="@Readonly" Step="@Step" Decimals="@Decimals" DecimalsSeparator="@DecimalsSeparator" Culture="@Culture" />
+    <NumericEdit TValue="double" Value="@((double)CellEditContext.CellValue)" ValueChanged="@OnEditValueChanged" ReadOnly="@Readonly" Step="@Step" Decimals="@Decimals" DecimalsSeparator="@DecimalsSeparator" Culture="@Culture" ShowStepButtons="@ShowStepButtons" EnableStep="@EnableStep" />
 }
 else if ( ValueType == typeof( double? ) )
 {
-    <NumericEdit TValue="double?" Value="@(( double?)CellEditContext.CellValue)" ValueChanged="@OnEditValueChanged" ReadOnly="@Readonly" Step="@Step" Decimals="@Decimals" DecimalsSeparator="@DecimalsSeparator" Culture="@Culture" />
+    <NumericEdit TValue="double?" Value="@(( double?)CellEditContext.CellValue)" ValueChanged="@OnEditValueChanged" ReadOnly="@Readonly" Step="@Step" Decimals="@Decimals" DecimalsSeparator="@DecimalsSeparator" Culture="@Culture" ShowStepButtons="@ShowStepButtons" EnableStep="@EnableStep" />
 }
 else if ( ValueType == typeof( float ) )
 {
-    <NumericEdit TValue="float" Value="@((float)CellEditContext.CellValue)" ValueChanged="@OnEditValueChanged" ReadOnly="@Readonly" Step="@Step" Decimals="@Decimals" DecimalsSeparator="@DecimalsSeparator" Culture="@Culture" />
+    <NumericEdit TValue="float" Value="@((float)CellEditContext.CellValue)" ValueChanged="@OnEditValueChanged" ReadOnly="@Readonly" Step="@Step" Decimals="@Decimals" DecimalsSeparator="@DecimalsSeparator" Culture="@Culture" ShowStepButtons="@ShowStepButtons" EnableStep="@EnableStep" />
 }
 else if ( ValueType == typeof( float? ) )
 {
-    <NumericEdit TValue="float?" Value="@((float?)CellEditContext.CellValue)" ValueChanged="@OnEditValueChanged" ReadOnly="@Readonly" Step="@Step" Decimals="@Decimals" DecimalsSeparator="@DecimalsSeparator" Culture="@Culture" />
+    <NumericEdit TValue="float?" Value="@((float?)CellEditContext.CellValue)" ValueChanged="@OnEditValueChanged" ReadOnly="@Readonly" Step="@Step" Decimals="@Decimals" DecimalsSeparator="@DecimalsSeparator" Culture="@Culture" ShowStepButtons="@ShowStepButtons" EnableStep="@EnableStep" />
 }
 else if ( ValueType == typeof( int ) )
 {
-    <NumericEdit TValue="int" Value="@((int)CellEditContext.CellValue)" ValueChanged="@OnEditValueChanged" ReadOnly="@Readonly" Step="@Step" Decimals="@Decimals" DecimalsSeparator="@DecimalsSeparator" Culture="@Culture" />
+    <NumericEdit TValue="int" Value="@((int)CellEditContext.CellValue)" ValueChanged="@OnEditValueChanged" ReadOnly="@Readonly" Step="@Step" Decimals="@Decimals" DecimalsSeparator="@DecimalsSeparator" Culture="@Culture" ShowStepButtons="@ShowStepButtons" EnableStep="@EnableStep" />
 }
 else if ( ValueType == typeof( int? ) )
 {
-    <NumericEdit TValue="int?" Value="@((int?)CellEditContext.CellValue)" ValueChanged="@OnEditValueChanged" ReadOnly="@Readonly" Step="@Step" Decimals="@Decimals" DecimalsSeparator="@DecimalsSeparator" Culture="@Culture" />
+    <NumericEdit TValue="int?" Value="@((int?)CellEditContext.CellValue)" ValueChanged="@OnEditValueChanged" ReadOnly="@Readonly" Step="@Step" Decimals="@Decimals" DecimalsSeparator="@DecimalsSeparator" Culture="@Culture" ShowStepButtons="@ShowStepButtons" EnableStep="@EnableStep" />
 }
 else if ( ValueType == typeof( long ) )
 {
-    <NumericEdit TValue="long" Value="@((long)CellEditContext.CellValue)" ValueChanged="@OnEditValueChanged" ReadOnly="@Readonly" Step="@Step" Decimals="@Decimals" DecimalsSeparator="@DecimalsSeparator" Culture="@Culture" />
+    <NumericEdit TValue="long" Value="@((long)CellEditContext.CellValue)" ValueChanged="@OnEditValueChanged" ReadOnly="@Readonly" Step="@Step" Decimals="@Decimals" DecimalsSeparator="@DecimalsSeparator" Culture="@Culture" ShowStepButtons="@ShowStepButtons" EnableStep="@EnableStep" />
 }
 else if ( ValueType == typeof( long? ) )
 {
-    <NumericEdit TValue="long?" Value="@((long?)CellEditContext.CellValue)" ValueChanged="@OnEditValueChanged" ReadOnly="@Readonly" Step="@Step" Decimals="@Decimals" DecimalsSeparator="@DecimalsSeparator" Culture="@Culture" />
+    <NumericEdit TValue="long?" Value="@((long?)CellEditContext.CellValue)" ValueChanged="@OnEditValueChanged" ReadOnly="@Readonly" Step="@Step" Decimals="@Decimals" DecimalsSeparator="@DecimalsSeparator" Culture="@Culture" ShowStepButtons="@ShowStepButtons" EnableStep="@EnableStep" />
 }
 else if ( ValueType == typeof( bool ) )
 {

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridCellEdit.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridCellEdit.razor.cs
@@ -89,5 +89,15 @@ namespace Blazorise.DataGrid
         /// https://www.w3schools.com/tags/ref_language_codes.asp
         /// </remarks>
         [Parameter] public string Culture { get; set; }
+
+        /// <summary>
+        /// If true, step buttons will be visible.
+        /// </summary>
+        [Parameter] public bool? ShowStepButtons { get; set; }
+
+        /// <summary>
+        /// If true, enables change of numeric value by pressing on step buttons or by keyboard up/down keys.
+        /// </summary>
+        [Parameter] public bool? EnableStep { get; set; }
     }
 }

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridCellEditValidation.razor
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridCellEditValidation.razor
@@ -13,7 +13,7 @@
 }
 else if ( ValueType == typeof( decimal ) )
 {
-    <NumericEdit TValue="decimal" Value="@((decimal)CellEditContext.CellValue)" ValueChanged="@OnEditValueChanged" ValueExpression="@decimalExpression" ReadOnly="@Readonly" Pattern="@ValidationPattern" Step="@Step" Decimals="@Decimals" DecimalsSeparator="@DecimalsSeparator" Culture="@Culture">
+    <NumericEdit TValue="decimal" Value="@((decimal)CellEditContext.CellValue)" ValueChanged="@OnEditValueChanged" ValueExpression="@decimalExpression" ReadOnly="@Readonly" Pattern="@ValidationPattern" Step="@Step" Decimals="@Decimals" DecimalsSeparator="@DecimalsSeparator" Culture="@Culture" ShowStepButtons="@ShowStepButtons" EnableStep="@EnableStep">
         <Feedback>
             @if ( ShowValidationFeedback )
             {
@@ -24,7 +24,7 @@ else if ( ValueType == typeof( decimal ) )
 }
 else if ( ValueType == typeof( decimal? ) )
 {
-    <NumericEdit TValue="decimal?" Value="@((decimal?)CellEditContext.CellValue)" ValueChanged="@OnEditValueChanged" ValueExpression="@nullableDecimalExpression" ReadOnly="@Readonly" Pattern="@ValidationPattern" Step="@Step" Decimals="@Decimals" DecimalsSeparator="@DecimalsSeparator" Culture="@Culture">
+    <NumericEdit TValue="decimal?" Value="@((decimal?)CellEditContext.CellValue)" ValueChanged="@OnEditValueChanged" ValueExpression="@nullableDecimalExpression" ReadOnly="@Readonly" Pattern="@ValidationPattern" Step="@Step" Decimals="@Decimals" DecimalsSeparator="@DecimalsSeparator" Culture="@Culture" ShowStepButtons="@ShowStepButtons" EnableStep="@EnableStep">
         <Feedback>
             @if ( ShowValidationFeedback )
             {
@@ -35,7 +35,7 @@ else if ( ValueType == typeof( decimal? ) )
 }
 else if ( ValueType == typeof( double ) )
 {
-    <NumericEdit TValue="double" Value="@((double)CellEditContext.CellValue)" ValueChanged="@OnEditValueChanged" ValueExpression="@doubleExpression" ReadOnly="@Readonly" Pattern="@ValidationPattern" Step="@Step" Decimals="@Decimals" DecimalsSeparator="@DecimalsSeparator" Culture="@Culture">
+    <NumericEdit TValue="double" Value="@((double)CellEditContext.CellValue)" ValueChanged="@OnEditValueChanged" ValueExpression="@doubleExpression" ReadOnly="@Readonly" Pattern="@ValidationPattern" Step="@Step" Decimals="@Decimals" DecimalsSeparator="@DecimalsSeparator" Culture="@Culture" ShowStepButtons="@ShowStepButtons" EnableStep="@EnableStep">
         <Feedback>
             @if ( ShowValidationFeedback )
             {
@@ -46,7 +46,7 @@ else if ( ValueType == typeof( double ) )
 }
 else if ( ValueType == typeof( double? ) )
 {
-    <NumericEdit TValue="double?" Value="@(( double?)CellEditContext.CellValue)" ValueChanged="@OnEditValueChanged" ValueExpression="@nullableDoubleExpression" ReadOnly="@Readonly" Pattern="@ValidationPattern" Step="@Step" Decimals="@Decimals" DecimalsSeparator="@DecimalsSeparator" Culture="@Culture">
+    <NumericEdit TValue="double?" Value="@(( double?)CellEditContext.CellValue)" ValueChanged="@OnEditValueChanged" ValueExpression="@nullableDoubleExpression" ReadOnly="@Readonly" Pattern="@ValidationPattern" Step="@Step" Decimals="@Decimals" DecimalsSeparator="@DecimalsSeparator" Culture="@Culture" ShowStepButtons="@ShowStepButtons" EnableStep="@EnableStep">
         <Feedback>
             @if ( ShowValidationFeedback )
             {
@@ -57,7 +57,7 @@ else if ( ValueType == typeof( double? ) )
 }
 else if ( ValueType == typeof( float ) )
 {
-    <NumericEdit TValue="float" Value="@((float)CellEditContext.CellValue)" ValueChanged="@OnEditValueChanged" ValueExpression="@floatExpression" ReadOnly="@Readonly" Pattern="@ValidationPattern" Step="@Step" Decimals="@Decimals" DecimalsSeparator="@DecimalsSeparator" Culture="@Culture">
+    <NumericEdit TValue="float" Value="@((float)CellEditContext.CellValue)" ValueChanged="@OnEditValueChanged" ValueExpression="@floatExpression" ReadOnly="@Readonly" Pattern="@ValidationPattern" Step="@Step" Decimals="@Decimals" DecimalsSeparator="@DecimalsSeparator" Culture="@Culture" ShowStepButtons="@ShowStepButtons" EnableStep="@EnableStep">
         <Feedback>
             @if ( ShowValidationFeedback )
             {
@@ -68,7 +68,7 @@ else if ( ValueType == typeof( float ) )
 }
 else if ( ValueType == typeof( float? ) )
 {
-    <NumericEdit TValue="float?" Value="@((float?)CellEditContext.CellValue)" ValueChanged="@OnEditValueChanged" ValueExpression="@nullableFloatExpression" ReadOnly="@Readonly" Pattern="@ValidationPattern" Step="@Step" Decimals="@Decimals" DecimalsSeparator="@DecimalsSeparator" Culture="@Culture">
+    <NumericEdit TValue="float?" Value="@((float?)CellEditContext.CellValue)" ValueChanged="@OnEditValueChanged" ValueExpression="@nullableFloatExpression" ReadOnly="@Readonly" Pattern="@ValidationPattern" Step="@Step" Decimals="@Decimals" DecimalsSeparator="@DecimalsSeparator" Culture="@Culture" ShowStepButtons="@ShowStepButtons" EnableStep="@EnableStep">
         <Feedback>
             @if ( ShowValidationFeedback )
             {
@@ -79,7 +79,7 @@ else if ( ValueType == typeof( float? ) )
 }
 else if ( ValueType == typeof( int ) )
 {
-    <NumericEdit TValue="int" Value="@((int)CellEditContext.CellValue)" ValueChanged="@OnEditValueChanged" ValueExpression="@intExpression" ReadOnly="@Readonly" Pattern="@ValidationPattern" Step="@Step" Decimals="@Decimals" DecimalsSeparator="@DecimalsSeparator" Culture="@Culture">
+    <NumericEdit TValue="int" Value="@((int)CellEditContext.CellValue)" ValueChanged="@OnEditValueChanged" ValueExpression="@intExpression" ReadOnly="@Readonly" Pattern="@ValidationPattern" Step="@Step" Decimals="@Decimals" DecimalsSeparator="@DecimalsSeparator" Culture="@Culture" ShowStepButtons="@ShowStepButtons" EnableStep="@EnableStep">
         <Feedback>
             @if ( ShowValidationFeedback )
             {
@@ -90,7 +90,7 @@ else if ( ValueType == typeof( int ) )
 }
 else if ( ValueType == typeof( int? ) )
 {
-    <NumericEdit TValue="int?" Value="@((int?)CellEditContext.CellValue)" ValueChanged="@OnEditValueChanged" ValueExpression="@nullableIntExpression" ReadOnly="@Readonly" Pattern="@ValidationPattern" Step="@Step" Decimals="@Decimals" DecimalsSeparator="@DecimalsSeparator" Culture="@Culture">
+    <NumericEdit TValue="int?" Value="@((int?)CellEditContext.CellValue)" ValueChanged="@OnEditValueChanged" ValueExpression="@nullableIntExpression" ReadOnly="@Readonly" Pattern="@ValidationPattern" Step="@Step" Decimals="@Decimals" DecimalsSeparator="@DecimalsSeparator" Culture="@Culture" ShowStepButtons="@ShowStepButtons" EnableStep="@EnableStep">
         <Feedback>
             @if ( ShowValidationFeedback )
             {
@@ -101,7 +101,7 @@ else if ( ValueType == typeof( int? ) )
 }
 else if ( ValueType == typeof( long ) )
 {
-    <NumericEdit TValue="long" Value="@((long)CellEditContext.CellValue)" ValueChanged="@OnEditValueChanged" ValueExpression="@longExpression" ReadOnly="@Readonly" Pattern="@ValidationPattern" Step="@Step" Decimals="@Decimals" DecimalsSeparator="@DecimalsSeparator" Culture="@Culture">
+    <NumericEdit TValue="long" Value="@((long)CellEditContext.CellValue)" ValueChanged="@OnEditValueChanged" ValueExpression="@longExpression" ReadOnly="@Readonly" Pattern="@ValidationPattern" Step="@Step" Decimals="@Decimals" DecimalsSeparator="@DecimalsSeparator" Culture="@Culture" ShowStepButtons="@ShowStepButtons" EnableStep="@EnableStep">
         <Feedback>
             @if ( ShowValidationFeedback )
             {
@@ -112,7 +112,7 @@ else if ( ValueType == typeof( long ) )
 }
 else if ( ValueType == typeof( long? ) )
 {
-    <NumericEdit TValue="long?" Value="@((long?)CellEditContext.CellValue)" ValueChanged="@OnEditValueChanged" ValueExpression="@nullableLongExpression" ReadOnly="@Readonly" Pattern="@ValidationPattern" Step="@Step" Decimals="@Decimals" DecimalsSeparator="@DecimalsSeparator" Culture="@Culture">
+    <NumericEdit TValue="long?" Value="@((long?)CellEditContext.CellValue)" ValueChanged="@OnEditValueChanged" ValueExpression="@nullableLongExpression" ReadOnly="@Readonly" Pattern="@ValidationPattern" Step="@Step" Decimals="@Decimals" DecimalsSeparator="@DecimalsSeparator" Culture="@Culture" ShowStepButtons="@ShowStepButtons" EnableStep="@EnableStep">
         <Feedback>
             @if ( ShowValidationFeedback )
             {

--- a/docs/_docs/components/numeric.md
+++ b/docs/_docs/components/numeric.md
@@ -40,4 +40,5 @@ NumericEdit is just a specialized version of `TextEdit` component so all of the 
 | Min               | TValue                                                       | default | The minimum value to accept for this input.                                                          |
 | Max               | TValue                                                       | default | The maximum value to accept for this input.                                                          |
 | Autofocus         | `bool`                                                       |  false  | Set's the focus to the component after the rendering is done.                                        |
-| ShowSpinButtons   | `bool?`                                                      |  true   | Sets the visibility of spin buttons.                                                                 |
+| ShowStepButtons   | `bool?`                                                      |  true   | If true, step buttons will be visible.                                                               |
+| EnableStep        | `bool?`                                                      |  true   | If true, enables change of numeric value by pressing on step buttons or by keyboard up/down keys.    |


### PR DESCRIPTION
resolves #2316 NumericEdit cannot disable numeric stepping from keyboard up/down

- adds `EnableStep` parameter
- renames `ShowSpinButtons` into `ShowStepButtons`