### PR TITLE
Diferent structure for dropdown submenus

### DIFF
--- a/Demos/Blazorise.Demo/Pages/Tests/ButtonsPage.razor
+++ b/Demos/Blazorise.Demo/Pages/Tests/ButtonsPage.razor
@@ -230,33 +230,27 @@
                     <DropdownToggle Color="Color.Primary">Level 1</DropdownToggle>
                     <DropdownMenu>
                         <DropdownItem>Item 1.1</DropdownItem>
-                        <DropdownItem>
-                            <Dropdown Direction="Direction.Right">
-                                <DropdownToggle Color="Color.Secondary">Level 2</DropdownToggle>
-                                <DropdownMenu>
-                                    <DropdownItem>Item 2.1</DropdownItem>
-                                    <DropdownItem>Item 2.2</DropdownItem>
-                                    <DropdownItem>
-                                        <Dropdown Direction="Direction.Right">
-                                            <DropdownToggle Color="Color.Secondary">Level 3</DropdownToggle>
+                        <Dropdown>
+                            <DropdownToggle>Level 2</DropdownToggle>
+                            <DropdownMenu>
+                                <DropdownItem>Item 2.1</DropdownItem>
+                                <DropdownItem>Item 2.2</DropdownItem>
+                                <Dropdown>
+                                    <DropdownToggle>Level 3</DropdownToggle>
+                                    <DropdownMenu>
+                                        <DropdownItem>Item 3.1</DropdownItem>
+                                        <DropdownItem>Item 3.2</DropdownItem>
+                                        <Dropdown>
+                                            <DropdownToggle>Level 4</DropdownToggle>
                                             <DropdownMenu>
-                                                <DropdownItem>Item 3.1</DropdownItem>
-                                                <DropdownItem>Item 3.2</DropdownItem>
-                                                <DropdownItem>
-                                                    <Dropdown Direction="Direction.Right">
-                                                        <DropdownToggle Color="Color.Secondary">Level 4</DropdownToggle>
-                                                        <DropdownMenu>
-                                                            <DropdownItem>Item 4.1</DropdownItem>
-                                                            <DropdownItem>Item 4.2</DropdownItem>
-                                                        </DropdownMenu>
-                                                    </Dropdown>
-                                                </DropdownItem>
+                                                <DropdownItem>Item 4.1</DropdownItem>
+                                                <DropdownItem>Item 4.2</DropdownItem>
                                             </DropdownMenu>
                                         </Dropdown>
-                                    </DropdownItem>
-                                </DropdownMenu>
-                            </Dropdown>
-                        </DropdownItem>
+                                    </DropdownMenu>
+                                </Dropdown>
+                            </DropdownMenu>
+                        </Dropdown>
                     </DropdownMenu>
                 </Dropdown>
             </CardBody>

--- a/Source/Blazorise.AntDesign/AntDesignClassProvider.cs
+++ b/Source/Blazorise.AntDesign/AntDesignClassProvider.cs
@@ -364,6 +364,8 @@ namespace Blazorise.AntDesign
 
         public override string DropdownShow() => null;
 
+        public override string DropdownSubmenu() => null;
+
         public override string DropdownRight() => null;
 
         public override string DropdownItem() => "ant-dropdown-menu-item";
@@ -384,7 +386,7 @@ namespace Blazorise.AntDesign
 
         public override string DropdownMenuRight() => "dropdown-menu-right";
 
-        public override string DropdownToggle() => "ant-btn ant-dropdown-trigger";
+        public override string DropdownToggle( bool isDropdownSubmenu ) => "ant-btn ant-dropdown-trigger";
 
         public override string DropdownToggleColor( Color color ) => $"{Button()}-{ToColor( color )}";
 

--- a/Source/Blazorise.AntDesign/AntDesignClassProvider.cs
+++ b/Source/Blazorise.AntDesign/AntDesignClassProvider.cs
@@ -358,13 +358,11 @@ namespace Blazorise.AntDesign
 
         #region Dropdown
 
-        public override string Dropdown() => "ant-dropdown-group ant-dropdown-button"; // ant-dropdown-group is custom class
+        public override string Dropdown( bool isDropdownSubmenu ) => isDropdownSubmenu ? "ant-dropdown-menu-submenu ant-dropdown-menu-submenu-vertical" : "ant-dropdown-group ant-dropdown-button"; // ant-dropdown-group is custom class
 
         public override string DropdownGroup() => null;
 
         public override string DropdownShow() => null;
-
-        public override string DropdownSubmenu() => null;
 
         public override string DropdownRight() => null;
 

--- a/Source/Blazorise.Bootstrap/BootstrapClassProvider.cs
+++ b/Source/Blazorise.Bootstrap/BootstrapClassProvider.cs
@@ -363,6 +363,8 @@ namespace Blazorise.Bootstrap
 
         public override string DropdownShow() => Show();
 
