### PR TITLE
Anchor component that inherits from Link

### DIFF
--- a/Demos/Blazorise.Demo/Pages/Dashboard.razor
+++ b/Demos/Blazorise.Demo/Pages/Dashboard.razor
@@ -2,7 +2,7 @@
 <Heading Size="HeadingSize.Is1" Margin="Margin.Is3.FromBottom">Blazorise</Heading>
 
 <Paragraph>
-    Blazorise is a component library built on top of Blazor and CSS frameworks like <Blazorise.Link To="https://getbootstrap.com/" Target="Target.Blank">Bootstrap</Blazorise.Link>, <Blazorise.Link To="https://bulma.io/" Target="Target.Blank">Bulma</Blazorise.Link>, <Blazorise.Link To="https://ant.design/" Target="Target.Blank">Ant Design</Blazorise.Link>, and <Blazorise.Link To="http://daemonite.github.io/material/" Target="Target.Blank">Material</Blazorise.Link>. It can be used to build responsive, single-page web applications.
+    Blazorise is a component library built on top of Blazor and CSS frameworks like <Anchor To="https://getbootstrap.com/" Target="Target.Blank">Bootstrap</Anchor>, <Anchor To="https://bulma.io/" Target="Target.Blank">Bulma</Anchor>, <Anchor To="https://ant.design/" Target="Target.Blank">Ant Design</Anchor>, and <Anchor To="http://daemonite.github.io/material/" Target="Target.Blank">Material</Anchor>. It can be used to build responsive, single-page web applications.
 </Paragraph>
 
 <Alert Color="Color.Info" Visible="true">
@@ -13,10 +13,10 @@
         This is a demo application for Blazorise used to show basic example for most of the components and extensions.
     </Paragraph>
     <Paragraph>
-        Full source code for this demo can be found on <Blazorise.Link To="https://github.com/Megabit/Blazorise/tree/master/Demos/Blazorise.Demo" Target="Target.Blank">GitHub</Blazorise.Link>.
+        Full source code for this demo can be found on <Anchor To="https://github.com/Megabit/Blazorise/tree/master/Demos/Blazorise.Demo" Target="Target.Blank">GitHub</Anchor>.
     </Paragraph>
     <Paragraph>
-        If you wish to learn more about Blazorise please go to the official <Blazorise.Link To="https://blazorise.com/docs/" Target="Target.Blank">documentation</Blazorise.Link>.
+        If you wish to learn more about Blazorise please go to the official <Anchor To="https://blazorise.com/docs/" Target="Target.Blank">documentation</Anchor>.
     </Paragraph>
 </Alert>
 

--- a/Demos/Blazorise.Demo/Pages/Tests/RichTextEditPage.razor
+++ b/Demos/Blazorise.Demo/Pages/Tests/RichTextEditPage.razor
@@ -4,7 +4,7 @@
     <Column>
         <Card Margin="Margin.Is4.OnY">
             <CardHeader>
-                <CardTitle>Rich Text Editor (based on <Blazorise.Link To="https://quilljs.com/">QuillJs</Blazorise.Link>)</CardTitle>
+                <CardTitle>Rich Text Editor (based on <Anchor To="https://quilljs.com/">QuillJs</Anchor>)</CardTitle>
             </CardHeader>
             <CardBody>
                 <CardBody>

--- a/Demos/Blazorise.Demo/Pages/Tests/VerticalAlignPage.razor
+++ b/Demos/Blazorise.Demo/Pages/Tests/VerticalAlignPage.razor
@@ -8,7 +8,7 @@
             </CardHeader>
             <CardBody Padding="Padding.Is0.FromBottom">
                 <Paragraph>
