### PR TITLE
DataGrid initializer fix

### DIFF
--- a/Demos/Blazorise.Demo/Pages/Tests/DataGridPage.razor
+++ b/Demos/Blazorise.Demo/Pages/Tests/DataGridPage.razor
@@ -226,7 +226,8 @@
                           PageChanged="(e) => currentPage = e.Page"
                           FilteredDataChanged="@OnFilteredDataChanged"
                           UseValidation="true"
-                          SortChanged="@OnSortChanged">
+                          SortChanged="@OnSortChanged"
+                          NewItemCreator="@OnEmployeeNewItemCreator">
                     <EmptyTemplate>
                         <Span>
                             <Icon Name="IconName.InfoCircle" TextColor="TextColor.Info" Margin="Margin.Is2.FromRight" />
@@ -289,7 +290,7 @@
                                 <TextEdit Placeholder="Search name" Text="@context.SearchValue?.ToString()" TextChanged="@(v=> context.TriggerFilterChange(v))" />
                             </FilterTemplate>
                         </DataGridColumn>
-                        <DataGridColumn TItem="Employee" Field="Test.Name" Caption="Last Name" Editable="true" ValidationPattern="[A-Za-z]{3}" />
+                        <DataGridColumn TItem="Employee" Field="Test.Salary.Description" Caption="Last Name" Editable="true" />
                         <DataGridColumn TItem="Employee" Field="@nameof( Employee.EMail )" Caption="Email" Editable="true" PopupFieldColumnSize="ColumnSize.IsFull.OnDesktop" />
                         <DataGridColumn TItem="Employee" Field="@nameof( Employee.City )" Caption="City" Editable="true">
                             <CaptionTemplate>

--- a/Demos/Blazorise.Demo/Pages/Tests/DataGridPage.razor
+++ b/Demos/Blazorise.Demo/Pages/Tests/DataGridPage.razor
@@ -226,8 +226,7 @@
                           PageChanged="(e) => currentPage = e.Page"
                           FilteredDataChanged="@OnFilteredDataChanged"
                           UseValidation="true"
-                          SortChanged="@OnSortChanged"
-                          NewItemCreator="@OnEmployeeNewItemCreator">
+                          SortChanged="@OnSortChanged">
                     <EmptyTemplate>
                         <Span>
                             <Icon Name="IconName.InfoCircle" TextColor="TextColor.Info" Margin="Margin.Is2.FromRight" />
@@ -290,7 +289,7 @@
                                 <TextEdit Placeholder="Search name" Text="@context.SearchValue?.ToString()" TextChanged="@(v=> context.TriggerFilterChange(v))" />
                             </FilterTemplate>
                         </DataGridColumn>
-                        <DataGridColumn TItem="Employee" Field="Test.Salary.Description" Caption="Last Name" Editable="true" />
+                        <DataGridColumn TItem="Employee" Field="@nameof( Employee.LastName )" Caption="Last Name" Editable="true" />
                         <DataGridColumn TItem="Employee" Field="@nameof( Employee.EMail )" Caption="Email" Editable="true" PopupFieldColumnSize="ColumnSize.IsFull.OnDesktop" />
                         <DataGridColumn TItem="Employee" Field="@nameof( Employee.City )" Caption="City" Editable="true">
                             <CaptionTemplate>

--- a/Demos/Blazorise.Demo/Pages/Tests/DataGridPage.razor
+++ b/Demos/Blazorise.Demo/Pages/Tests/DataGridPage.razor
@@ -289,7 +289,7 @@
                                 <TextEdit Placeholder="Search name" Text="@context.SearchValue?.ToString()" TextChanged="@(v=> context.TriggerFilterChange(v))" />
                             </FilterTemplate>
                         </DataGridColumn>
-                        <DataGridColumn TItem="Employee" Field="@nameof( Employee.LastName )" Caption="Last Name" Editable="true" ValidationPattern="[A-Za-z]{3}" />
+                        <DataGridColumn TItem="Employee" Field="Test.Name" Caption="Last Name" Editable="true" ValidationPattern="[A-Za-z]{3}" />
                         <DataGridColumn TItem="Employee" Field="@nameof( Employee.EMail )" Caption="Email" Editable="true" PopupFieldColumnSize="ColumnSize.IsFull.OnDesktop" />
                         <DataGridColumn TItem="Employee" Field="@nameof( Employee.City )" Caption="City" Editable="true">
                             <CaptionTemplate>

--- a/Demos/Blazorise.Demo/Pages/Tests/DataGridPage.razor.cs
+++ b/Demos/Blazorise.Demo/Pages/Tests/DataGridPage.razor.cs
@@ -45,6 +45,10 @@ namespace Blazorise.Demo.Pages.Tests
 
         public class MyTest
         {
+            public Salary Salary { get; set; }
+
+            [Required]
+            [MinLength(3)]
             public string Name { get; set; }
 
             public MyTest( string name )
@@ -62,6 +66,11 @@ namespace Blazorise.Demo.Pages.Tests
             }
 
             public DateTime Date { get; set; }
