### PR TITLE
Horizontal Dropdown fix

### DIFF
--- a/Source/Blazorise.Bootstrap/BarDropdownMenu.razor
+++ b/Source/Blazorise.Bootstrap/BarDropdownMenu.razor
@@ -1,0 +1,15 @@
+﻿@inherits Blazorise.BarDropdownMenu
+@if ( ParentDropdownState.Mode == BarMode.Horizontal )
+{
+    <div id="@ElementId" class="@ClassNames" style="@StyleNames" @attributes="@Attributes" @onmouseenter="@ParentBarDropdown.OnMouseEnter" @onmouseleave="@ParentBarDropdown.OnMouseLeave" data-visible="@VisibleString">
+        @ChildContent
+    </div>
+}
+else
+{
+    <div class="@ContainerClassNames">
+        <div id="@ElementId" class="@ClassNames" style="@StyleNames" @attributes="@Attributes" @onmouseenter="@ParentBarDropdown.OnMouseEnter" @onmouseleave="@ParentBarDropdown.OnMouseLeave" data-visible="@VisibleString">
+            @ChildContent
+        </div>
+    </div>
+}

--- a/Source/Blazorise.Bootstrap/Config.cs
+++ b/Source/Blazorise.Bootstrap/Config.cs
@@ -44,6 +44,7 @@ namespace Blazorise.Bootstrap
             { typeof( Blazorise.Addon ), typeof( Bootstrap.Addon ) },
             { typeof( Blazorise.BarToggler ), typeof( Bootstrap.BarToggler ) },
             { typeof( Blazorise.BarDropdown ), typeof( Bootstrap.BarDropdown ) },
+            { typeof( Blazorise.BarDropdownMenu ), typeof( Bootstrap.BarDropdownMenu ) },
             { typeof( Blazorise.CardTitle ), typeof( Bootstrap.CardTitle ) },
             { typeof( Blazorise.CardSubtitle ), typeof( Bootstrap.CardSubtitle ) },
             { typeof( Blazorise.Carousel ), typeof( Bootstrap.Carousel ) },

--- a/Source/Blazorise/wwwroot/blazorise.js
+++ b/Source/Blazorise/wwwroot/blazorise.js
@@ -985,7 +985,7 @@ document.addEventListener('mousedown', function handler(evt) {
 });
 
 document.addEventListener('mouseup', function handler(evt) {
-    if (evt.target === window.blazorise.lastClickedDocumentElement && window.blazorise.closableComponents && window.blazorise.closableComponents.length > 0) {
+    if (evt.button === 0 && evt.target === window.blazorise.lastClickedDocumentElement && window.blazorise.closableComponents && window.blazorise.closableComponents.length > 0) {
         const lastClosable = window.blazorise.closableComponents[window.blazorise.closableComponents.length - 1];
 
         if (lastClosable) {


### PR DESCRIPTION
The horizontal menu was wrongly placed inside of empty div and it would break the Bootstrap structure.

I also make the closing of closable components only with the left mouse button.