### PR TITLE
Datagrid: Revert "Dirty only when data changed"

### DIFF
--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -1314,11 +1314,7 @@ namespace Blazorise.DataGrid
             get { return data; }
             set
             {
-                if ( !value.AreEqual( data ) )
-                {
-                    SetDirty();
-                }
-
+                SetDirty();
                 data = value;
             }
         }


### PR DESCRIPTION
Unfortunately 
![image](https://user-images.githubusercontent.com/22283161/126393368-ae1aecda-5b2f-4a3f-8c6f-4984b93e14ed.png)
Causes a bug... since setter value and data will pretty much always be equal. We would need to keep a copy of the old data and compare... I'm not sure it would be worth it at all... we could still take a look in the future.

Fixes #2675