### PR TITLE
AntDesign - Table Fixed Header Fix

### DIFF
--- a/Source/Blazorise.AntDesign/Styles/_table.scss
+++ b/Source/Blazorise.AntDesign/Styles/_table.scss
@@ -86,3 +86,26 @@
 .ant-table-responsive > .ant-table-bordered {
     border: 0;
 }
+
+.ant-table-fixed-header {
+    .ant-table-container{ 
+        overflow-y: auto;
+    }
+
+    .table {
+        border-collapse: separate;
+        border-spacing: 0;
+    }
+
+    thead tr th {
+        border-top: none;
+        position: sticky;
+        background: white;
+        z-index: 1;
+    }
+
+    thead tr:nth-child(1) th {
+        top: 0;
+    }
+}
+

--- a/Source/Blazorise.AntDesign/Table.razor
+++ b/Source/Blazorise.AntDesign/Table.razor
@@ -2,9 +2,9 @@
 <CascadingValue Value="@this" IsFixed="true">
     @if ( FixedHeader )
     {
-        <div id="@ElementId" class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
-            <div class="ant-table-container">
-                <div class="ant-table-header" style="overflow: hidden;">
+        <div id="@ElementId" class="@ClassNames" @attributes="@Attributes">
+            <div class="ant-table-container" style="@ContainerStyleNames">
+                <div class="ant-table-header">
                     <table @ref="@ElementRef" style="table-layout: fixed;"
                            draggable="@Draggable"
                            @ondrag="@OnDragHandler"

--- a/Source/Blazorise.AntDesign/Table.razor.cs
+++ b/Source/Blazorise.AntDesign/Table.razor.cs
@@ -12,16 +12,5 @@ namespace Blazorise.AntDesign
             builder.Append( ClassProvider.TableFixedHeader(), FixedHeader );
         }
 
-        protected override void BuildStyles( StyleBuilder builder )
-        {
-            // don't add anything for antdesign
-        }
-
-        protected override ValueTask InitializeTableFixedHeader()
-        {
-            // antdesign has a different table structure so we don't need to do anything
-
-            return ValueTask.CompletedTask;
-        }
     }
 }

--- a/Source/Blazorise.AntDesign/wwwroot/blazorise.antdesign.css
+++ b/Source/Blazorise.AntDesign/wwwroot/blazorise.antdesign.css
@@ -2222,6 +2222,22 @@ li.ant-list-item-actionable {
 .ant-table-responsive > .ant-table-bordered {
     border: 0; }
 
+.ant-table-fixed-header .ant-table-container {
+    overflow-y: auto; }
+
+.ant-table-fixed-header .table {
+    border-collapse: separate;
+    border-spacing: 0; }
+
+.ant-table-fixed-header thead tr th {
+    border-top: none;
+    position: sticky;
+    background: white;
+    z-index: 1; }
+
+.ant-table-fixed-header thead tr:nth-child(1) th {
+    top: 0; }
+
 .ant-tabs.ant-tabs-fill .ant-tabs-tab {
     flex-grow: 1;
     margin-right: 0px;


### PR DESCRIPTION
Fixes #2621 

Certainly you were trying to get the native's AntDesign fixed header to work. 
https://ant.design/components/table/#components-table-demo-fixed-header
![image](https://user-images.githubusercontent.com/22283161/125146046-e5297c80-e11b-11eb-9c02-75e39c1154d1.png)
Problem is they separate **Header** From **Body** on FixedHeader feature, unlike us. And I believe we would need to slightly redesign our table to be able to have a collection of TableHeaderRows vs TableBodyRows, so we could do the native implementation. 

This PR should serve as a workaround to get it working for the time being.