+        public override string DropdownSubmenu() => "dropdown-submenu";
+
         public override string DropdownRight() => null;
 
         public override string DropdownItem() => "dropdown-item";
@@ -383,7 +385,7 @@ namespace Blazorise.Bootstrap
 
         public override string DropdownMenuRight() => "dropdown-menu-right";
 
-        public override string DropdownToggle() => "btn dropdown-toggle";
+        public override string DropdownToggle( bool isDropdownSubmenu ) => isDropdownSubmenu ? "dropdown-item dropdown-toggle" : "btn dropdown-toggle";
 
         public override string DropdownToggleColor( Color color ) => $"{Button()}-{ToColor( color )}";
 

--- a/Source/Blazorise.Bootstrap/BootstrapClassProvider.cs
+++ b/Source/Blazorise.Bootstrap/BootstrapClassProvider.cs
@@ -357,13 +357,11 @@ namespace Blazorise.Bootstrap
 
         #region Dropdown
 
-        public override string Dropdown() => "dropdown";
+        public override string Dropdown( bool isDropdownSubmenu ) => isDropdownSubmenu ? "dropdown-submenu" : "dropdown";
 
         public override string DropdownGroup() => "btn-group";
 
         public override string DropdownShow() => Show();
-
-        public override string DropdownSubmenu() => "dropdown-submenu";
 
         public override string DropdownRight() => null;
 

--- a/Source/Blazorise.Bootstrap/Config.cs
+++ b/Source/Blazorise.Bootstrap/Config.cs
@@ -50,6 +50,7 @@ namespace Blazorise.Bootstrap
             { typeof( Blazorise.Carousel ), typeof( Bootstrap.Carousel ) },
             { typeof( Blazorise.CloseButton ), typeof( Bootstrap.CloseButton ) },
             { typeof( Blazorise.Check<> ), typeof( Bootstrap.Check<> ) },
+            { typeof( Blazorise.DropdownToggle ), typeof( Bootstrap.DropdownToggle ) },
             { typeof( Blazorise.Field ), typeof( Bootstrap.Field ) },
             { typeof( Blazorise.FieldBody ), typeof( Bootstrap.FieldBody ) },
             { typeof( Blazorise.FileEdit ), typeof( Bootstrap.FileEdit ) },

--- a/Source/Blazorise.Bootstrap/DropdownToggle.razor
+++ b/Source/Blazorise.Bootstrap/DropdownToggle.razor
@@ -1,0 +1,13 @@
+﻿@inherits Blazorise.DropdownToggle
+@if ( ParentDropdown?.IsDropdownSubmenu == true )
+{
+    <a @ref="@ElementRef" id="@ElementId" class="@ClassNames" style="@StyleNames" data-boundary="@DataBoundary" disabled="@IsDisabled" tabindex="@TabIndex" @onclick="@ClickHandler" href="javascript:void(0)" @attributes="@Attributes">
+        @ChildContent
+    </a>
+}
+else
+{
+    <button @ref="@ElementRef" id="@ElementId" type="button" class="@ClassNames" style="@StyleNames" data-boundary="@DataBoundary" disabled="@IsDisabled" tabindex="@TabIndex" @onclick="@ClickHandler" @attributes="@Attributes">
+        @ChildContent
+    </button>
+}

--- a/Source/Blazorise.Bootstrap/Styles/_dropdown.scss
+++ b/Source/Blazorise.Bootstrap/Styles/_dropdown.scss
@@ -21,3 +21,67 @@
     max-height: var(--autocomplete-menu-max-height, 200px);
     overflow-y: scroll;
 }
+/*
+.dropdown-submenu {
+    position: relative;
+}
+
+.dropdown-submenu button.dropdown-toggle {
+    width: 100%;
+}
+
+.dropdown-submenu button.dropdown-toggle::after,
+.dropdown-submenu a::after {
+    transform: rotate(-90deg);
+    position: absolute;
+    right: 10%;
+    top: 45%;
+}
+
+.dropdown-submenu::after {
+    transform: rotate(-90deg);
+    position: absolute;
+    right: 6px;
+    top: .8em;
+}
+
+.dropdown-submenu .dropdown-menu {
+    top: 0;
+    left: 100%;
+    margin-left: 0rem;
+    margin-right: .1rem;
+}*/
+
+
+.dropdown {
+    > .dropdown-menu {
+        > .dropdown {
+            position: relative;
+
+            &::after {
+                transform: rotate(-90deg);
+                position: absolute;
+                right: 6px;
+                top: .8em;
+            }
+
+            > .dropdown-toggle {
+                width: 100%;
+
+                &::after {
+                    transform: rotate(-90deg);
+                    position: absolute;
+                    right: 10%;
+                    top: 45%;
+                }
+            }
+
+            > .dropdown-menu {
+                top: 0;
+                left: 100%;
+                margin-left: 0rem;
+                margin-right: .1rem;
+            }
+        }
+    }
+}

