### PR TITLE
Use catch when

### DIFF
--- a/Source/Blazorise/Components/Bar/Bar.razor.cs
+++ b/Source/Blazorise/Components/Bar/Bar.razor.cs
@@ -127,12 +127,8 @@ namespace Blazorise
                     {
                         await task;
                     }
-                    catch
+                    catch when ( task.IsCanceled )
                     {
-                        if ( !task.IsCanceled )
-                        {
-                            throw;
-                        }
                     }
 
                     DisposeDotNetObjectRef( dotNetObjectRef );

--- a/Source/Blazorise/Components/Bar/BarDropdownToggle.razor.cs
+++ b/Source/Blazorise/Components/Bar/BarDropdownToggle.razor.cs
@@ -65,12 +65,8 @@ namespace Blazorise
                     {
                         await task;
                     }
-                    catch
+                    catch when ( task.IsCanceled )
                     {
-                        if ( !task.IsCanceled )
-                        {
-                            throw;
-                        }
                     }
                 }
 

--- a/Source/Blazorise/Components/Button/Button.cs
+++ b/Source/Blazorise/Components/Button/Button.cs
@@ -109,12 +109,8 @@ namespace Blazorise
                     {
                         await task;
                     }
-                    catch
+                    catch when ( task.IsCanceled )
                     {
-                        if ( !task.IsCanceled )
-                        {
-                            throw;
-                        }
                     }
                 }
 

--- a/Source/Blazorise/Components/DatePicker/DatePicker.razor.cs
+++ b/Source/Blazorise/Components/DatePicker/DatePicker.razor.cs
@@ -104,12 +104,8 @@ namespace Blazorise
                     {
                         await task;
                     }
-                    catch
+                    catch when ( task.IsCanceled )
                     {
-                        if ( !task.IsCanceled )
-                        {
-                            throw;
-                        }
                     }
                 }
             }

--- a/Source/Blazorise/Components/Dropdown/DropdownToggle.razor.cs
+++ b/Source/Blazorise/Components/Dropdown/DropdownToggle.razor.cs
@@ -81,12 +81,8 @@ namespace Blazorise
                     {
                         await task;
                     }
-                    catch
+                    catch when ( task.IsCanceled )
                     {
-                        if ( !task.IsCanceled )
-                        {
-                            throw;
-                        }
                     }
                 }
 

--- a/Source/Blazorise/Components/FileEdit/FileEdit.razor.cs
+++ b/Source/Blazorise/Components/FileEdit/FileEdit.razor.cs
@@ -107,12 +107,8 @@ namespace Blazorise
                 {
                     await task;
                 }
-                catch
+                catch when ( task.IsCanceled )
                 {
-                    if ( !task.IsCanceled )
-                    {
-                        throw;
-                    }
                 }
 
                 DisposeDotNetObjectRef( dotNetObjectRef );

--- a/Source/Blazorise/Components/Modal/Modal.razor.cs
+++ b/Source/Blazorise/Components/Modal/Modal.razor.cs
@@ -103,12 +103,8 @@ namespace Blazorise
                     {
                         await task;
                     }
-                    catch
+                    catch when ( task.IsCanceled )
                     {
-                        if ( !task.IsCanceled )
-                        {
-                            throw;
-                        }
                     }
                 }
 

--- a/Source/Blazorise/Components/NumericEdit/NumericEdit.razor.cs
+++ b/Source/Blazorise/Components/NumericEdit/NumericEdit.razor.cs
@@ -109,12 +109,8 @@ namespace Blazorise
                 {
                     await task;
                 }
-                catch
+                catch when ( task.IsCanceled )
                 {
-                    if ( !task.IsCanceled )
-                    {
-                        throw;
-                    }
                 }
 
                 DisposeDotNetObjectRef( dotNetObjectRef );

--- a/Source/Blazorise/Components/TextEdit/TextEdit.razor.cs
+++ b/Source/Blazorise/Components/TextEdit/TextEdit.razor.cs
@@ -59,12 +59,8 @@ namespace Blazorise
                 {
                     await task;
                 }
-                catch
+                catch when ( task.IsCanceled )
                 {
-                    if ( !task.IsCanceled )
-                    {
-                        throw;
-                    }
                 }
             }
 

--- a/Source/Blazorise/Components/TimePicker/TimePicker.razor.cs
+++ b/Source/Blazorise/Components/TimePicker/TimePicker.razor.cs
@@ -100,12 +100,8 @@ namespace Blazorise
                     {
                         await task;
                     }
-                    catch
+                    catch when ( task.IsCanceled )
                     {
-                        if ( !task.IsCanceled )
-                        {
-                            throw;
-                        }
                     }
                 }
             }


### PR DESCRIPTION
to avoid the catch and re-throw when !task.IsCanceled

so we only swallow  when ( task.IsCanceled )