### PR TITLE
Refactor Modal Visible parameter and state management

### DIFF
--- a/Documentation/Blazorise.Docs/Components/DocsAttributes.razor
+++ b/Documentation/Blazorise.Docs/Components/DocsAttributes.razor
@@ -9,9 +9,9 @@
     <TableHeader ThemeContrast="ThemeContrast.Light">
         <TableRow>
             <TableHeaderCell>Name</TableHeaderCell>
+            <TableHeaderCell>Description</TableHeaderCell>
             <TableHeaderCell>Type</TableHeaderCell>
             <TableHeaderCell>Default</TableHeaderCell>
-            <TableHeaderCell>Description</TableHeaderCell>
         </TableRow>
     </TableHeader>
     <TableBody>

--- a/Documentation/Blazorise.Docs/Components/DocsAttributesItem.razor
+++ b/Documentation/Blazorise.Docs/Components/DocsAttributesItem.razor
@@ -3,6 +3,9 @@
         <Code>@Name</Code>
     </TableRowCell>
     <TableRowCell>
+        @ChildContent
+    </TableRowCell>
+    <TableRowCell>
         <Code Tag="@TypeTag">@Type</Code>
     </TableRowCell>
     <TableRowCell Class="@DefaultClassNames">
@@ -10,8 +13,5 @@
         {
             <Code>@Default</Code>
         }
-    </TableRowCell>
-    <TableRowCell>
-        @ChildContent
     </TableRowCell>
 </TableRow>

--- a/Documentation/Blazorise.Docs/Models/Snippets.generated.cs
+++ b/Documentation/Blazorise.Docs/Models/Snippets.generated.cs
@@ -1253,7 +1253,7 @@ namespace Blazorise.Docs.Models
     }
 }";
 
-        public const string BasicModalExample = @"<Button Clicked=""@ShowModal"">Show Modal</Button>
+        public const string BasicModalExample = @"<Button Color=""Color.Primary"" Clicked=""@ShowModal"">Show Modal</Button>
 
 <Modal @ref=""modalRef"">
     <ModalContent Centered=""true"">
@@ -1293,6 +1293,51 @@ namespace Blazorise.Docs.Models
     }
 }";
 
+        public const string ModalBindingExample = @"<Button Color=""Color.Primary"" Clicked=""@ShowModal"">Show Modal</Button>
+
+<Span Margin=""Margin.Is3.FromLeft"">Modal is visible: @modalVisible</Span>
+
+<Modal @bind-Visible=""@modalVisible"">
+    <ModalContent Centered=""true"">
+        <ModalHeader>
+            <ModalTitle>Employee edit</ModalTitle>
+            <CloseButton />
+        </ModalHeader>
+        <ModalBody>
+            <Field>
+                <FieldLabel>Name</FieldLabel>
+                <TextEdit Placeholder=""Enter name..."" />
+            </Field>
+            <Field>
+                <FieldLabel>Surname</FieldLabel>
+                <TextEdit Placeholder=""Enter surname..."" />
+            </Field>
+        </ModalBody>
+        <ModalFooter>
+            <Button Color=""Color.Secondary"" Clicked=""@HideModal"">Close</Button>
+            <Button Color=""Color.Primary"" Clicked=""@HideModal"">Save Changes</Button>
+        </ModalFooter>
+    </ModalContent>
+</Modal>
+
+@code{
+    private bool modalVisible;
+
+    private Task ShowModal()
+    {
+        modalVisible = true;
+
+        return Task.CompletedTask;
+    }
+
+    private Task HideModal()
+    {
+        modalVisible = false;
+
+        return Task.CompletedTask;
+    }
+}";
+
         public const string ModalClosingExample = @"<Modal @ref=""modalRef"" Closing=""@OnModalClosing"">
     ...
 </Modal>
@@ -1301,10 +1346,12 @@ namespace Blazorise.Docs.Models
     // reference to the modal component
     private Modal modalRef;
 
