### PR TITLE
Notification location and refactoring

### DIFF
--- a/Source/Blazorise.AntDesign/Styles/_extensions.scss
+++ b/Source/Blazorise.AntDesign/Styles/_extensions.scss
@@ -1,3 +1,7 @@
-﻿.snackbar {
+﻿.snackbar-stack {
+    z-index: 1009 !important;
+}
+
+.snackbar {
     z-index: 1010 !important;
 }

--- a/Source/Blazorise.AntDesign/wwwroot/blazorise.antdesign.css
+++ b/Source/Blazorise.AntDesign/wwwroot/blazorise.antdesign.css
@@ -1196,6 +1196,9 @@
     max-height: var(--autocomplete-menu-max-height, 200px);
     overflow-y: scroll; }
 
+.snackbar-stack {
+    z-index: 1009 !important; }
+
 .snackbar {
     z-index: 1010 !important; }
 

--- a/Source/Blazorise.Bootstrap/Styles/_extensions.scss
+++ b/Source/Blazorise.Bootstrap/Styles/_extensions.scss
@@ -1,3 +1,7 @@
-﻿.snackbar {
+﻿.snackbar-stack {
+    z-index: 1059 !important;
+}
+
+.snackbar {
     z-index: 1060 !important;
 }

--- a/Source/Blazorise.Bootstrap/wwwroot/blazorise.bootstrap.css
+++ b/Source/Blazorise.Bootstrap/wwwroot/blazorise.bootstrap.css
@@ -98,6 +98,9 @@
     max-height: var(--autocomplete-menu-max-height, 200px);
     overflow-y: scroll; }
 
+.snackbar-stack {
+    z-index: 1059 !important; }
+
 .snackbar {
     z-index: 1060 !important; }
 

--- a/Source/Blazorise.Material/Styles/_extensions.scss
+++ b/Source/Blazorise.Material/Styles/_extensions.scss
@@ -1,3 +1,7 @@
-﻿.snackbar {
+﻿.snackbar-stack {
+    z-index: 1059 !important;
+}
+
+.snackbar {
     z-index: 1060 !important;
 }

--- a/Source/Blazorise.Material/wwwroot/blazorise.material.css
+++ b/Source/Blazorise.Material/wwwroot/blazorise.material.css
@@ -75,6 +75,9 @@
 .b-is-autocomplete .dropdown-menu:before {
     box-shadow: none; }
 
+.snackbar-stack {
+    z-index: 1059 !important; }
+
 .snackbar {
     z-index: 1060 !important; }
 

--- a/Source/Blazorise/Enums/NotificationLocation.cs
+++ b/Source/Blazorise/Enums/NotificationLocation.cs
@@ -1,0 +1,23 @@
+﻿namespace Blazorise
+{
+    /// <summary>
+    /// Defines the notification location.
+    /// </summary>
+    public enum NotificationLocation
+    {
+        /// <summary>
+        /// Default behavior, shows the notification on the center.
+        /// </summary>
+        Center,
+
+        /// <summary>
+        /// Show the notification on the left side of the screen.
+        /// </summary>
+        Left,
+
+        /// <summary>
+        /// Show the notification on the right side of the screen.
+        /// </summary>
+        Right,
+    }
+}

--- a/Source/Blazorise/EventArguments/NotificationEventArgs.cs
+++ b/Source/Blazorise/EventArguments/NotificationEventArgs.cs
@@ -40,7 +40,7 @@ namespace Blazorise
         /// <summary>
         /// Gets the notification type.
         /// </summary>
-        public NotificationType NotificationType { get; set; }
+        public NotificationType NotificationType { get; }
 
         /// <summary>
         /// Gets the notification description.

--- a/Source/Blazorise/Models/NotificationOptions.cs
+++ b/Source/Blazorise/Models/NotificationOptions.cs
@@ -22,11 +22,17 @@
         public static NotificationOptions Default => new()
         {
             OkButtonIcon = "OK",
+            Multiline = true,
         };
 
         /// <summary>
         /// Delay in milliseconds to wait before closing.
         /// </summary>
         public double? IntervalBeforeClose { get; set; }
+
+        /// <summary>
+        /// Defines if the notification will contain multiple lines.
+        /// </summary>
+        public bool Multiline { get; set; }
     }
 }

--- a/Source/Extensions/Blazorise.Components/NotificationAlert.razor
+++ b/Source/Extensions/Blazorise.Components/NotificationAlert.razor
@@ -1,9 +1,8 @@
 ﻿@namespace Blazorise.Components
 @inherits BaseComponent
 <SnackbarStack @ref="SnackbarStack"
-               Location="SnackbarStackLocation.Right"
-               Multiline="true"
                DelayCloseOnClick="true"
                DefaultInterval=@(DefaultInterval ?? Constants.DefaultIntervalBeforeClose)
                DelayCloseOnClickInterval="@Constants.DefaultOnClickIntervalBeforeClose"
-               Closed="@OnSnackbarClosed" />
+               Closed="@OnSnackbarClosed"
+               Location="@GetSnackbarStackLocation(Location)" />