--- a/Source/Blazorise.Bootstrap/wwwroot/blazorise.bootstrap.css
+++ b/Source/Blazorise.Bootstrap/wwwroot/blazorise.bootstrap.css
@@ -98,6 +98,56 @@
     max-height: var(--autocomplete-menu-max-height, 200px);
     overflow-y: scroll; }
 
+/*
+.dropdown-submenu {
+    position: relative;
+}
+
+.dropdown-submenu button.dropdown-toggle {
+    width: 100%;
+}
+
+.dropdown-submenu button.dropdown-toggle::after,
+.dropdown-submenu a::after {
+    transform: rotate(-90deg);
+    position: absolute;
+    right: 10%;
+    top: 45%;
+}
+
+.dropdown-submenu::after {
+    transform: rotate(-90deg);
+    position: absolute;
+    right: 6px;
+    top: .8em;
+}
+
+.dropdown-submenu .dropdown-menu {
+    top: 0;
+    left: 100%;
+    margin-left: 0rem;
+    margin-right: .1rem;
+}*/
+.dropdown > .dropdown-menu > .dropdown {
+    position: relative; }
+    .dropdown > .dropdown-menu > .dropdown::after {
+        transform: rotate(-90deg);
+        position: absolute;
+        right: 6px;
+        top: .8em; }
+    .dropdown > .dropdown-menu > .dropdown > .dropdown-toggle {
+        width: 100%; }
+        .dropdown > .dropdown-menu > .dropdown > .dropdown-toggle::after {
+            transform: rotate(-90deg);
+            position: absolute;
+            right: 10%;
+            top: 45%; }
+    .dropdown > .dropdown-menu > .dropdown > .dropdown-menu {
+        top: 0;
+        left: 100%;
+        margin-left: 0rem;
+        margin-right: .1rem; }
+
 .snackbar {
     z-index: 1060 !important; }
 
@@ -1301,7 +1351,7 @@ ol.ordered-list-upper-roman {
             border-color: #007bff; }
     .flatpickr-day:hover {
         background: rgba(0, 123, 255, 0.1);
-        border-color: transparent; }
+        border-color: rgba(0, 0, 0, 0); }
 
 span.flatpickr-weekday {
     color: #212529; }

--- a/Source/Blazorise.Bootstrap5/Bootstrap5ClassProvider.cs
+++ b/Source/Blazorise.Bootstrap5/Bootstrap5ClassProvider.cs
@@ -355,6 +355,8 @@ namespace Blazorise.Bootstrap5
 
         public override string DropdownShow() => Show();
 
+        public override string DropdownSubmenu() => null;
+
         public override string DropdownRight() => null;
 
         public override string DropdownItem() => "dropdown-item";
@@ -375,7 +377,7 @@ namespace Blazorise.Bootstrap5
 
         public override string DropdownMenuRight() => "dropdown-menu-end";
 
-        public override string DropdownToggle() => "btn dropdown-toggle";
+        public override string DropdownToggle( bool isDropdownSubmenu ) => "btn dropdown-toggle";
 
         public override string DropdownToggleColor( Color color ) => $"{Button()}-{ToColor( color )}";
 

--- a/Source/Blazorise.Bootstrap5/Bootstrap5ClassProvider.cs
+++ b/Source/Blazorise.Bootstrap5/Bootstrap5ClassProvider.cs
@@ -377,7 +377,7 @@ namespace Blazorise.Bootstrap5
 
         public override string DropdownMenuRight() => "dropdown-menu-end";
 
-        public override string DropdownToggle( bool isDropdownSubmenu ) => "btn dropdown-toggle";
+        public override string DropdownToggle( bool isDropdownSubmenu ) => isDropdownSubmenu ? "dropdown-item dropdown-toggle" : "btn dropdown-toggle";
 
         public override string DropdownToggleColor( Color color ) => $"{Button()}-{ToColor( color )}";
 

--- a/Source/Blazorise.Bootstrap5/Bootstrap5ClassProvider.cs
+++ b/Source/Blazorise.Bootstrap5/Bootstrap5ClassProvider.cs
@@ -349,13 +349,11 @@ namespace Blazorise.Bootstrap5
 
         #region Dropdown
 
-        public override string Dropdown() => "dropdown";
+        public override string Dropdown( bool isDropdownSubmenu ) => "dropdown";
 
         public override string DropdownGroup() => "btn-group";
 
         public override string DropdownShow() => Show();
-
-        public override string DropdownSubmenu() => null;
 
         public override string DropdownRight() => null;
 

--- a/Source/Blazorise.Bootstrap5/DropdownToggle.razor
+++ b/Source/Blazorise.Bootstrap5/DropdownToggle.razor
@@ -7,7 +7,10 @@
 }
 else
 {
-    <button @ref="@ElementRef" id="@ElementId" type="button" class="@ClassNames" style="@StyleNames" data-boundary="@DataBoundary" disabled="@IsDisabled" tabindex="@TabIndex" @onclick="@ClickHandler" @attributes="@Attributes">
+    <button @ref="@ElementRef" id="@ElementId" type="button" class="@ClassNames" style="@StyleNames" data-bs-toggle="@DataToggle" data-boundary="@DataBoundary" disabled="@IsDisabled" tabindex="@TabIndex" @onclick="@ClickHandler" @attributes="@Attributes">
         @ChildContent
     </button>
+}
+@code {
+    string DataToggle => ParentDropdown?.HasSubmenu == true ? null : "dropdown";
 }

