### PR TITLE
Fix missing TableRow on DataGrid inline edit

### DIFF
--- a/Source/Extensions/Blazorise.DataGrid/_DataGridRowEdit.razor
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridRowEdit.razor
@@ -82,52 +82,54 @@ else if ( EditMode == DataGridEditMode.Inline )
                 </TableRowCell>
             </TableRow>
         }
-        @foreach ( var column in DisplayableColumns )
-        {
-            @if ( column.IsCommandColumn )
+        <TableRow>
+            @foreach ( var column in DisplayableColumns )
             {
-                @if ( ParentDataGrid.IsCommandVisible )
+                @if ( column.IsCommandColumn )
                 {
-                    <_DataGridRowCommand TItem="TItem"
-                                         Item="@Item"
-                                         Class="@column.CellClass?.Invoke(Item)"
-                                         Style="@column.BuildCellStyle(Item)"
-                                         TextAlignment="@column.TextAlignment"
-                                         EditState="DataGridEditState.Edit"
-                                         Save="@SaveWithValidation"
-                                         Cancel="@Cancel"
-                                         Width="@column.Width" />
-                }
-            }
-            else if ( column.IsMultiSelectColumn )
-            {
-                @if ( ParentDataGrid.MultiSelect )
-                {
-                    <TableRowCell Class="@column.CellClass?.Invoke(Item)"
-                                  Style="@column.BuildCellStyle(Item)"
-                                  TextAlignment="@column.TextAlignment"></TableRowCell>
-                }
-            }
-            else if ( column.Displayable )
-            {
-                <TableRowCell Class="@column.CellClass?.Invoke(Item)" Style="@column.BuildCellStyle(Item)" TextAlignment="@column.TextAlignment">
-                    @if ( ParentDataGrid.IsCommandVisible && column.CellValueIsEditable )
+                    @if ( ParentDataGrid.IsCommandVisible )
                     {
-                        <_DataGridCell TItem="TItem" Column="@column" Item="@Item" CellEditContext="@CellValues[column.ElementId]" ShowValidationFeedback="@ParentDataGrid.ShowValidationFeedback" />
+                        <_DataGridRowCommand TItem="TItem"
+                                             Item="@Item"
+                                             Class="@column.CellClass?.Invoke(Item)"
+                                             Style="@column.BuildCellStyle(Item)"
+                                             TextAlignment="@column.TextAlignment"
+                                             EditState="DataGridEditState.Edit"
+                                             Save="@SaveWithValidation"
+                                             Cancel="@Cancel"
+                                             Width="@column.Width" />
                     }
-                    else
+                }
+                else if ( column.IsMultiSelectColumn )
+                {
+                    @if ( ParentDataGrid.MultiSelect )
                     {
-                        if ( column.DisplayTemplate != null )
+                        <TableRowCell Class="@column.CellClass?.Invoke(Item)"
+                                      Style="@column.BuildCellStyle(Item)"
+                                      TextAlignment="@column.TextAlignment"></TableRowCell>
+                    }
+                }
+                else if ( column.Displayable )
+                {
+                    <TableRowCell Class="@column.CellClass?.Invoke(Item)" Style="@column.BuildCellStyle(Item)" TextAlignment="@column.TextAlignment">
+                        @if ( ParentDataGrid.IsCommandVisible && column.CellValueIsEditable )
                         {
-                            @column.DisplayTemplate( Item )
+                            <_DataGridCell TItem="TItem" Column="@column" Item="@Item" CellEditContext="@CellValues[column.ElementId]" ShowValidationFeedback="@ParentDataGrid.ShowValidationFeedback" />
                         }
                         else
                         {
-                            @column.FormatDisplayValue( Item )
+                            if ( column.DisplayTemplate != null )
+                            {
+                                @column.DisplayTemplate( Item )
+                            }
+                            else
+                            {
+                                @column.FormatDisplayValue( Item )
+                            }
                         }
-                    }
-                </TableRowCell>
+                    </TableRowCell>
+                }
             }
-        }
+        </TableRow>
     </Validations>
 }


### PR DESCRIPTION
fixes #2413 DataGrid inline edit mode forgets text alignment settings