-    private void OnModalClosing( ModalClosingEventArgs e )
+    private Task OnModalClosing( ModalClosingEventArgs e )
     {
         // just set Cancel to true to prevent modal from closing
         e.Cancel = true;
+
+        return Task.CompletedTask;
     }
 }";
 

--- a/Documentation/Blazorise.Docs/Models/Snippets.generated.cs
+++ b/Documentation/Blazorise.Docs/Models/Snippets.generated.cs
@@ -1347,18 +1347,52 @@ namespace Blazorise.Docs.Models
     }
 }";
 
-        public const string ModalClosingExample = @"<Modal @ref=""modalRef"" Closing=""@OnModalClosing"">
-    ...
+        public const string ModalClosingExample = @"<Button Color=""Color.Primary"" Clicked=""@ShowModal"">Show Modal</Button>
+
+<Modal @ref=""modalRef"" Closing=""@OnModalClosing"">
+    <ModalContent Centered=""true"">
+        <ModalHeader>
+            <ModalTitle>Closing modal</ModalTitle>
+        </ModalHeader>
+        <ModalBody>
+            Click on the buttons to close the modal.
+        </ModalBody>
+        <ModalFooter>
+            <Button Color=""Color.Secondary"" Clicked=""@CloseModal"">This will close the modal</Button>
+            <Button Color=""Color.Primary"" Clicked=""@TryCloseModal"">This will not</Button>
+        </ModalFooter>
+    </ModalContent>
 </Modal>
 
-@code{
+@code {
     // reference to the modal component
     private Modal modalRef;
 
+    private bool cancelClose;
+
+    private Task ShowModal()
+    {
+        return modalRef.Show();
+    }
+
+    private Task CloseModal()
+    {
+        cancelClose = false;
+
+        return modalRef.Hide();
+    }
+
+    private Task TryCloseModal()
+    {
+        cancelClose = true;
+
+        return modalRef.Hide();
+    }
+
     private Task OnModalClosing( ModalClosingEventArgs e )
     {
-        // just set Cancel to true to prevent modal from closing
-        e.Cancel = true;
+        // just set Cancel to prevent modal from closing
+        e.Cancel = cancelClose;
 
         return Task.CompletedTask;
     }

--- a/Documentation/Blazorise.Docs/Pages/Docs/Components/Modals/Code/ModalBindingExampleCode.html
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Components/Modals/Code/ModalBindingExampleCode.html
@@ -2,7 +2,9 @@
 <div class="html"><pre>
 <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">Button</span> <span class="htmlAttributeName">Color</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="enum">Color</span><span class="enumValue">.Primary</span><span class="quot">&quot;</span> <span class="htmlAttributeName">Clicked</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="sharpVariable"><span class="atSign">&#64;</span>ShowModal</span><span class="quot">&quot;</span><span class="htmlTagDelimiter">&gt;</span>Show Modal<span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">Button</span><span class="htmlTagDelimiter">&gt;</span>
 
-<span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">Modal</span> <span class="htmlAttributeName"><span class="atSign">&#64;</span>ref</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">modalRef</span><span class="quot">&quot;</span><span class="htmlTagDelimiter">&gt;</span>
+<span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">Span</span> <span class="htmlAttributeName">Margin</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">Margin.Is3.FromLeft</span><span class="quot">&quot;</span><span class="htmlTagDelimiter">&gt;</span>Modal is visible: <span class="atSign">&#64;</span>modalVisible<span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">Span</span><span class="htmlTagDelimiter">&gt;</span>
+
+<span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">Modal</span> <span class="htmlAttributeName"><span class="atSign">&#64;</span>bind-Visible</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="sharpVariable"><span class="atSign">&#64;</span>modalVisible</span><span class="quot">&quot;</span><span class="htmlTagDelimiter">&gt;</span>
     <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">ModalContent</span> <span class="htmlAttributeName">Centered</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="keyword">true</span><span class="quot">&quot;</span><span class="htmlTagDelimiter">&gt;</span>
         <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">ModalHeader</span><span class="htmlTagDelimiter">&gt;</span>
             <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">ModalTitle</span><span class="htmlTagDelimiter">&gt;</span>Employee edit<span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">ModalTitle</span><span class="htmlTagDelimiter">&gt;</span>
@@ -27,17 +29,20 @@
 </pre></div>
 <div class="csharp"><pre>
 <span class="atSign">&#64;</span>code{
-    <span class="comment">// reference to the modal component</span>
-    <span class="keyword">private</span> Modal modalRef;
+    <span class="keyword">private</span> <span class="keyword">bool</span> modalVisible;
 
     <span class="keyword">private</span> Task ShowModal()
     {
-        <span class="keyword">return</span> modalRef.Show();
+        modalVisible = <span class="keyword">true</span>;
+
+        <span class="keyword">return</span> Task.CompletedTask;
     }
 
     <span class="keyword">private</span> Task HideModal()
     {
-        <span class="keyword">return</span> modalRef.Hide();
+        modalVisible = <span class="keyword">false</span>;
+
+        <span class="keyword">return</span> Task.CompletedTask;
     }
 }
 </pre></div>

--- a/Documentation/Blazorise.Docs/Pages/Docs/Components/Modals/Code/ModalClosingExampleCode.html
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Components/Modals/Code/ModalClosingExampleCode.html
@@ -9,10 +9,12 @@
     <span class="comment">// reference to the modal component</span>
     <span class="keyword">private</span> Modal modalRef;
 
-    <span class="keyword">private</span> <span class="keyword">void</span> OnModalClosing( ModalClosingEventArgs e )
+    <span class="keyword">private</span> Task OnModalClosing( ModalClosingEventArgs e )
     {
         <span class="comment">// just set Cancel to true to prevent modal from closing</span>
         e.Cancel = <span class="keyword">true</span>;
+
+        <span class="keyword">return</span> Task.CompletedTask;
     }
 }
 </pre></div>