--- a/Source/Blazorise.Bootstrap5/DropdownToggle.razor
+++ b/Source/Blazorise.Bootstrap5/DropdownToggle.razor
@@ -1,4 +1,13 @@
 ﻿@inherits Blazorise.DropdownToggle
-<button @ref="@ElementRef" id="@ElementId" type="button" class="@ClassNames" style="@StyleNames" data-boundary="@DataBoundary" disabled="@IsDisabled" tabindex="@TabIndex" @onclick="@ClickHandler" @attributes="@Attributes">
-    @ChildContent
-</button>
+@if ( ParentDropdown?.IsDropdownSubmenu == true )
+{
+    <a @ref="@ElementRef" id="@ElementId" class="@ClassNames" style="@StyleNames" data-boundary="@DataBoundary" disabled="@IsDisabled" tabindex="@TabIndex" @onclick="@ClickHandler" href="javascript:void(0)" @attributes="@Attributes">
+        @ChildContent
+    </a>
+}
+else
+{
+    <button @ref="@ElementRef" id="@ElementId" type="button" class="@ClassNames" style="@StyleNames" data-boundary="@DataBoundary" disabled="@IsDisabled" tabindex="@TabIndex" @onclick="@ClickHandler" @attributes="@Attributes">
+        @ChildContent
+    </button>
+}

--- a/Source/Blazorise.Bootstrap5/Styles/_dropdown.scss
+++ b/Source/Blazorise.Bootstrap5/Styles/_dropdown.scss
@@ -21,3 +21,36 @@
     max-height: var(--autocomplete-menu-max-height, 200px);
     overflow-y: scroll;
 }
+
+.dropdown {
+    > .dropdown-menu {
+        > .dropdown {
+            position: relative;
+
+            &::after {
+                transform: rotate(-90deg);
+                position: absolute;
+                right: 6px;
+                top: .8em;
+            }
+
+            > .dropdown-toggle {
+                width: 100%;
+
+                &::after {
+                    transform: rotate(-90deg);
+                    position: absolute;
+                    right: 10%;
+                    top: 45%;
+                }
+            }
+
+            > .dropdown-menu {
+                top: 0;
+                left: 100%;
+                margin-left: 0rem;
+                margin-right: .1rem;
+            }
+        }
+    }
+}

--- a/Source/Blazorise.Bootstrap5/wwwroot/blazorise.bootstrap5.css
+++ b/Source/Blazorise.Bootstrap5/wwwroot/blazorise.bootstrap5.css
@@ -109,6 +109,26 @@ input[type="button"].btn-block {
     max-height: var(--autocomplete-menu-max-height, 200px);
     overflow-y: scroll; }
 
+.dropdown > .dropdown-menu > .dropdown {
+    position: relative; }
+    .dropdown > .dropdown-menu > .dropdown::after {
+        transform: rotate(-90deg);
+        position: absolute;
+        right: 6px;
+        top: .8em; }
+    .dropdown > .dropdown-menu > .dropdown > .dropdown-toggle {
+        width: 100%; }
+        .dropdown > .dropdown-menu > .dropdown > .dropdown-toggle::after {
+            transform: rotate(-90deg);
+            position: absolute;
+            right: 10%;
+            top: 45%; }
+    .dropdown > .dropdown-menu > .dropdown > .dropdown-menu {
+        top: 0;
+        left: 100%;
+        margin-left: 0rem;
+        margin-right: .1rem; }
+
 .snackbar {
     z-index: 1060 !important; }
 