-                    Easily change the <Blazorise.Link To="https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align" Target="Target.Blank">vertical alignment</Blazorise.Link> of inline, inline-block, inline-table, and table cell elements.
+                    Easily change the <Anchor To="https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align" Target="Target.Blank">vertical alignment</Anchor> of inline, inline-block, inline-table, and table cell elements.
                 </Paragraph>
                 <Paragraph>
                     Change the alignment of elements with the vertical-alignment utilities. Please note that vertical-align only affects inline, inline-block, inline-table, and table cell elements.

--- a/Source/Blazorise.AntDesign/BarDropdownItem.razor
+++ b/Source/Blazorise.AntDesign/BarDropdownItem.razor
@@ -1,6 +1,6 @@
 ﻿@inherits Blazorise.BarDropdownItem
 <li id="@ElementId" class="@ClassNames" role="menuitem" @attributes="@Attributes">
-    <Blazorise.Link Style="@StyleNames" To="@To" Target="@Target" Title="@Title" Match="@Match" Clicked="@ClickHandler" Attributes="@Attributes">
+    <Anchor Style="@StyleNames" To="@To" Target="@Target" Title="@Title" Match="@Match" Clicked="@ClickHandler" Attributes="@Attributes">
         @ChildContent
-    </Blazorise.Link>
+    </Anchor>
 </li>

--- a/Source/Blazorise.AntDesign/BarLink.razor
+++ b/Source/Blazorise.AntDesign/BarLink.razor
@@ -1,4 +1,4 @@
 ﻿@inherits Blazorise.BarLink
-<Blazorise.Link ElementId="@ElementId" Class="@ClassNames" Style="@StyleNames" To="@To" Clicked="@ClickHandler" Target="@Target" Title="@Title" Match="@Match" Attributes="@Attributes">
+<Anchor ElementId="@ElementId" Class="@ClassNames" Style="@StyleNames" To="@To" Clicked="@ClickHandler" Target="@Target" Title="@Title" Match="@Match" Attributes="@Attributes">
     <span>@ChildContent</span>
-</Blazorise.Link>
+</Anchor>

--- a/Source/Blazorise.AntDesign/BreadcrumbLink.razor
+++ b/Source/Blazorise.AntDesign/BreadcrumbLink.razor
@@ -6,9 +6,9 @@
     }
     else
     {
-        <Blazorise.Link ElementId="@ElementId" Class="@ClassNames" Style="@StyleNames" To="@To" Target="@Target" Title="@Title" Match="@Match" Clicked="@ClickHandler" Attributes="@Attributes">
+        <Anchor ElementId="@ElementId" Class="@ClassNames" Style="@StyleNames" To="@To" Target="@Target" Title="@Title" Match="@Match" Clicked="@ClickHandler" Attributes="@Attributes">
             @ChildContent
-        </Blazorise.Link>
+        </Anchor>
     }
 </span>
 <span class="ant-breadcrumb-separator">/</span>

--- a/Source/Blazorise.Bulma/BreadcrumbLink.razor
+++ b/Source/Blazorise.Bulma/BreadcrumbLink.razor
@@ -1,4 +1,4 @@
 ﻿@inherits Blazorise.BreadcrumbLink
-<Blazorise.Link ElementId="@ElementId" Class="@ClassNames" Style="@StyleNames" To="@To" Target="@Target" Title="@Title" Match="@Match" Clicked="@ClickHandler" Attributes="@Attributes">
+<Anchor ElementId="@ElementId" Class="@ClassNames" Style="@StyleNames" To="@To" Target="@Target" Title="@Title" Match="@Match" Clicked="@ClickHandler" Attributes="@Attributes">
     @ChildContent
-</Blazorise.Link>
+</Anchor>

--- a/Source/Blazorise/Components/Bar/BarDropdownItem.razor
+++ b/Source/Blazorise/Components/Bar/BarDropdownItem.razor
@@ -1,5 +1,5 @@
 ﻿@namespace Blazorise
 @inherits BaseComponent
