### PR TITLE
Prototype for handling DetailRow on click, saving row state, ...

### DIFF
--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor
@@ -122,25 +122,20 @@
             }
             @if ( IsDisplayDataVisible )
             {
-                @foreach ( var item in DisplayData )
+                @foreach ( var row in DisplayRowData )
                 {
-                    @if ( Editable && editState == DataGridEditState.Edit && EditMode != DataGridEditMode.Popup && item.IsEqual( editItem ) )
+                    @if ( Editable && editState == DataGridEditState.Edit && EditMode != DataGridEditMode.Popup && row.Item.IsEqual( editItem ) )
                     {
                         <_DataGridRowEdit TItem="TItem" Item="@editItem" ValidationItem="@validationItem" Columns="@Columns" CellValues="@editItemCellValues" Save="@Save" Cancel="@Cancel" EditMode="@EditMode" />
                     }
                     else
                     {
-                        <_DataGridRow @key="@item" TItem="TItem" Item="@item" Columns="@DisplayableColumns" HoverCursor="@(RowHoverCursor?.Invoke(item) ?? Cursor.Pointer)" Edit="@Edit" Delete="@Delete" Save="@Save" Cancel="@Cancel" Selected="@Select" Clicked="@OnRowClickedCommand" DoubleClicked="@OnRowDoubleClickedCommand" MultiSelect="OnMultiSelectCommand" />
-                        @if ( DetailRowTemplate != null )
+                        <_DataGridRow @key="@row.Item" TItem="TItem" Item="@row.Item" DetailRowTrigger="@DetailRowTrigger" Columns="@DisplayableColumns" HoverCursor="@(RowHoverCursor?.Invoke(row.Item) ?? Cursor.Pointer)" Edit="@Edit" Delete="@Delete" Save="@Save" Cancel="@Cancel" Selected="@Select" Clicked="@OnRowClickedCommand" DoubleClicked="@OnRowDoubleClickedCommand" MultiSelect="OnMultiSelectCommand" />
+                        @if ( DetailRowTemplate != null && row.ShowDetail )
                         {
-                            var canShow = DetailRowTrigger?.Invoke( item ) ?? true;
-
-                            @if ( canShow )
-                            {
-                                <_DataGridDetailRow TItem="TItem" Item="@item" Columns="@Columns">
-                                    @DetailRowTemplate( item )
-                                </_DataGridDetailRow>
-                            }
+                            <_DataGridDetailRow TItem="TItem" Item="@row.Item" Columns="@Columns">
+                                @DetailRowTemplate( row.Item )
+                            </_DataGridDetailRow>
                         }
                     }
                 }

--- a/Source/Extensions/Blazorise.DataGrid/Models/DataGridColumnInfo.cs
+++ b/Source/Extensions/Blazorise.DataGrid/Models/DataGridColumnInfo.cs
@@ -4,6 +4,7 @@ using System;
 
 namespace Blazorise.DataGrid
 {
+
     /// <summary>
     /// Holds the basic information about the datagrid column.
     /// </summary>

--- a/Source/Extensions/Blazorise.DataGrid/Models/DataGridRowInfo.cs
+++ b/Source/Extensions/Blazorise.DataGrid/Models/DataGridRowInfo.cs
@@ -1,0 +1,29 @@
+﻿#region Using directives
+#endregion
+
+namespace Blazorise.DataGrid
+{
+    /// <summary>
+    /// Holds the basic information about the datagrid row.
+    /// </summary>
+    public class DataGridRowInfo<TItem>
+    {
+        private bool showDetail;
+        /// <summary>
+        /// Initializes a new instance of row info.
+        /// </summary>
+        /// <param name="item">Row Item</param>
+        public DataGridRowInfo( TItem item )
+        {
+            Item = item;
+        }
+
+        public TItem Item { get; }
+
+        public bool ShowDetail => showDetail;
+
+        public void SetShowDetail(bool toShowDetail)
+            => showDetail = !showDetail & toShowDetail;
+
+    }
+}

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridRow.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridRow.razor.cs
@@ -1,4 +1,5 @@
 ﻿#region Using directives
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -67,6 +68,8 @@ namespace Blazorise.DataGrid
 
             await HandleMultiSelectClick( eventArgs );
             clickFromCheck = false;
+
+            await ParentDataGrid.ToggleDetailRow( Item );
         }
 
         private async Task HandleMultiSelectClick( BLMouseEventArgs eventArgs )
@@ -248,6 +251,16 @@ namespace Blazorise.DataGrid
         [Parameter] public Cursor HoverCursor { get; set; }
 
         [Parameter] public RenderFragment ChildContent { get; set; }
+
+        /// <summary>
+        /// Holds the basic information about the datagrid row.
+        /// </summary>
+        [Parameter] public DataGridRowInfo<TItem> RowInfo { get; set; }
+
+        /// <summary>
+        /// A trigger function used to handle the visibility of detail row.
+        /// </summary>
+        [Parameter] public Func<TItem, bool> DetailRowTrigger { get; set; }
 
         #endregion
     }


### PR DESCRIPTION
@stsrki can you take a look at these suggestions?
**Disclaimer :** Commit still not clean / not final code, since I've done some prototypying here.

I was initially going to do this with some flags and some tricks to keep track of the state... But I figured we're starting to scatter too much logic because of missing state...
So... Introduced new RowInfo Internal API as a suggestion.
I really think we are missing this, to keep state around of each Row, and it is limiting the stuff that we can do and expose to our users.
Tell me what you think? This should also be the foundation for the requested multi row edit handling, as you can finally keep track of the state of multiple rows.

Also Figured `dirtyView` was always true due to `Data` Parameter always calling set..., so everything was always recalculated, on every interaction, I did a tiny dirty fix on it, but probably should think of a different approach.

Also the DetailRow, will now behave slightly differently. Since it's triggered on rowclick, which should be more efficient, instead of always being re-evaluated, you will now be able to have several row details open, which in my opinion would be the actual correct behaviour for `DetailRowTrigger` but it is indeed different from the current behaviour, which only keeps a single detail open. (The fix is however easy, as we just need to check if the item is selected or not, to go back to the previous behaviour with this new implementation)

Also there's still a bug with changing the PageSize, as it looses track of the row info.

Closes #2532 // #2500