### PR TITLE
Update Blazorise to use .Net 6 RC1

### DIFF
--- a/Build/Blazorise.props
+++ b/Build/Blazorise.props
@@ -42,8 +42,8 @@
 	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-		<PackageReference Include="Microsoft.AspNetCore.Components" Version="6.0.0-preview.5.*" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.0.0-preview.5.*" />
+		<PackageReference Include="Microsoft.AspNetCore.Components" Version="6.0.0-rc.1.*" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.0.0-rc.1.*" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="*" />
 	</ItemGroup>
 


### PR DESCRIPTION
resolves #2944 Support for .NET 6 RC1