--- a/Source/Extensions/Blazorise.Components/NotificationAlert.razor.cs
+++ b/Source/Extensions/Blazorise.Components/NotificationAlert.razor.cs
@@ -38,17 +38,13 @@ namespace Blazorise.Components
 
         private async void OnNotificationReceived( object sender, NotificationEventArgs e )
         {
-            NotificationType = e.NotificationType;
-            Message = e.Message;
-            Title = e.Title;
-            Options = e.Options;
+            var okButtonText = e?.Options?.OkButtonText ?? "OK";
 
-            var okButtonText = Options?.OkButtonText ?? "OK";
-
-            await SnackbarStack.PushAsync( Message, Title, GetSnackbarColor( e.NotificationType ), ( options ) =>
+            await SnackbarStack.PushAsync( e.Message, e.Title, GetSnackbarColor( e.NotificationType ), ( options ) =>
             {
                 options.CloseButtonIcon = IconName.Times;
                 options.ActionButtonText = okButtonText;
+                options.Multiline = e.Options.Multiline;
 
                 if ( e.Options.IntervalBeforeClose > 0 )
                 {
@@ -84,6 +80,19 @@ namespace Blazorise.Components
             };
         }
 
+        /// <summary>
+        /// Gets the snackbar location based on the predefined notification location.
+        /// </summary>
+        protected virtual SnackbarStackLocation GetSnackbarStackLocation( NotificationLocation notificationLocation )
+        {
+            return notificationLocation switch
+            {
+                NotificationLocation.Left => SnackbarStackLocation.Left,
+                NotificationLocation.Right => SnackbarStackLocation.Right,
+                _ => SnackbarStackLocation.Center,
+            };
+        }
+
         #endregion
 
         #region Properties
@@ -99,29 +108,14 @@ namespace Blazorise.Components
         [Inject] protected INotificationService NotificationService { get; set; }
 
         /// <summary>
-        /// Gets or sets the notification type.
+        /// Gets or sets the notification location.
         /// </summary>
-        [Parameter] public NotificationType NotificationType { get; set; }
-
-        /// <summary>
-        /// Gets or sets the message content.
-        /// </summary>
-        [Parameter] public MarkupString Message { get; set; }
-
-        /// <summary>
-        /// Gets or sets the message title.
-        /// </summary>
-        [Parameter] public string Title { get; set; }
+        [Parameter] public NotificationLocation Location { get; set; } = NotificationLocation.Center;
 
         /// <summary>
         /// Defines the default interval (in milliseconds) after which the notification alert will be automatically closed (used if IntervalBeforeClose is not set on PushAsync call).
         /// </summary>
         [Parameter] public double? DefaultInterval { get; set; }
-
-        /// <summary>
-        /// Gets or sets the custom message options.
-        /// </summary>
-        [Parameter] public NotificationOptions Options { get; set; }
 
         /// <summary>
         /// Occurs after the user has responded with an OK action.

--- a/Source/Extensions/Blazorise.Snackbar/SnackbarOptions.cs
+++ b/Source/Extensions/Blazorise.Snackbar/SnackbarOptions.cs
@@ -53,5 +53,10 @@ namespace Blazorise.Snackbar
         /// Time in millisecond until snackbar is automatically closed.
         /// </summary>
         public double? IntervalBeforeClose { get; set; }
+
+        /// <summary>
+        /// Defines if the snackbar will contain multiple lines.
+        /// </summary>
+        public bool Multiline { get; set; }
     }
 }

--- a/Source/Extensions/Blazorise.Snackbar/SnackbarStack.razor
+++ b/Source/Extensions/Blazorise.Snackbar/SnackbarStack.razor
@@ -7,7 +7,7 @@
                   Key="@snackbarInfo.Key"
                   Visible="@snackbarInfo.Visible"
                   Color="@snackbarInfo.Color"
-                  Multiline="@Multiline"
+                  Multiline="@snackbarInfo.Multiline"
                   Interval="@(snackbarInfo.IntervalBeforeClose ?? Constants.DefaultIntervalBeforeClose)"
                   DelayCloseOnClick="@DelayCloseOnClick"
                   DelayCloseOnClickInterval="@DelayCloseOnClickInterval"

--- a/Source/Extensions/Blazorise.Snackbar/SnackbarStack.razor.cs
+++ b/Source/Extensions/Blazorise.Snackbar/SnackbarStack.razor.cs
@@ -27,7 +27,8 @@ namespace Blazorise.Snackbar
                 bool showActionButton,
                 string actionButtonText,
                 object actionButtonIcon,
-                double? intervalBeforeClose )
+                double? intervalBeforeClose,
+                bool multiline )
             {
                 Message = message;
                 Title = title;
@@ -41,6 +42,7 @@ namespace Blazorise.Snackbar
                 ActionButtonText = actionButtonText;
                 ActionButtonIcon = actionButtonIcon;
                 IntervalBeforeClose = intervalBeforeClose;
+                Multiline = multiline;
             }
 
             public MarkupString Message { get; }
@@ -68,6 +70,8 @@ namespace Blazorise.Snackbar
             public double? IntervalBeforeClose { get; }
 
             public bool Visible { get; } = true;
+
+            public bool Multiline { get; } = true;
         }
 
         private SnackbarStackLocation location = SnackbarStackLocation.Center;
@@ -145,7 +149,8 @@ namespace Blazorise.Snackbar
                 snackbarOptions.ShowActionButton,
                 snackbarOptions.ActionButtonText,
                 snackbarOptions.ActionButtonIcon,
-                snackbarOptions.IntervalBeforeClose ) );
+                snackbarOptions.IntervalBeforeClose,
+                snackbarOptions.Multiline ) );
 
             return InvokeAsync( StateHasChanged );
         }


### PR DESCRIPTION
resolves #2830 Notification service Location missing

With this PR the new `Location` parameter is added on the `NotificationAlert` component. The reason why on `NotificationAlert` and not on the `options` for each individual message is that everything is built around the SnackbarStack. And SnackbarStack can be only one at a time. So the location must be defined for the `NotificationAlert` and in turn for `SnackbarStack`.

I have also removed NotificationType, Message, and Title from NotificationAlert because they were not needed on the `global` level.

---

**Usage**

```cshtml
<NotificationAlert Location="NotificationLocation.Right" />
```