@@ -1164,7 +1184,7 @@ ol.ordered-list-upper-roman {
             border-color: #007bff; }
     .flatpickr-day:hover {
         background: rgba(0, 123, 255, 0.1);
-        border-color: transparent; }
+        border-color: rgba(0, 0, 0, 0); }
 
 span.flatpickr-weekday {
     color: #212529; }

--- a/Source/Blazorise.Bulma/BulmaClassProvider.cs
+++ b/Source/Blazorise.Bulma/BulmaClassProvider.cs
@@ -361,13 +361,11 @@ namespace Blazorise.Bulma
 
         #region Dropdown
 
-        public override string Dropdown() => "dropdown";
+        public override string Dropdown( bool isDropdownSubmenu ) => "dropdown";
 
         public override string DropdownGroup() => "field has-addons";
 
         public override string DropdownShow() => Active();
-
-        public override string DropdownSubmenu() => null;
 
         public override string DropdownRight() => "is-right";
 

--- a/Source/Blazorise.Bulma/BulmaClassProvider.cs
+++ b/Source/Blazorise.Bulma/BulmaClassProvider.cs
@@ -367,6 +367,8 @@ namespace Blazorise.Bulma
 
         public override string DropdownShow() => Active();
 
+        public override string DropdownSubmenu() => null;
+
         public override string DropdownRight() => "is-right";
 
         public override string DropdownItem() => "dropdown-item";
@@ -387,7 +389,7 @@ namespace Blazorise.Bulma
 
         public override string DropdownMenuRight() => null;
 
-        public override string DropdownToggle() => "button dropdown-trigger";
+        public override string DropdownToggle( bool isDropdownSubmenu ) => "button dropdown-trigger";
 
         public override string DropdownToggleColor( Color color ) => $"is-{ToColor( color )}";
 

--- a/Source/Blazorise.Material/Styles/_dropdown.scss
+++ b/Source/Blazorise.Material/Styles/_dropdown.scss
@@ -29,3 +29,36 @@
 .b-is-autocomplete .dropdown-menu:before {
     box-shadow: none;
 }
+
+.dropdown {
+    > .dropdown-menu {
+        > .dropdown {
+            position: relative;
+
+            &::after {
+                transform: rotate(-90deg);
+                position: absolute;
+                right: 6px;
+                top: .8em;
+            }
+
+            > .dropdown-toggle {
+                width: 100%;
+
+                &::after {
+                    transform: rotate(-90deg);
+                    position: absolute;
+                    right: 10%;
+                    top: 45%;
+                }
+            }
+
+            > .dropdown-menu {
+                top: 0;
+                left: 100%;
+                margin-left: 0rem;
+                margin-right: .1rem;
+            }
+        }
+    }
+}

--- a/Source/Blazorise.Material/wwwroot/blazorise.material.css
+++ b/Source/Blazorise.Material/wwwroot/blazorise.material.css
@@ -75,6 +75,26 @@
 .b-is-autocomplete .dropdown-menu:before {
     box-shadow: none; }
 
+.dropdown > .dropdown-menu > .dropdown {
+    position: relative; }
+    .dropdown > .dropdown-menu > .dropdown::after {
+        transform: rotate(-90deg);
+        position: absolute;
+        right: 6px;
+        top: .8em; }
+    .dropdown > .dropdown-menu > .dropdown > .dropdown-toggle {
+        width: 100%; }
+        .dropdown > .dropdown-menu > .dropdown > .dropdown-toggle::after {
+            transform: rotate(-90deg);
+            position: absolute;
+            right: 10%;
+            top: 45%; }
+    .dropdown > .dropdown-menu > .dropdown > .dropdown-menu {
+        top: 0;
+        left: 100%;
+        margin-left: 0rem;
+        margin-right: .1rem; }
+
 .snackbar {
     z-index: 1060 !important; }
 
@@ -109,7 +129,7 @@ input.form-control[type=color] {
     height: 1.75rem;
     /*height: 36px;*/
     line-height: 1.5;
-    padding: 0.26563rem 0 calc(0.26563rem - 1px); }
+    padding: 0.26562rem 0 calc(0.26562rem - 1px); }
     .form-control-sm[type='file'] {
         max-height: 1.75rem; }
 
