### PR TITLE
Remove instruction to include DataGrid CSS

### DIFF
--- a/docs/_docs/extensions/datagrid.md
+++ b/docs/_docs/extensions/datagrid.md
@@ -45,11 +45,9 @@ In your main _Imports.razor_ add:
 
 ### Static Files
 
-Include CSS link into your index.html or _Host.cshtml file, depending if you’re using a Blazor WebAssembly or Blazor Server side project.
+Include script file into your index.html or _Host.cshtml file, depending if you’re using a Blazor WebAssembly or Blazor Server side project.
 
 ```html
-<link href="_content/Blazorise.DataGrid/blazorise.datagrid.css" rel="stylesheet" />
-
 <script src="_content/Blazorise.DataGrid/blazorise.datagrid.js"></script>
 ```
 


### PR DESCRIPTION
The DataGrid CSS file was removed in commit a0363dcbb7c6cf61a9417c6e9a01ed4255df68a5. Including it in version 0.9.3.10 or higher will result in a 404 response.