### PR TITLE
Selection Changed Bugfix

### DIFF
--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -207,7 +207,6 @@ namespace Blazorise.DataGrid
                 return;
             }
 
-            await HandleSelectionModeChanged();
             await HandleVirtualize();
 
             await base.OnAfterRenderAsync( firstRender );

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -225,27 +225,27 @@ namespace Blazorise.DataGrid
             }
         }
 
-        private Task HandleSelectionModeChanged()
+        private async Task HandleSelectionModeChanged()
         {
             if ( selectionMode == DataGridSelectionMode.Multiple && SelectedRow != null )
             {
                 SelectedRows ??= new();
 
-                if ( !SelectedRows.Contains( SelectedRow ) )
+                if ( !SelectedRows.Contains( SelectedRow ) && Data.Contains( SelectedRow ) )
                 {
                     SelectedRows.Add( SelectedRow );
 
-                    return SelectedRowsChanged.InvokeAsync( SelectedRows );
+                    await SelectedRowsChanged.InvokeAsync( SelectedRows );
                 }
             }
             else if ( selectionMode == DataGridSelectionMode.Single && SelectedRows != null )
             {
                 SelectedRows = null;
 
-                return SelectedRowsChanged.InvokeAsync( SelectedRows );
+                await SelectedRowsChanged.InvokeAsync( SelectedRows );
             }
 
-            return Task.CompletedTask;
+            await InvokeAsync( StateHasChanged );
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #2734 

- Made Selection Changed only be called on setter. No idea why it was calling on every OnAfterRender... Retested and everything okay.
- Fixed the bug found on #2734 | When SelectionModeChanged is triggered internally, and SelectionMode is Multiple and there's a SelectedRow, make sure the SelectedRow is in the Data collection before adding it to the SelectedRows collection.
