### PR TITLE
Fixes Dirty Filter not being reset upon null data use case

### DIFF
--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -978,6 +978,8 @@ namespace Blazorise.DataGrid
 
         private void FilterData( IQueryable<TItem> query )
         {
+            dirtyFilter = false;
+
             if ( query == null )
             {
                 filteredData.Clear();
@@ -1048,8 +1050,6 @@ namespace Blazorise.DataGrid
             }
 
             filteredData = query.ToList();
-
-            dirtyFilter = false;
 
             FilteredDataChanged?.Invoke( new(
                 filteredData,


### PR DESCRIPTION
Fixes #2800 

When data provided is null + Dirty Filter being set(Pager calls TotalItems Getter) + statehaschanged call on the Filtering method caused infinite loop.

Fixed Dirty Filter to be reset also when the data is null.

Code used to reproduce bug & test:
```
    <DataGrid ElementId="ColoniesGrid-DataGrid-0" TItem="Employee" Data="@colonies" Striped="true" Bordered="true" Editable="true"ShowPager="true" Narrow="true" Resizable="true" ResizeMode="TableResizeMode.Columns"  RowSelectable="@(v => false)">

        <DataGridColumn ElementId="ColoniesGrid-DataGridColumn-0" TItem="Employee" Field="FirstName" Caption="FirstName" />
    </DataGrid>

    @code {
                public class Employee
        {
            public int Id { get; set; }

            public string FirstName { get; set; }

        }

        private IEnumerable<Employee> colonies;
    }
```