### PR TITLE
Benchmark project | ArrayExtensions AreEqual refactor

### DIFF
--- a/Blazorise.sln
+++ b/Blazorise.sln
@@ -84,6 +84,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Blazorise.SpinKit", "Source
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Blazorise.Markdown", "Source\Extensions\Blazorise.Markdown\Blazorise.Markdown.csproj", "{1D30D96F-71FC-49A7-AF88-5749CBAA8153}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Blazorise.Benchmark", "Tests\Blazorise.Benchmark\Blazorise.Benchmark.csproj", "{E4EDDFC0-0E25-48E1-A8AC-6ED091FC859F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -222,6 +224,10 @@ Global
 		{1D30D96F-71FC-49A7-AF88-5749CBAA8153}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1D30D96F-71FC-49A7-AF88-5749CBAA8153}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1D30D96F-71FC-49A7-AF88-5749CBAA8153}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E4EDDFC0-0E25-48E1-A8AC-6ED091FC859F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E4EDDFC0-0E25-48E1-A8AC-6ED091FC859F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E4EDDFC0-0E25-48E1-A8AC-6ED091FC859F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E4EDDFC0-0E25-48E1-A8AC-6ED091FC859F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -262,6 +268,7 @@ Global
 		{4D0B561C-B957-4D02-861F-2E1968D6BC1F} = {9731051E-0AA7-411E-A76A-987854F034DA}
 		{DF5A3CCD-ECEA-49BC-871E-350CEAA7790A} = {9731051E-0AA7-411E-A76A-987854F034DA}
 		{1D30D96F-71FC-49A7-AF88-5749CBAA8153} = {9731051E-0AA7-411E-A76A-987854F034DA}
+		{E4EDDFC0-0E25-48E1-A8AC-6ED091FC859F} = {D04C5874-4D6A-493E-8CF4-6C7922198563}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {205B3EA4-470F-45DA-911E-346AF7D0A9A5}

--- a/Source/Blazorise/Extensions/ArrayExtensions.cs
+++ b/Source/Blazorise/Extensions/ArrayExtensions.cs
@@ -21,14 +21,10 @@ namespace Blazorise.Extensions
             if ( array1 == null && array2 == null )
                 return true;
 
-            if ( array1 != null && array2 != null && array1.Count() == array2.Count() )
-            {
-                return array1
-                    .Zip( array2, ( value1, value2 ) => value1.IsEqual( value2 ) )
-                    .All( result => result );
-            }
+            if ( ( array1 != null && array2 == null ) || ( array2 != null && array1 == null ) )
+                return false;
 
-            return false;
+            return array1.SequenceEqual( array2 );
         }
 
         /// <summary>

--- a/Tests/Blazorise.Benchmark/Blazorise.Benchmark.csproj
+++ b/Tests/Blazorise.Benchmark/Blazorise.Benchmark.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Source\Blazorise\Blazorise.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/Blazorise.Benchmark/Program.cs
+++ b/Tests/Blazorise.Benchmark/Program.cs
@@ -1,10 +1,11 @@
-﻿using System;
+﻿#region Using directives
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Security.Cryptography;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Running;
 using Blazorise.Extensions;
+#endregion
 
 namespace Blazorise.Benchmark
 {
@@ -13,7 +14,8 @@ namespace Blazorise.Benchmark
         static void Main( string[] args )
         {
             Console.WriteLine( "Hello World!" );
-            var summary = BenchmarkRunner.Run<SequenceEquals>();
+
+            _ = BenchmarkRunner.Run<SequenceEquals>();
         }
 
         public class SequenceEquals
@@ -26,6 +28,5 @@ namespace Blazorise.Benchmark
             [Benchmark]
             public bool ArraySequenceEqual() => simpleList1.AreEqual( simpleList2 );
         }
-
     }
 }

--- a/Tests/Blazorise.Benchmark/Program.cs
+++ b/Tests/Blazorise.Benchmark/Program.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Running;
+using Blazorise.Extensions;
+
+namespace Blazorise.Benchmark
+{
+    public class Program
+    {
+        static void Main( string[] args )
+        {
+            Console.WriteLine( "Hello World!" );
+            var summary = BenchmarkRunner.Run<SequenceEquals>();
+        }
+
+        public class SequenceEquals
+        {
+            private List<string> simpleList1 = new() { "A", "B", "C" };
+            private List<string> simpleList2 = new() { "A", "B", "C" };
+            [Benchmark]
+            public bool SequenceEqual() => simpleList1.SequenceEqual( simpleList2 );
+
+            [Benchmark]
+            public bool ArraySequenceEqual() => simpleList1.AreEqual( simpleList2 );
+        }
+
+    }
+}

--- a/Tests/Blazorise.Tests/Extensions/ArrayExtensions.cs
+++ b/Tests/Blazorise.Tests/Extensions/ArrayExtensions.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using Blazorise.Extensions;
+using Blazorise.Utilities;
+using Xunit;
+
+namespace Blazorise.Tests.Extensions
+{
+    public class ArrayExtensions
+    {
+        [Theory]
+        [InlineData( null, null )]
+        [InlineData( new[] { "A", "B", "C" }, new[] { "A", "B", "C" } )]
+        [InlineData( new[] { "1", "2", "3" }, new[] { "1", "2", "3" } )]
+        public void AreEqual_Returns_True( string[] list1, string[] list2 )
+        {
+            Assert.True( list1.AreEqual( list2 ) );
+        }
+
+        [Theory]
+        [InlineData( null, new[] { "data" } )]
+        [InlineData( new[] { "A", "B", "C" }, new[] { "C", "B", "A" } )]
+        [InlineData( new[] { "1", "2", "3" }, new[] { "1", "2", "3", "4" } )]
+        public void AreEqual_Returns_False( string[] list1, string[] list2 )
+        {
+            Assert.False( list1.AreEqual( list2 ) );
+        }
+
+    }
+}

--- a/Tests/Blazorise.Tests/Extensions/ArrayExtensions.cs
+++ b/Tests/Blazorise.Tests/Extensions/ArrayExtensions.cs
@@ -1,10 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.Serialization;
+﻿#region Using directives
 using Blazorise.Extensions;
-using Blazorise.Utilities;
 using Xunit;
+#endregion
 
 namespace Blazorise.Tests.Extensions
 {
@@ -27,6 +24,5 @@ namespace Blazorise.Tests.Extensions
         {
             Assert.False( list1.AreEqual( list2 ) );
         }
-
     }
 }


### PR DESCRIPTION
Added Benchmark project with 
https://benchmarkdotnet.org/articles/guides/getting-started.html
so we can easily do some simple benchmarking.

Since we walked about `SequenceEquals` vs the Blazorise `AreEqual`, I compared them.
**Results (Mean is what matters most as it's the metric you can look at for performance, in nanoseconds here):**
![image](https://user-images.githubusercontent.com/22283161/125207090-4d926e00-e282-11eb-87c2-22ec9f520ae5.png)

After doing some unit tests for `AreEqual`, I noticed `SequenceEquals` does not handle nulls.
Refactored `AreEqual` to handle the nulls and use `SequenceEquals` internally for the comparision behind the scenes.
**Results (Mean is what matters most as it's the metric you can look at for performance, in nanoseconds here):**
![image](https://user-images.githubusercontent.com/22283161/125207171-b37ef580-e282-11eb-86ce-548d855ef19e.png)

**Legend:**
![image](https://user-images.githubusercontent.com/22283161/125207213-f0e38300-e282-11eb-85e7-3eabbeae5cb0.png)

