### PR TITLE
DataGrid : MultiSelect Fix Click being called twice.

### DIFF
--- a/Source/Extensions/Blazorise.DataGrid/_DataGridRowMultiSelect.razor
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridRowMultiSelect.razor
@@ -1,6 +1,6 @@
 ﻿@typeparam TItem
 @inherits _BaseDataGridRowMultiSelect<TItem>
-<TableRowCell Class="@(Column.CellClass?.Invoke(Item))" Style="@BuildCellStyle()" TextAlignment="@Column.TextAlignment" VerticalAlignment="@Column.VerticalAlignment">
+<TableRowCell @onclick:preventDefault Class="@(Column.CellClass?.Invoke(Item))" Style="@BuildCellStyle()" TextAlignment="@Column.TextAlignment" VerticalAlignment="@Column.VerticalAlignment">
     @if ( ParentDataGrid.MultiSelectColumn?.MultiSelectTemplate != null )
     {
         <Label @onclick="@OnCheckedClicked">


### PR DESCRIPTION
Fixes #2860

Click was actually being called twice on row.
On chrome it would call once with Detail = 1 that is handled as a single click.
The second one would be called with Detail = 0, which would have no effect.

On firefox both were called as Detail = 1 that would provoke a state reset.
Added a preventDefault to the outter container preventing a two clicks trigger.