### PR TITLE
Datagrid: BugFix : When data is null on init, set internal viewdata to empty list

### DIFF
--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -71,7 +71,7 @@ namespace Blazorise.DataGrid
         /// <summary>
         /// Marks the grid to refresh currently visible page.
         /// </summary>
-        private bool dirtyView;
+        private bool dirtyView = true;
 
         /// <summary>
         /// Keeps track whether the user has changed the filter for Virtualize purposes.

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -1375,7 +1375,7 @@ namespace Blazorise.DataGrid
 
                 dirtyView = false;
 
-                return viewData;
+                return viewData ?? Enumerable.Empty<TItem>();
             }
         }
 

--- a/docs/assets/css/main.scss
+++ b/docs/assets/css/main.scss
@@ -49,3 +49,21 @@ $base0f: #d33682;
 .page-wide {
   width: 100%;
 }
+
+.masthead__menu .visible-links .masthead__menu-item:first-child a {
+  display: inline-block;
+  margin-bottom: 0.25em;
+  padding: 0.5em 1em;
+  font-family: -apple-system, BlinkMacSystemFont, "Roboto", "Segoe UI", "Helvetica Neue", "Lucida Grande", Arial,
+    sans-serif;
+  font-size: 0.75em;
+  font-weight: bold;
+  text-align: center;
+  text-decoration: none;
+  border-width: 0;
+  border-radius: 4px;
+  cursor: pointer;
+
+  background-color: #5e72e4;
+  color: #fff;
+}


### PR DESCRIPTION
Closes #2658


Tested the grid's null start with main variants.
```
<DataGrid TItem="Animal"></DataGrid>
<DataGrid TItem="Animal" Virtualize="true"></DataGrid>
<DataGrid TItem="Animal" ReadData="@((x) => null)"></DataGrid>
<DataGrid TItem="Animal" Virtualize="true" ReadData="@((x) => null)"></DataGrid>
```