@@ -150,9 +170,9 @@ input.form-control[type=color] {
 .custom-select-sm {
     font-size: 0.8125rem;
     line-height: 1.5;
-    padding: 0.26563rem 1.5em calc(0.26563rem - 1px) 0; }
+    padding: 0.26562rem 1.5em calc(0.26562rem - 1px) 0; }
     .custom-select-sm[multiple], .custom-select-sm[size]:not([size='1']) {
-        padding: calc(0.76563rem - 1px) 0.75rem; }
+        padding: calc(0.76562rem - 1px) 0.75rem; }
 
 .custom-select-md {
     font-size: 1.25rem;
@@ -1140,7 +1160,7 @@ ol.ordered-list-upper-roman {
             border-color: #9c27b0; }
     .flatpickr-day:hover {
         background: rgba(156, 39, 176, 0.1);
-        border-color: transparent; }
+        border-color: rgba(0, 0, 0, 0); }
 
 span.flatpickr-weekday {
     color: rgba(0, 0, 0, 0.87); }

--- a/Source/Blazorise/Components/Dropdown/Dropdown.razor.cs
+++ b/Source/Blazorise/Components/Dropdown/Dropdown.razor.cs
@@ -46,10 +46,9 @@ namespace Blazorise
         /// <inheritdoc/>
         protected override void BuildClasses( ClassBuilder builder )
         {
-            builder.Append( ClassProvider.Dropdown() );
+            builder.Append( ClassProvider.Dropdown( IsDropdownSubmenu ) );
             builder.Append( ClassProvider.DropdownGroup(), IsGroup );
             builder.Append( ClassProvider.DropdownShow(), Visible );
-            builder.Append( ClassProvider.DropdownSubmenu(), IsDropdownSubmenu );
             builder.Append( ClassProvider.DropdownRight(), RightAligned );
             builder.Append( ClassProvider.DropdownDirection( Direction ), Direction != Direction.Down );
             builder.Append( ClassProvider.DropdownTableResponsive(), InResponsiveTable );

--- a/Source/Blazorise/Components/Dropdown/Dropdown.razor.cs
+++ b/Source/Blazorise/Components/Dropdown/Dropdown.razor.cs
@@ -49,6 +49,7 @@ namespace Blazorise
             builder.Append( ClassProvider.Dropdown() );
             builder.Append( ClassProvider.DropdownGroup(), IsGroup );
             builder.Append( ClassProvider.DropdownShow(), Visible );
+            builder.Append( ClassProvider.DropdownSubmenu(), IsDropdownSubmenu );
             builder.Append( ClassProvider.DropdownRight(), RightAligned );
             builder.Append( ClassProvider.DropdownDirection( Direction ), Direction != Direction.Down );
             builder.Append( ClassProvider.DropdownTableResponsive(), InResponsiveTable );
@@ -235,6 +236,11 @@ namespace Blazorise
         /// Makes the drop down to behave as a group for buttons(used for the split-button behaviour).
         /// </summary>
         protected internal bool IsGroup => ParentButtons != null || buttonList?.Count >= 1;
+
+        /// <summary>
+        /// Returns true if the dropdown is placed inside of another dropdown.
+        /// </summary>
+        protected internal bool IsDropdownSubmenu => ParentDropdown != null;
 
         /// <summary>
         /// Returns true if dropdown is placed inside of responsive table.

--- a/Source/Blazorise/Components/Dropdown/Dropdown.razor.cs
+++ b/Source/Blazorise/Components/Dropdown/Dropdown.razor.cs
@@ -34,26 +34,21 @@ namespace Blazorise
         /// </summary>
         private List<Button> buttonList;
 
-        /// <summary>
-        /// Tracks the last DropdownToggle Element Id that acted.
-        /// </summary>
-        public string SelectedDropdownElementId { get; set; }
+        private Dropdown childDroopdown;
 
         #endregion
 
-        #region Methods        
+        #region Methods
 
         /// <inheritdoc/>
-        protected override void BuildClasses( ClassBuilder builder )
+        protected override void OnInitialized()
         {
-            builder.Append( ClassProvider.Dropdown( IsDropdownSubmenu ) );
-            builder.Append( ClassProvider.DropdownGroup(), IsGroup );
-            builder.Append( ClassProvider.DropdownShow(), Visible );
-            builder.Append( ClassProvider.DropdownRight(), RightAligned );
-            builder.Append( ClassProvider.DropdownDirection( Direction ), Direction != Direction.Down );
-            builder.Append( ClassProvider.DropdownTableResponsive(), InResponsiveTable );
+            if ( ParentDropdown != null )
+            {
+                ParentDropdown.NotifyChildDropdownInitialized( this );
+            }
 
-            base.BuildClasses( builder );
+            base.OnInitialized();
         }
 
         /// <inheritdoc/>
@@ -70,6 +65,33 @@ namespace Blazorise
             WasJustToggled = false;
 
             base.OnAfterRender( firstRender );
+        }
+
+        /// <inheritdoc/>
+        protected override void BuildClasses( ClassBuilder builder )
+        {
+            builder.Append( ClassProvider.Dropdown( IsDropdownSubmenu ) );
+            builder.Append( ClassProvider.DropdownGroup(), IsGroup );
+            builder.Append( ClassProvider.DropdownShow(), Visible );
+            builder.Append( ClassProvider.DropdownRight(), RightAligned );
+            builder.Append( ClassProvider.DropdownDirection( Direction ), Direction != Direction.Down );
+            builder.Append( ClassProvider.DropdownTableResponsive(), InResponsiveTable );
+
+            base.BuildClasses( builder );
+        }
+
+        /// <inheritdoc/>
+        protected override void Dispose( bool disposing )
+        {
+            if ( disposing )
+            {
+                if ( ParentDropdown != null )
+                {
+                    ParentDropdown.NotifyChildDropdownRemoved( this );
+                }
+            }
+
+            base.Dispose( disposing );
         }
 
         /// <summary>
@@ -107,17 +129,6 @@ namespace Blazorise
         }
 
         /// <summary>
