### PR TITLE
DataGrid : Show Validation Errors | Same Logic on Popup / Form / Edit

### DIFF
--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -1328,7 +1328,7 @@ namespace Blazorise.DataGrid
         }
 
         /// <summary>
-        /// Gets if <see cref="ShowValidationsSummary"/> is true, and there are validation error messages <seealso cref="ValidationsSummaryErrors"/>.
+        /// Gets true if <see cref="ShowValidationsSummary"/> is enabled, and there are validation error messages <seealso cref="ValidationsSummaryErrors"/>.
         /// </summary>
         internal bool HasValidationsSummary => ShowValidationsSummary && ValidationsSummaryErrors?.Length > 0;
 

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -1328,6 +1328,11 @@ namespace Blazorise.DataGrid
         }
 
         /// <summary>
+        /// Gets if <see cref="ShowValidationsSummary"/> is true, and there are validation error messages <seealso cref="ValidationsSummaryErrors"/>.
+        /// </summary>
+        internal bool HasValidationsSummary => ShowValidationsSummary && ValidationsSummaryErrors?.Length > 0;
+
+        /// <summary>
         /// Gets or sets the datagrid data-source.
         /// </summary>
         [Parameter]

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridModal.razor
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridModal.razor
@@ -23,7 +23,9 @@
             <Validations @ref="validations" Mode="ValidationMode.Manual" StatusChanged="@ValidationsStatusChanged" Model="@ValidationItem">
                 @if ( ParentDataGrid.ShowValidationsSummary )
                 {
-                    <ValidationSummary Label="@ParentDataGrid.ValidationsSummaryLabel" Errors="@ParentDataGrid.ValidationsSummaryErrors" />
+                    <Field Display="@(ParentDataGrid.HasValidationsSummary || isInvalid ? Display.Always : Display.None)">
+                        <ValidationSummary Label="@ParentDataGrid.ValidationsSummaryLabel" Errors="@ParentDataGrid.ValidationsSummaryErrors" />
+                    </Field>
                 }
                 <Fields>
                     @foreach ( var column in OrderedEditableColumns )

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridModal.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridModal.razor.cs
@@ -19,6 +19,8 @@ namespace Blazorise.DataGrid
 
         protected bool popupVisible;
 
+        protected bool isInvalid;
+
         protected EventCallback Cancel
             => EventCallback.Factory.Create( this, ParentDataGrid.Cancel );
 
@@ -45,6 +47,8 @@ namespace Blazorise.DataGrid
 
         protected void ValidationsStatusChanged( ValidationsStatusChangedEventArgs args )
         {
+            isInvalid = args.Status == ValidationStatus.Error;
+
             InvokeAsync( StateHasChanged );
         }
 

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridRowEdit.razor
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridRowEdit.razor
@@ -7,7 +7,7 @@
             <TableRowCell ColumnSpan="@(Columns.Count() + 1)">
                 @if ( ParentDataGrid.ShowValidationsSummary )
                 {
-                    <Row>
+                    <Row Display="@(ParentDataGrid.HasValidationsSummary || isInvalid ? Display.Always : Display.None)">
                         <ValidationSummary Label="@ParentDataGrid.ValidationsSummaryLabel" Errors="@ParentDataGrid.ValidationsSummaryErrors" />
                     </Row>
                 }
@@ -78,8 +78,8 @@ else if ( EditMode == DataGridEditMode.Inline )
     <Validations @ref="validations" Mode="ValidationMode.Manual" StatusChanged="@ValidationsStatusChanged" Model="@ValidationItem">
         @if ( ParentDataGrid.ShowValidationsSummary )
         {
-            <TableRow Display="@(isInvalid ? Display.TableRow : Display.None)">
-                <TableRowCell ColumnSpan="@Columns.Count()" Display="@(isInvalid ? Display.TableCell : Display.None)">
+            <TableRow Display="@(ParentDataGrid.HasValidationsSummary || isInvalid ? Display.TableRow : Display.None)">
+                <TableRowCell ColumnSpan="@Columns.Count()">
                     <ValidationSummary Label="@ParentDataGrid.ValidationsSummaryLabel" Errors="@ParentDataGrid.ValidationsSummaryErrors" />
                 </TableRowCell>
             </TableRow>


### PR DESCRIPTION
Closes #2777

Like we've talked, the Popup / Form / Edit do not have the exact same logic to display the validation error messages.
We've decided to give freedom to the developer, meaning that even if the Validation status isn't invalid, but there are error messages, they will display across all modes. This allows for the developer to set error messages at different stages.

Once ShowValidationsSummary is set to true, we keep the ValidationSummary hidden, because it has to run the constructor and listen to the Validator changes (`validationsStatusChangedEventHandler`). 

The **flag** to display the Validation Errors Summary is either:
- Validator has invalid validation status (which means there may be validator error messages) or
- there are error messages set at DataGrid level.