--- a/Documentation/Blazorise.Docs/Pages/Docs/Components/Modals/Code/ModalClosingExampleCode.html
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Components/Modals/Code/ModalClosingExampleCode.html
@@ -1,18 +1,52 @@
 <div class="blazorise-codeblock">
 <div class="html"><pre>
+<span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">Button</span> <span class="htmlAttributeName">Color</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="enum">Color</span><span class="enumValue">.Primary</span><span class="quot">&quot;</span> <span class="htmlAttributeName">Clicked</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="sharpVariable"><span class="atSign">&#64;</span>ShowModal</span><span class="quot">&quot;</span><span class="htmlTagDelimiter">&gt;</span>Show Modal<span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">Button</span><span class="htmlTagDelimiter">&gt;</span>
+
 <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">Modal</span> <span class="htmlAttributeName"><span class="atSign">&#64;</span>ref</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">modalRef</span><span class="quot">&quot;</span> <span class="htmlAttributeName">Closing</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="sharpVariable"><span class="atSign">&#64;</span>OnModalClosing</span><span class="quot">&quot;</span><span class="htmlTagDelimiter">&gt;</span>
-    ...
+    <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">ModalContent</span> <span class="htmlAttributeName">Centered</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="keyword">true</span><span class="quot">&quot;</span><span class="htmlTagDelimiter">&gt;</span>
+        <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">ModalHeader</span><span class="htmlTagDelimiter">&gt;</span>
+            <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">ModalTitle</span><span class="htmlTagDelimiter">&gt;</span>Closing modal<span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">ModalTitle</span><span class="htmlTagDelimiter">&gt;</span>
+        <span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">ModalHeader</span><span class="htmlTagDelimiter">&gt;</span>
+        <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">ModalBody</span><span class="htmlTagDelimiter">&gt;</span>
+            Click on the buttons to close the modal.
+        <span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">ModalBody</span><span class="htmlTagDelimiter">&gt;</span>
+        <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">ModalFooter</span><span class="htmlTagDelimiter">&gt;</span>
+            <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">Button</span> <span class="htmlAttributeName">Color</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="enum">Color</span><span class="enumValue">.Secondary</span><span class="quot">&quot;</span> <span class="htmlAttributeName">Clicked</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="sharpVariable"><span class="atSign">&#64;</span>CloseModal</span><span class="quot">&quot;</span><span class="htmlTagDelimiter">&gt;</span>This will close the modal<span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">Button</span><span class="htmlTagDelimiter">&gt;</span>
+            <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">Button</span> <span class="htmlAttributeName">Color</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="enum">Color</span><span class="enumValue">.Primary</span><span class="quot">&quot;</span> <span class="htmlAttributeName">Clicked</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="sharpVariable"><span class="atSign">&#64;</span>TryCloseModal</span><span class="quot">&quot;</span><span class="htmlTagDelimiter">&gt;</span>This will not<span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">Button</span><span class="htmlTagDelimiter">&gt;</span>
+        <span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">ModalFooter</span><span class="htmlTagDelimiter">&gt;</span>
+    <span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">ModalContent</span><span class="htmlTagDelimiter">&gt;</span>
 <span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">Modal</span><span class="htmlTagDelimiter">&gt;</span>
 </pre></div>
 <div class="csharp"><pre>