-        /// Keeps track whether the Dropdown is in a state where it should close.
-        /// </summary>
-        internal bool ShouldClose { get; set; } = false;
-
-        /// <summary>
-        /// Keeps track whether the Dropdown was just toggled, ignoring possible DropdownItem clicks which would otherwise close the dropdown.
-        /// </summary>
-        internal bool WasJustToggled { get; set; } = false;
-
-
-        /// <summary>
         /// Handles the onmouseleave event.
         /// </summary>
         /// <returns>A task that represents the asynchronous operation.</returns>
@@ -125,7 +136,6 @@ namespace Blazorise
         {
             ShouldClose = true;
         }
-
 
         /// <summary>
         /// Handles the onmouseenter event.
@@ -199,6 +209,25 @@ namespace Blazorise
         }
 
         /// <summary>
+        /// Notifies the <see cref="Dropdown"/> that it has a child dropdown component.
+        /// </summary>
+        /// <param name="dropdown">Reference to the <see cref="Dropdown"/> that is placed inside of this <see cref="Dropdown"/>.</param>
+        internal void NotifyChildDropdownInitialized( Dropdown dropdown )
+        {
+            if ( childDroopdown == null )
+                childDroopdown = dropdown;
+        }
+
+        /// <summary>
+        /// Notifies the <see cref="Dropdown"/> that it's a child dropdown component should be removed.
+        /// </summary>
+        /// <param name="dropdown">Reference to the <see cref="Dropdown"/> that is placed inside of this <see cref="Dropdown"/>.</param>
+        internal void NotifyChildDropdownRemoved( Dropdown dropdown )
+        {
+            childDroopdown = null;
+        }
+
+        /// <summary>
         /// Handles the styles based on the visibility flag.
         /// </summary>
         /// <param name="visible">Dropdown menu visibility flag.</param>
@@ -223,6 +252,16 @@ namespace Blazorise
 
         #region Properties
 
+        /// <summary>
+        /// Keeps track whether the Dropdown is in a state where it should close.
+        /// </summary>
+        internal bool ShouldClose { get; set; } = false;
+
+        /// <summary>
+        /// Keeps track whether the Dropdown was just toggled, ignoring possible DropdownItem clicks which would otherwise close the dropdown.
+        /// </summary>
+        internal bool WasJustToggled { get; set; } = false;
+
         /// <inheritdoc/>
         protected override bool ShouldAutoGenerateId => true;
 
@@ -242,9 +281,19 @@ namespace Blazorise
         protected internal bool IsDropdownSubmenu => ParentDropdown != null;
 
         /// <summary>
+        /// Returns true if this dropdown contains any child dropdown.
+        /// </summary>
+        protected internal bool HasSubmenu => childDroopdown != null;
+
+        /// <summary>
         /// Returns true if dropdown is placed inside of responsive table.
         /// </summary>
         protected internal bool InResponsiveTable => ParentTable?.Responsive == true;
+
+        /// <summary>
+        /// Tracks the last DropdownToggle Element Id that acted.
+        /// </summary>
+        public string SelectedDropdownElementId { get; set; }
 
         /// <summary>
         /// If true, a dropdown menu will be visible.

