### PR TITLE
Make sure methods that mutate the Datagrid state call StateHasChanged.

### DIFF
--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -333,7 +333,7 @@ namespace Blazorise.DataGrid
 
             editState = DataGridEditState.New;
 
-            return Task.CompletedTask;
+            return InvokeAsync( StateHasChanged );
         }
 
         /// <summary>
@@ -379,6 +379,8 @@ namespace Blazorise.DataGrid
             {
                 await Paginate( ( CurrentPage - 1 ).ToString() );
             }
+
+            await InvokeAsync( StateHasChanged );
         }
 
         /// <summary>
@@ -429,17 +431,21 @@ namespace Blazorise.DataGrid
                 editState = DataGridEditState.None;
                 await VirtualizeOnEditCompleteScroll().AsTask();
             }
+
+            await InvokeAsync( StateHasChanged );
         }
 
         /// <summary>
         /// Cancels the editing of DataGrid item.
         /// </summary>
         /// <returns>A task that represents the asynchronous operation.</returns>
-        public Task Cancel()
+        public async Task Cancel()
         {
             editState = DataGridEditState.None;
 
-            return VirtualizeOnEditCompleteScroll().AsTask();
+            await VirtualizeOnEditCompleteScroll().AsTask();
+
+            await InvokeAsync( StateHasChanged );
         }
 
         /// <summary>
@@ -447,9 +453,11 @@ namespace Blazorise.DataGrid
         /// </summary>
         /// <param name="item">Item to select.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
-        public Task Select( TItem item )
+        public async Task Select( TItem item )
         {
-            return SelectRow( item );
+            await SelectRow( item );
+
+            await InvokeAsync( StateHasChanged );
         }
 
         /// <summary>
@@ -535,7 +543,7 @@ namespace Blazorise.DataGrid
                 }
             }
 
-            return Task.CompletedTask;
+            return InvokeAsync( StateHasChanged );
         }
 
         /// <summary>
@@ -562,6 +570,7 @@ namespace Blazorise.DataGrid
         public void FilterData()
         {
             FilterData( Data?.AsQueryable() );
+            StateHasChanged();
         }
 
         /// <summary>
@@ -580,6 +589,7 @@ namespace Blazorise.DataGrid
             {
                 cellEditContext.CellValue = value;
             }
+            StateHasChanged();
         }
 
         /// <summary>
@@ -684,6 +694,7 @@ namespace Blazorise.DataGrid
             }
 
             await SelectedRowsChanged.InvokeAsync( SelectedRows );
+            await InvokeAsync( StateHasChanged );
         }
 
         private async Task HandleShiftClick( MultiSelectEventArgs<TItem> eventArgs )
@@ -752,6 +763,7 @@ namespace Blazorise.DataGrid
             UnSelectAllRows = !selectAll;
 
             await SelectedRowsChanged.InvokeAsync( SelectedRows );
+            await InvokeAsync( StateHasChanged );
         }
 
         // this is to give user a way to stop save if necessary

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -570,7 +570,8 @@ namespace Blazorise.DataGrid
         public void FilterData()
         {
             FilterData( Data?.AsQueryable() );
-            StateHasChanged();
+
+            InvokeAsync( StateHasChanged );
         }
 
         /// <summary>
@@ -589,7 +590,8 @@ namespace Blazorise.DataGrid
             {
                 cellEditContext.CellValue = value;
             }
-            StateHasChanged();
+
+            InvokeAsync( StateHasChanged );
         }
 
         /// <summary>
@@ -694,6 +696,7 @@ namespace Blazorise.DataGrid
             }
 
             await SelectedRowsChanged.InvokeAsync( SelectedRows );
+
             await InvokeAsync( StateHasChanged );
         }
 
@@ -763,6 +766,7 @@ namespace Blazorise.DataGrid
             UnSelectAllRows = !selectAll;
 
             await SelectedRowsChanged.InvokeAsync( SelectedRows );
+
             await InvokeAsync( StateHasChanged );
         }
 

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridRow.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridRow.razor.cs
@@ -95,7 +95,6 @@ namespace Blazorise.DataGrid
 
             await HandleMultiSelectClick( eventArgs );
             clickFromCheck = false;
-            await ParentDataGrid.Refresh();
         }
 
         private async Task HandleMultiSelectClick( BLMouseEventArgs eventArgs )


### PR DESCRIPTION
Reason why we didn't catch this on testing, is because our datagrid demo has a lot of parameters and still calls StateHasChanged. I had a gut feeling we should call it when we were reworking the Datagrid's internal params... but it was working... O.O
So, to reproduce need a minimal Datagrid.

Closes #2722

Code from Dashboard, I had sitting here used to reproduce:
```
@page "/"
<Heading Size="HeadingSize.Is1" Margin="Margin.Is3.FromBottom">Blazorise</Heading>

    <Button Clicked="AddItem" Color="Color.Primary">Add Item</Button>

    <Heading>Blazorise DataGrid</Heading>
    <DataGrid TItem="Animal" Data="@forecasts" Editable="true" EditMode="DataGridEditMode.Popup" Responsive="true" PageSize="100" Sortable="true">
        <DataGridColumns>
            <DataGridCommandColumn TItem="Animal" />
            <DataGridColumn Editable="true" TItem="Animal" Field="@nameof(Animal.Date)" Caption="Date" />

        </DataGridColumns>
    </DataGrid>


}



<DataGrid TItem="Animal"></DataGrid>
<DataGrid TItem="Animal" Virtualize="true"></DataGrid>
<DataGrid TItem="Animal" ReadData="@((x) => null)"></DataGrid>
<DataGrid TItem="Animal" Virtualize="true" ReadData="@((x) => null)"></DataGrid>

<Paragraph>
    Blazorise is a component library built on top of Blazor and CSS frameworks like <Blazorise.Link To="https://getbootstrap.com/" Target="Target.Blank">Bootstrap</Blazorise.Link>, <Blazorise.Link To="https://bulma.io/" Target="Target.Blank">Bulma</Blazorise.Link>, <Blazorise.Link To="https://ant.design/" Target="Target.Blank">Ant Design</Blazorise.Link>, and <Blazorise.Link To="http://daemonite.github.io/material/" Target="Target.Blank">Material</Blazorise.Link>. It can be used to build responsive, single-page web applications.
</Paragraph>

<Alert Color="Color.Info" Visible="true">
    <Heading Size="HeadingSize.Is4" TextColor="TextColor.Success">
        Note:
    </Heading>
    <Paragraph>
        This is a demo application for Blazorise used to show basic example for most of the components and extensions.
    </Paragraph>
    <Paragraph>
        Full source code for this demo can be found on <Blazorise.Link To="https://github.com/Megabit/Blazorise/tree/master/Demos/Blazorise.Demo" Target="Target.Blank">GitHub</Blazorise.Link>.
    </Paragraph>
    <Paragraph>
        If you wish to learn more about Blazorise please go to the official <Blazorise.Link To="https://blazorise.com/docs/" Target="Target.Blank">documentation</Blazorise.Link>.
    </Paragraph>
</Alert>

<Paragraph>
    On the left sidebar you can see the Blazorise components and extensions in action.
</Paragraph>
<br />
<Paragraph>
    <Strong> Demo application for</Strong>: Blazorise @($"v{typeof( Blazorise.BaseComponent ).Assembly.GetName().Version.ToString( 3 )}")
</Paragraph>
@code {
    public class Animal
    {
        public DateTime Date { get; set; } }    


        private List<Animal> forecasts;


    private void AddItem()
        {
            forecasts ??= new();
        forecasts.Add(new Animal { Date = DateTime.Today } );
    }
}
```