-<span class="atSign">&#64;</span>code{
+<span class="atSign">&#64;</span>code {
     <span class="comment">// reference to the modal component</span>
     <span class="keyword">private</span> Modal modalRef;
 
+    <span class="keyword">private</span> <span class="keyword">bool</span> cancelClose;
+
+    <span class="keyword">private</span> Task ShowModal()
+    {
+        <span class="keyword">return</span> modalRef.Show();
+    }
+
+    <span class="keyword">private</span> Task CloseModal()
+    {
+        cancelClose = <span class="keyword">false</span>;
+
+        <span class="keyword">return</span> modalRef.Hide();
+    }
+
+    <span class="keyword">private</span> Task TryCloseModal()
+    {
+        cancelClose = <span class="keyword">true</span>;
+
+        <span class="keyword">return</span> modalRef.Hide();
+    }
+
     <span class="keyword">private</span> Task OnModalClosing( ModalClosingEventArgs e )
     {
-        <span class="comment">// just set Cancel to true to prevent modal from closing</span>
-        e.Cancel = <span class="keyword">true</span>;
+        <span class="comment">// just set Cancel to prevent modal from closing</span>
+        e.Cancel = cancelClose;
 
         <span class="keyword">return</span> Task.CompletedTask;
     }

--- a/Documentation/Blazorise.Docs/Pages/Docs/Components/Modals/Examples/ModalBindingExample.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Components/Modals/Examples/ModalBindingExample.razor
@@ -2,7 +2,9 @@
 
 <Button Color="Color.Primary" Clicked="@ShowModal">Show Modal</Button>
 
-<Modal @ref="modalRef">
+<Span Margin="Margin.Is3.FromLeft">Modal is visible: @modalVisible</Span>
+
+<Modal @bind-Visible="@modalVisible">
     <ModalContent Centered="true">
         <ModalHeader>
             <ModalTitle>Employee edit</ModalTitle>
@@ -26,16 +28,19 @@
 </Modal>
 
 @code{
-    // reference to the modal component
-    private Modal modalRef;
+    private bool modalVisible;
 
     private Task ShowModal()
     {
-        return modalRef.Show();
+        modalVisible = true;
+
+        return Task.CompletedTask;
     }
 
     private Task HideModal()
     {
-        return modalRef.Hide();
+        modalVisible = false;
+
+        return Task.CompletedTask;
     }
 }

--- a/Documentation/Blazorise.Docs/Pages/Docs/Components/Modals/Examples/ModalClosingExample.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Components/Modals/Examples/ModalClosingExample.razor
@@ -8,9 +8,11 @@
     // reference to the modal component
     private Modal modalRef;
 