--- a/Source/Blazorise/Components/Dropdown/DropdownToggle.razor.cs
+++ b/Source/Blazorise/Components/Dropdown/DropdownToggle.razor.cs
@@ -52,7 +52,7 @@ namespace Blazorise
         /// <inheritdoc/>
         protected override void BuildClasses( ClassBuilder builder )
         {
-            builder.Append( ClassProvider.DropdownToggle() );
+            builder.Append( ClassProvider.DropdownToggle( ParentDropdown?.IsDropdownSubmenu == true ) );
             builder.Append( ClassProvider.DropdownToggleColor( Color ), Color != Color.None && !Outline );
             builder.Append( ClassProvider.DropdownToggleOutline( Color ), Color != Color.None && Outline );
             builder.Append( ClassProvider.DropdownToggleSize( ThemeSize ), ThemeSize != Blazorise.Size.None );

--- a/Source/Blazorise/Interfaces/IClassProvider.cs
+++ b/Source/Blazorise/Interfaces/IClassProvider.cs
@@ -325,13 +325,11 @@ namespace Blazorise
 
         #region Dropdown
 
-        string Dropdown();
+        string Dropdown( bool isDropdownSubmenu );
 
         string DropdownGroup();
 
         string DropdownShow();
-
-        string DropdownSubmenu();
 
         string DropdownRight();
 

--- a/Source/Blazorise/Interfaces/IClassProvider.cs
+++ b/Source/Blazorise/Interfaces/IClassProvider.cs
@@ -331,6 +331,8 @@ namespace Blazorise
 
         string DropdownShow();
 
+        string DropdownSubmenu();
+
         string DropdownRight();
 
         string DropdownItem();
@@ -351,7 +353,7 @@ namespace Blazorise
 
         string DropdownMenuRight();
 
-        string DropdownToggle();
+        string DropdownToggle( bool isDropdownSubmenu );
 
         string DropdownToggleColor( Color color );
 

--- a/Source/Blazorise/Providers/ClassProvider.cs
+++ b/Source/Blazorise/Providers/ClassProvider.cs
@@ -332,6 +332,8 @@ namespace Blazorise
 
         public abstract string DropdownShow();
 
+        public abstract string DropdownSubmenu();
+
         public abstract string DropdownRight();
 
         public abstract string DropdownItem();
@@ -352,7 +354,7 @@ namespace Blazorise
 
         public abstract string DropdownMenuRight();
 
-        public abstract string DropdownToggle();
+        public abstract string DropdownToggle( bool isDropdownSubmenu );
 
         public abstract string DropdownToggleColor( Color color );
 

--- a/Source/Blazorise/Providers/ClassProvider.cs
+++ b/Source/Blazorise/Providers/ClassProvider.cs
@@ -326,13 +326,11 @@ namespace Blazorise
 
         #region Dropdown
 
-        public abstract string Dropdown();
+        public abstract string Dropdown( bool isDropdownSubmenu );
 
         public abstract string DropdownGroup();
 
         public abstract string DropdownShow();
-
-        public abstract string DropdownSubmenu();
 
         public abstract string DropdownRight();
 

--- a/Source/Blazorise/Providers/EmptyClassProvider.cs
+++ b/Source/Blazorise/Providers/EmptyClassProvider.cs
@@ -333,6 +333,8 @@ namespace Blazorise.Providers
 
         public string DropdownShow() => null;
 
+        public string DropdownSubmenu() => null;
+
         public string DropdownRight() => null;
 
         public string DropdownItem() => null;
@@ -353,7 +355,7 @@ namespace Blazorise.Providers
 
         public string DropdownMenuRight() => null;
 
-        public string DropdownToggle() => null;
+        public string DropdownToggle( bool isDropdownSubmenu ) => null;
 
         public string DropdownToggleColor( Color color ) => null;
 

--- a/Source/Blazorise/Providers/EmptyClassProvider.cs
+++ b/Source/Blazorise/Providers/EmptyClassProvider.cs
@@ -327,13 +327,11 @@ namespace Blazorise.Providers
 
         #region Dropdown
 
-        public string Dropdown() => null;
+        public string Dropdown( bool isDropdownSubmenu ) => null;
 
         public string DropdownGroup() => null;
 
         public string DropdownShow() => null;
-
-        public string DropdownSubmenu() => null;
 
         public string DropdownRight() => null;
 


### PR DESCRIPTION
This PR adds several improvements

- Places sub-Dropdown on the same level as sibling DropdownItem
- Custom CSS to adjust submenus next to the toggle button
- No need for `Direction="Direction.Right"`

I probably need to remove `.dropdown-submenu` but I will leave it until we settle for the final version.

Example

```cshtml
<Dropdown>
    <DropdownToggle Color="Color.Primary">Level 1</DropdownToggle>
    <DropdownMenu>
        <DropdownItem>Item 1.1</DropdownItem>
        <Dropdown Direction="Direction.Right">
            <DropdownToggle>Level 2</DropdownToggle>
            <DropdownMenu>
                <DropdownItem>Item 2.1</DropdownItem>
                <DropdownItem>Item 2.2</DropdownItem>
                <Dropdown Direction="Direction.Right">
                    <DropdownToggle>Level 3</DropdownToggle>
                    <DropdownMenu>
                        <DropdownItem>Item 3.1</DropdownItem>
                        <DropdownItem>Item 3.2</DropdownItem>
                        <Dropdown Direction="Direction.Right">
                            <DropdownToggle>Level 4</DropdownToggle>
                            <DropdownMenu>
                                <DropdownItem>Item 4.1</DropdownItem>
                                <DropdownItem>Item 4.2</DropdownItem>
                            </DropdownMenu>
                        </Dropdown>
                    </DropdownMenu>
                </Dropdown>
            </DropdownMenu>
        </Dropdown>
    </DropdownMenu>
</Dropdown>
```