-<Blazorise.Link ElementId="@ElementId" Class="@ClassNames" Style="@StyleNames" To="@To" Target="@Target" Title="@Title" Match="@Match" Clicked="@ClickHandler" Attributes="@Attributes">
+<Anchor ElementId="@ElementId" Class="@ClassNames" Style="@StyleNames" To="@To" Target="@Target" Title="@Title" Match="@Match" Clicked="@ClickHandler" Attributes="@Attributes">
     @ChildContent
-</Blazorise.Link>
+</Anchor>

--- a/Source/Blazorise/Components/Bar/BarLink.razor
+++ b/Source/Blazorise/Components/Bar/BarLink.razor
@@ -1,5 +1,5 @@
 ﻿@namespace Blazorise
 @inherits BaseComponent
-<Blazorise.Link ElementId="@ElementId" Class="@ClassNames" Style="@StyleNames" To="@To" Target="@Target" Title="@Title" Match="@Match" Clicked="@ClickHandler" Attributes="@Attributes">
+<Anchor ElementId="@ElementId" Class="@ClassNames" Style="@StyleNames" To="@To" Target="@Target" Title="@Title" Match="@Match" Clicked="@ClickHandler" Attributes="@Attributes">
     @ChildContent
-</Blazorise.Link>
+</Anchor>

--- a/Source/Blazorise/Components/Breadcrumb/BreadcrumbLink.razor
+++ b/Source/Blazorise/Components/Breadcrumb/BreadcrumbLink.razor
@@ -6,7 +6,7 @@
 }
 else
 {
-    <Blazorise.Link ElementId="@ElementId" Class="@ClassNames" Style="@StyleNames" To="@To" Target="@Target" Title="@Title" Match="@Match" Clicked="@ClickHandler" Attributes="@Attributes">
+    <Anchor ElementId="@ElementId" Class="@ClassNames" Style="@StyleNames" To="@To" Target="@Target" Title="@Title" Match="@Match" Clicked="@ClickHandler" Attributes="@Attributes">
         @ChildContent
-    </Blazorise.Link>
+    </Anchor>
 }

--- a/Source/Blazorise/Components/Link/Anchor.razor
+++ b/Source/Blazorise/Components/Link/Anchor.razor
@@ -1,0 +1,5 @@
+﻿@namespace Blazorise
+@inherits Blazorise.Link
+<a id="@ElementId" href="@To" class="@ClassNames" style="@StyleNames" title="@Title" target="@TargetName" @onclick="@OnClickHandler" @onclick:preventDefault="@PreventDefault" @attributes="@Attributes">
+    @ChildContent
+</a>

--- a/Source/Blazorise/Components/Link/Anchor.razor.cs
+++ b/Source/Blazorise/Components/Link/Anchor.razor.cs
@@ -1,0 +1,10 @@
+﻿namespace Blazorise
+{
+    /// <summary>
+    /// A component that renders an anchor tag, automatically toggling its 'active'
+    /// class based on whether its 'href' matches the current URI.
+    /// </summary>
+    public partial class Anchor : Link
+    {
+    }
+}

--- a/Source/Extensions/Blazorise.Sidebar/SidebarLink.razor
+++ b/Source/Extensions/Blazorise.Sidebar/SidebarLink.razor
@@ -1,4 +1,4 @@
 ﻿@inherits BaseComponent
-<Blazorise.Link Class="@ClassNames" Style="@StyleNames" To="@To" Target="@Target" Title="@Title" Match="@Match" Clicked="@ClickHandler" Attributes="@LinkAttributes">
+<Anchor Class="@ClassNames" Style="@StyleNames" To="@To" Target="@Target" Title="@Title" Match="@Match" Clicked="@ClickHandler" Attributes="@LinkAttributes">
     @ChildContent
-</Blazorise.Link>
+</Anchor>


### PR DESCRIPTION
resolves #2875 Rename Link component

Instead of renaming the Link component, I have decided to leave it in hope that Microsoft will one day fix the issue with their razor engine.

So I have added a new Anchor component that is basically just inherited from Link.