-    private void OnModalClosing( ModalClosingEventArgs e )
+    private Task OnModalClosing( ModalClosingEventArgs e )
     {
         // just set Cancel to true to prevent modal from closing
         e.Cancel = true;
+
+        return Task.CompletedTask;
     }
 }

--- a/Documentation/Blazorise.Docs/Pages/Docs/Components/Modals/Examples/ModalClosingExample.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Components/Modals/Examples/ModalClosingExample.razor
@@ -1,17 +1,51 @@
 ﻿@namespace Blazorise.Docs.Docs.Examples
 
+<Button Color="Color.Primary" Clicked="@ShowModal">Show Modal</Button>
+
 <Modal @ref="modalRef" Closing="@OnModalClosing">
-    ...
+    <ModalContent Centered="true">
+        <ModalHeader>
+            <ModalTitle>Closing modal</ModalTitle>
+        </ModalHeader>
+        <ModalBody>
+            Click on the buttons to close the modal.
+        </ModalBody>
+        <ModalFooter>
+            <Button Color="Color.Secondary" Clicked="@CloseModal">This will close the modal</Button>
+            <Button Color="Color.Primary" Clicked="@TryCloseModal">This will not</Button>
+        </ModalFooter>
+    </ModalContent>
 </Modal>
 
-@code{
+@code {
     // reference to the modal component
     private Modal modalRef;
 
+    private bool cancelClose;
+
+    private Task ShowModal()
+    {
+        return modalRef.Show();
+    }
+
+    private Task CloseModal()
+    {
+        cancelClose = false;
+
+        return modalRef.Hide();
+    }
+
+    private Task TryCloseModal()
+    {
+        cancelClose = true;
+
+        return modalRef.Hide();
+    }
+
     private Task OnModalClosing( ModalClosingEventArgs e )
     {
-        // just set Cancel to true to prevent modal from closing
-        e.Cancel = true;
+        // just set Cancel to prevent modal from closing
+        e.Cancel = cancelClose;
 
         return Task.CompletedTask;
     }

--- a/Documentation/Blazorise.Docs/Pages/Docs/Components/Modals/ModalPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Components/Modals/ModalPage.razor
@@ -56,6 +56,16 @@
 </DocsPageSection>
 
 <DocsPageSection>
+    <DocsPageSectionHeader Title="Two-way binding">
+        You can also control the <Code>Modal</Code> visibility by declaring the <Code>Visible</Code> state.
+    </DocsPageSectionHeader>
+    <DocsPageSectionContent Outlined FullWidth>
+        <ModalBindingExample />
+    </DocsPageSectionContent>
+    <DocsPageSectionSource Code="ModalBindingExample" />
+</DocsPageSection>
+
+<DocsPageSection>
     <DocsPageSectionHeader Title="Closing">
         If you want to prevent modal from closing you can use <Code>Closing</Code> event.
     </DocsPageSectionHeader>

--- a/Documentation/Blazorise.Docs/Pages/Docs/Components/Modals/ModalPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Components/Modals/ModalPage.razor
@@ -106,8 +106,20 @@
     <DocsAttributesItem Name="Visible" Type="boolean" Default="false">
         Handles the visibility of modal dialog.
     </DocsAttributesItem>
-    <DocsAttributesItem Name="Closing" Type="Action<ModalClosingEventArgs>">
+    <DocsAttributesItem Name="VisibleChanged" Type="EventCallback<bool>">
+        Occurs when the modal visibility state changes.
+    </DocsAttributesItem>
+    <DocsAttributesItem Name="Opening" Type="Func<ModalOpeningEventArgs, Task>">
         Occurs before the modal is closed and can be used to prevent the modal from closing.
+    </DocsAttributesItem>
+    <DocsAttributesItem Name="Closing" Type="Func<ModalClosingEventArgs, Task>">
+        Occurs before the modal is closed and can be used to prevent the modal from closing.
+    </DocsAttributesItem>
+    <DocsAttributesItem Name="Opened" Type="EventCallback">
+        Occurs after the modal has opened.
+    </DocsAttributesItem>
+    <DocsAttributesItem Name="Closed" Type="EventCallback">
+        Occurs after the modal has closed.
     </DocsAttributesItem>
     <DocsAttributesItem Name="ScrollToTop" Type="boolean" Default="true">
         If true modal will scroll to top when opened.

--- a/Documentation/Blazorise.Docs/Pages/Docs/Components/Modals/ModalPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Components/Modals/ModalPage.razor
@@ -69,6 +69,9 @@
     <DocsPageSectionHeader Title="Closing">
         If you want to prevent modal from closing you can use <Code>Closing</Code> event.
     </DocsPageSectionHeader>
+    <DocsPageSectionContent Outlined FullWidth>
+        <ModalClosingExample />
+    </DocsPageSectionContent>
     <DocsPageSectionSource Code="ModalClosingExample" />
 </DocsPageSection>
 

--- a/Documentation/Blazorise.Docs/Pages/News/2021-10-17-release-notes-095.razor
+++ b/Documentation/Blazorise.Docs/Pages/News/2021-10-17-release-notes-095.razor
@@ -32,6 +32,11 @@
             <TableRowCell><Code>Task Hide()</Code></TableRowCell>
         </TableRow>
         <TableRow>
+            <TableRowCell></TableRowCell>
+            <TableRowCell><Code>Action&lt;ModalClosingEventArgs&gt;</Code></TableRowCell>
+            <TableRowCell><Code>Func&lt;ModalClosingEventArgs, Task&gt;</Code></TableRowCell>
+        </TableRow>
+        <TableRow>
             <TableRowCell>Alert</TableRowCell>
             <TableRowCell><Code>void Show()</Code></TableRowCell>
             <TableRowCell><Code>Task Show()</Code></TableRowCell>

--- a/Source/Blazorise.AntDesign/ModalContent.razor
+++ b/Source/Blazorise.AntDesign/ModalContent.razor
@@ -1,6 +1,6 @@
 ﻿@inherits Blazorise.ModalContent
 <CascadingValue Value="@this" IsFixed="true">
-    <div id="@WrapperElementId" class="ant-modal-wrap" role="dialog" style="@(ParentModal?.Visible == true ? "" : "display: none;")">
+    <div id="@WrapperElementId" class="ant-modal-wrap" role="dialog" style="@(ParentModal?.IsVisible == true ? "" : "display: none;")">
         <div class="@DialogClassNames" role="document">
             <div id="@ElementId" class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
                 @ChildContent

--- a/Source/Blazorise.AntDesign/wwwroot/blazorise.antdesign.js
+++ b/Source/Blazorise.AntDesign/wwwroot/blazorise.antdesign.js
@@ -15,7 +15,11 @@ window.antDesign = {
     modal: {
         open: (element, scrollToTop) => {
             if (scrollToTop) {
-                element.querySelector('.ant-modal-body').scrollTop = 0;
+                const modalBody = element.querySelector('.ant-modal-body');
+
+                if (modalBody) {
+                    modalBody.scrollTop = 0;
+                }
             }
         },
         close: (element) => {

--- a/Source/Blazorise.Bootstrap/Modal.razor
+++ b/Source/Blazorise.Bootstrap/Modal.razor
@@ -4,7 +4,7 @@
         <div @ref="@ElementRef" id="@ElementId" class="@ClassNames" style="@StyleNames" tabindex="-1" role="dialog" @attributes="@Attributes">
             @ChildContent
         </div>
-        @if ( ShowBackdrop && Visible )
+        @if ( ShowBackdrop && IsVisible )
         {
             <_ModalBackdrop CloseActivatorDisabled="true" />
         }

--- a/Source/Blazorise.Bootstrap/wwwroot/blazorise.bootstrap.js
+++ b/Source/Blazorise.Bootstrap/wwwroot/blazorise.bootstrap.js
@@ -28,7 +28,11 @@ window.blazoriseBootstrap = {
             document.body.setAttribute("data-modals", modals.toString());
 
             if (scrollToTop) {
-                element.querySelector('.modal-body').scrollTop = 0;
+                const modalBody = element.querySelector('.modal-body');
+
+                if (modalBody) {
+                    modalBody.scrollTop = 0;
+                }
             }
         },
         close: (element) => {

--- a/Source/Blazorise.Bootstrap5/Modal.razor
+++ b/Source/Blazorise.Bootstrap5/Modal.razor
@@ -4,7 +4,7 @@
         <div @ref="@ElementRef" id="@ElementId" class="@ClassNames" style="@StyleNames" tabindex="-1" role="dialog" @attributes="@Attributes">
             @ChildContent
         </div>
-        @if ( ShowBackdrop && Visible )
+        @if ( ShowBackdrop && IsVisible )
         {
             <_ModalBackdrop CloseActivatorDisabled="true" />
         }

--- a/Source/Blazorise.Bootstrap5/wwwroot/blazorise.bootstrap5.js
+++ b/Source/Blazorise.Bootstrap5/wwwroot/blazorise.bootstrap5.js
@@ -28,7 +28,11 @@ window.blazoriseBootstrap = {
             document.body.setAttribute("data-modals", modals.toString());
 
             if (scrollToTop) {
-                element.querySelector('.modal-body').scrollTop = 0;
+                const modalBody = element.querySelector('.modal-body');
+
+                if (modalBody) {
+                    modalBody.scrollTop = 0;
+                }
             }
         },
         close: (element) => {

--- a/Source/Blazorise.Bulma/wwwroot/blazorise.bulma.js
+++ b/Source/Blazorise.Bulma/wwwroot/blazorise.bulma.js
@@ -24,7 +24,11 @@ window.blazoriseBulma = {
     modal: {
         open: (element, scrollToTop) => {
             if (scrollToTop) {
-                element.querySelector('.modal-card-body').scrollTop = 0;
+                const modalBody = element.querySelector('.modal-card-body');
+
+                if (modalBody) {
+                    modalBody.scrollTop = 0;
+                }
             }
         },
         close: (element) => {

--- a/Source/Blazorise.Material/wwwroot/blazorise.material.js
+++ b/Source/Blazorise.Material/wwwroot/blazorise.material.js
@@ -23,7 +23,11 @@ window.blazoriseMaterial = {
             window.blazorise.addClassToBody("modal-open");
 
             if (scrollToTop) {
-                element.querySelector('.modal-body').scrollTop = 0;
+                const modalBody = element.querySelector('.modal-body');
+
+                if (modalBody) {
+                    modalBody.scrollTop = 0;
+                }
             }
         },
         close: (element) => {

--- a/Source/Blazorise/Components/MessageAlert/MessageAlert.razor.cs
+++ b/Source/Blazorise/Components/MessageAlert/MessageAlert.razor.cs
@@ -101,10 +101,12 @@ namespace Blazorise
         /// Handles the <see cref="Modal"/> closing event.
         /// </summary>
         /// <param name="eventArgs">Provides the data for the modal closing event.</param>
-        protected virtual void OnModalClosing( ModalClosingEventArgs eventArgs )
+        protected virtual Task OnModalClosing( ModalClosingEventArgs eventArgs )
         {
             eventArgs.Cancel = BackgroundCancel && ( eventArgs.CloseReason == CloseReason.EscapeClosing
                 || eventArgs.CloseReason == CloseReason.FocusLostClosing );
+
+            return Task.CompletedTask;
         }
 
         #endregion

--- a/Source/Blazorise/Components/Modal/Modal.razor.cs
+++ b/Source/Blazorise/Components/Modal/Modal.razor.cs
@@ -68,17 +68,11 @@ namespace Blazorise
             {
                 if ( visibleResult == true && await IsSafeToOpen() )
                 {
-                    state = state with { Visible = true };
-
-                    HandleVisibilityStyles( true );
-                    RaiseEvents( true );
+                    SetVisibleState( true );
                 }
                 else if ( visibleResult == false && await IsSafeToClose() )
                 {
-                    state = state with { Visible = false };
-
-                    HandleVisibilityStyles( false );
-                    RaiseEvents( false );
+                    SetVisibleState( false );
                 }
                 else
                 {
@@ -180,10 +174,7 @@ namespace Blazorise
 
             if ( await IsSafeToOpen() )
             {
-                state = state with { Visible = true };
-
-                HandleVisibilityStyles( true );
-                RaiseEvents( true );
+                SetVisibleState( true );
 
                 await InvokeAsync( StateHasChanged );
             }
@@ -212,10 +203,7 @@ namespace Blazorise
 
             if ( await IsSafeToClose() )
             {
-                state = state with { Visible = false };
-
-                HandleVisibilityStyles( false );
-                RaiseEvents( false );
+                SetVisibleState( false );
 
                 // finally reset close reason so it doesn't interfere with internal closing by Visible property
                 this.closeReason = CloseReason.None;
@@ -388,6 +376,18 @@ namespace Blazorise
         public Task Close( CloseReason closeReason )
         {
             return Hide( closeReason );
+        }
+
+        /// <summary>
+        /// Handles the internal visibility states.
+        /// </summary>
+        /// <param name="visible">Visible state.</param>
+        private void SetVisibleState( bool visible )
+        {
+            state = state with { Visible = visible };
+
+            HandleVisibilityStyles( visible );
+            RaiseEvents( visible );
         }
 
         #endregion

--- a/Source/Blazorise/Components/Modal/Modal.razor.cs
+++ b/Source/Blazorise/Components/Modal/Modal.razor.cs
@@ -316,7 +316,11 @@ namespace Blazorise
         /// <param name="visible"></param>
         protected virtual void RaiseEvents( bool visible )
         {
-            if ( !visible )
+            if ( visible )
+            {
+                Opened.InvokeAsync();
+            }
+            else
             {
                 Closed.InvokeAsync();
             }
@@ -444,6 +448,11 @@ namespace Blazorise
         /// Occurs before the modal is closed.
         /// </summary>
         [Parameter] public Func<ModalClosingEventArgs, Task> Closing { get; set; }
+
+        /// <summary>
+        /// Occurs after the modal has opened.
+        /// </summary>
+        [Parameter] public EventCallback Opened { get; set; }
 
         /// <summary>
         /// Occurs after the modal has closed.

--- a/Source/Blazorise/EventArguments/ModalOpeningEventArgs.cs
+++ b/Source/Blazorise/EventArguments/ModalOpeningEventArgs.cs
@@ -1,0 +1,21 @@
+﻿#region Using directives
+using System.ComponentModel;
+#endregion
+
+namespace Blazorise
+{
+    /// <summary>
+    /// Provides data for the <see cref="Modal.Opening"/> event.
+    /// </summary>
+    public class ModalOpeningEventArgs : CancelEventArgs
+    {
+        /// <summary>
+        /// A default <see cref="ModalOpeningEventArgs"/> constructor.
+        /// </summary>
+        /// <param name="cancel">True if close event should be cancelled.</param>
+        public ModalOpeningEventArgs( bool cancel )
+            : base( cancel )
+        {
+        }
+    }
+}


### PR DESCRIPTION
closes #2810 Modal Closing is an Action instead of an EventCallback
closes #1359 Modal - Show event

I have refactored the `Visible` parameter and `Closing` event. Instead of doing all the logic in the `Visible` setter, I have moved it to the `SetParametersAsync` lifecycle.

- The benefit of this is that the `Closing` event can now be properly awaited.
- The disadvantage is that `Visible` is used only as a hint for us that the parameter was received by the Blazot lifecycle. It should never be used directly as that would leave it in a bad state, eg. `modal.Visible = true`.

This will also come in handy for #1359