### PR TITLE
DataGrid : Internally have datagrid's child component's notify of a statechanged

### DIFF
--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -831,11 +831,12 @@ namespace Blazorise.DataGrid
         }
 
         /// <summary>
-        /// Notifies the <see cref="DataGrid{TItem}"/> that state has changed.
+        /// Tells the <see cref="DataGrid{TItem}"/> to refresh.
+        /// <para>Internally calls StateHasChanged.</para>
         /// </summary>
         /// <returns></returns>
-        protected internal new void  StateHasChanged()
-            =>  base.StateHasChanged();
+        public async Task Refresh()
+            => await InvokeAsync( StateHasChanged );
 
         protected async Task HandleReadData( CancellationToken cancellationToken )
         {

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -831,11 +831,10 @@ namespace Blazorise.DataGrid
         }
 
         /// <summary>
-        /// Tells the <see cref="DataGrid{TItem}"/> to refresh.
-        /// <para>Internally calls StateHasChanged.</para>
+        /// Notifies the <see cref="DataGrid{TItem}"/> to refresh.
         /// </summary>
         /// <returns></returns>
-        public async Task Refresh()
+        protected internal async virtual Task Refresh()
             => await InvokeAsync( StateHasChanged );
 
         protected async Task HandleReadData( CancellationToken cancellationToken )

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -830,6 +830,13 @@ namespace Blazorise.DataGrid
             }
         }
 
+        /// <summary>
+        /// Notifies the <see cref="DataGrid{TItem}"/> that state has changed.
+        /// </summary>
+        /// <returns></returns>
+        protected internal new void  StateHasChanged()
+            =>  base.StateHasChanged();
+
         protected async Task HandleReadData( CancellationToken cancellationToken )
         {
             try

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridRow.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridRow.razor.cs
@@ -95,6 +95,7 @@ namespace Blazorise.DataGrid
 
             await HandleMultiSelectClick( eventArgs );
             clickFromCheck = false;
+            await InvokeAsync( ParentDataGrid.StateHasChanged );
         }
 
         private async Task HandleMultiSelectClick( BLMouseEventArgs eventArgs )

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridRow.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridRow.razor.cs
@@ -95,7 +95,7 @@ namespace Blazorise.DataGrid
 
             await HandleMultiSelectClick( eventArgs );
             clickFromCheck = false;
-            await InvokeAsync( ParentDataGrid.StateHasChanged );
+            await ParentDataGrid.Refresh();
         }
 
         private async Task HandleMultiSelectClick( BLMouseEventArgs eventArgs )


### PR DESCRIPTION
Fixes #2676

Since Datagrid on 0.9.4 does not refresh every single time due to alot of internal parameter passage between components being removed. 

There should be a way for a child to notify the parent that there have been changes that may affect other children. 
(Like, in the case of this issue, recalculating the style of other rows, when a row is clicked/selected)