+
+            [Required]
+            [MinLength( 3 )]
+            public string Description { get; set; }
+
             public decimal Total { get; set; }
         }
 
@@ -153,7 +162,7 @@ namespace Blazorise.Demo.Pages.Tests
         {
             return new Employee
             {
-                Test = new MyTest( "" ),
+                Test = new MyTest( "" ) { Salary = new(DateTime.Now, 10)},
             };
         }
 

--- a/Demos/Blazorise.Demo/Pages/Tests/DataGridPage.razor.cs
+++ b/Demos/Blazorise.Demo/Pages/Tests/DataGridPage.razor.cs
@@ -39,22 +39,6 @@ namespace Blazorise.Demo.Pages.Tests
             public bool IsActive { get; set; }
 
             public List<Salary> Salaries { get; set; } = new();
-
-            public MyTest Test { get; set; }
-        }
-
-        public class MyTest
-        {
-            public Salary Salary { get; set; }
-
-            [Required]
-            [MinLength(3)]
-            public string Name { get; set; }
-
-            public MyTest( string name )
-            {
-                Name = name;
-            }
         }
 
         public class Salary
@@ -66,10 +50,6 @@ namespace Blazorise.Demo.Pages.Tests
             }
 
             public DateTime Date { get; set; }
-
-            [Required]
-            [MinLength( 3 )]
-            public string Description { get; set; }
 
             public decimal Total { get; set; }
         }
@@ -156,14 +136,6 @@ namespace Blazorise.Demo.Pages.Tests
             {
                 validationArgs.ErrorText = "First name has to be provided";
             }
-        }
-
-        Employee OnEmployeeNewItemCreator()
-        {
-            return new Employee
-            {
-                Test = new MyTest( "" ) { Salary = new(DateTime.Now, 10)},
-            };
         }
 
         void OnEmployeeNewItemDefaultSetter( Employee employee )

--- a/Demos/Blazorise.Demo/Pages/Tests/DataGridPage.razor.cs
+++ b/Demos/Blazorise.Demo/Pages/Tests/DataGridPage.razor.cs
@@ -39,10 +39,28 @@ namespace Blazorise.Demo.Pages.Tests
             public bool IsActive { get; set; }
 
             public List<Salary> Salaries { get; set; } = new();
+
+            public MyTest Test { get; set; }
+        }
+
+        public class MyTest
+        {
+            public string Name { get; set; }
+
+            public MyTest( string name )
+            {
+                Name = name;
+            }
         }
 
         public class Salary
         {
+            public Salary( DateTime date, decimal total )
+            {
+                Date = date;
+                Total = total;
+            }
+
             public DateTime Date { get; set; }
             public decimal Total { get; set; }
         }
@@ -129,6 +147,14 @@ namespace Blazorise.Demo.Pages.Tests
             {
                 validationArgs.ErrorText = "First name has to be provided";
             }
+        }
+
+        Employee OnEmployeeNewItemCreator()
+        {
+            return new Employee
+            {
+                Test = new MyTest( "" ),
+            };
         }
 
         void OnEmployeeNewItemDefaultSetter( Employee employee )

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -633,7 +633,9 @@ namespace Blazorise.DataGrid
             editItem = item;
             editItemCellValues = new();
 
-            validationItem = RecursiveObjectActivator.CreateInstance<TItem>();
+            validationItem = UseValidation
+                ? RecursiveObjectActivator.CreateInstance<TItem>()
+                : default;
 
             foreach ( var column in EditableColumns )
             {
@@ -642,7 +644,8 @@ namespace Blazorise.DataGrid
                     CellValue = column.GetValue( editItem ),
                 } );
 
-                column.SetValue( validationItem, editItemCellValues[column.ElementId].CellValue );
+                if ( validationItem != null )
+                    column.SetValue( validationItem, editItemCellValues[column.ElementId].CellValue );
             }
         }
 

--- a/Source/Extensions/Blazorise.DataGrid/Utils/FunctionCompiler.cs
+++ b/Source/Extensions/Blazorise.DataGrid/Utils/FunctionCompiler.cs
@@ -169,13 +169,15 @@ namespace Blazorise.DataGrid.Utils
             var parameter = Expression.Parameter( typeof( TItem ), "item" );
             var property = GetPropertyOrField( parameter, fieldName );
             var path = fieldName.Split( '.' );
+
             Func<TItem, object> instanceGetter;
+
             if ( path.Length <= 1 )
                 instanceGetter = ( item ) => item;
             else
                 instanceGetter = CreateValueGetter<TItem>( string.Join( '.', path.Take( path.Length - 1 ) ) );
 
-            var convertExpression = Expression.MakeMemberAccess( Expression.Constant( instanceGetter( item) ), property.Member );
+            var convertExpression = Expression.MakeMemberAccess( Expression.Constant( instanceGetter( item ) ), property.Member );
 
             return Expression.Lambda<Func<TValue>>( convertExpression );
         }

--- a/Source/Extensions/Blazorise.DataGrid/Utils/FunctionCompiler.cs
+++ b/Source/Extensions/Blazorise.DataGrid/Utils/FunctionCompiler.cs
@@ -1,6 +1,7 @@
 ﻿#region Using directives
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using Microsoft.AspNetCore.Components.Forms;
@@ -167,8 +168,14 @@ namespace Blazorise.DataGrid.Utils
         {
             var parameter = Expression.Parameter( typeof( TItem ), "item" );
             var property = GetPropertyOrField( parameter, fieldName );
+            var path = fieldName.Split( '.' );
+            Func<TItem, object> instanceGetter;
+            if ( path.Length <= 1 )
+                instanceGetter = ( item ) => item;
+            else
+                instanceGetter = CreateValueGetter<TItem>( string.Join( '.', path.Take( path.Length - 1 ) ) );
 
-            var convertExpression = Expression.MakeMemberAccess( Expression.Constant( item ), property.Member );
+            var convertExpression = Expression.MakeMemberAccess( Expression.Constant( instanceGetter( item) ), property.Member );
 
             return Expression.Lambda<Func<TValue>>( convertExpression );
         }

--- a/Source/Extensions/Blazorise.DataGrid/Utils/RecursiveObjectActivator.cs
+++ b/Source/Extensions/Blazorise.DataGrid/Utils/RecursiveObjectActivator.cs
@@ -1,6 +1,7 @@
 ﻿#region Using directives
 using System;
 using System.Reflection;
+using System.Runtime.Serialization;
 #endregion
 
 namespace Blazorise.DataGrid.Utils
@@ -28,7 +29,7 @@ namespace Blazorise.DataGrid.Utils
         public static TItem CreateInstance<TItem>()
         {
             var objType = typeof( TItem );
-            var obj = Activator.CreateInstance<TItem>();
+            var obj = (TItem)FormatterServices.GetUninitializedObject( typeof( TItem ) );
             var properties = objType.GetProperties( BindingFlags.Public | BindingFlags.Instance );
             CreateInstanceRecursive( obj, properties, (null, objType) );
 
@@ -56,7 +57,7 @@ namespace Blazorise.DataGrid.Utils
                     var instanced = property.GetValue( currObjInstance );
                     if ( instanced is null )
                     {
-                        instanced = Activator.CreateInstance( currType );
+                        instanced = FormatterServices.GetUninitializedObject( currType );
                         property.SetValue( currObjInstance, instanced );
                     }
                     if ( typeTracker.parentType == currType || typeTracker.previousParentType == currType )

--- a/Source/Extensions/Blazorise.DataGrid/Utils/RecursiveObjectActivator.cs
+++ b/Source/Extensions/Blazorise.DataGrid/Utils/RecursiveObjectActivator.cs
@@ -29,7 +29,7 @@ namespace Blazorise.DataGrid.Utils
         public static TItem CreateInstance<TItem>()
         {
             var objType = typeof( TItem );
-            var obj = (TItem)FormatterServices.GetUninitializedObject( typeof( TItem ) );
+            var obj = (TItem)FormatterServices.GetUninitializedObject( objType );
             var properties = objType.GetProperties( BindingFlags.Public | BindingFlags.Instance );
             CreateInstanceRecursive( obj, properties, (null, objType) );
 

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridCellEdit.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridCellEdit.razor.cs
@@ -22,7 +22,8 @@ namespace Blazorise.DataGrid
         {
             CellEditContext.CellValue = value;
 
-            Column.SetValue( ValidationItem, value );
+            if ( ValidationItem != null )
+                Column.SetValue( ValidationItem, value );
 
             return CellValueChanged.InvokeAsync( value );
         }

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridCellEditValidation.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridCellEditValidation.razor.cs
@@ -48,7 +48,7 @@ namespace Blazorise.DataGrid
         protected override Task OnInitializedAsync()
         {
             if ( ValueType == typeof( string ) )
-                stringExpression = FunctionCompiler.CreateValidationExpressionGetter<TItem, string>( ValidationItem, Column.Field );
+                stringExpression = FunctionCompiler.CreateValidationExpressionGetter<TItem, string>( ValidationItem, Field );
             else if ( ValueType == typeof( decimal ) )
                 decimalExpression = FunctionCompiler.CreateValidationExpressionGetter<TItem, decimal>( ValidationItem, Field );
             else if ( ValueType == typeof( decimal? ) )


### PR DESCRIPTION
fixes #2785 

In this PR I have used `FormatterServices.GetUninitializedObject` instead of `Activator.CreateInstance`. The reason is that FormatterServices creates an empty object without the need for any parameterless constructor. And an empty object is what we want to have.

Source: https://stackoverflow.com/questions/390578/creating-instance-of-type-without-default-constructor-in-c-sharp-using-reflectio

Note: Test data in the demo should be removed once we make it work!

@David-Moreira Now the problem is in `FunctionCompiler.CreateValidationExpressionGetter`. When an access field is null it cannot generate member access. Can you also have a look?