### PR TITLE
Numeric Min and Max of TValue

### DIFF
--- a/Source/Blazorise/Components/NumericEdit/NumericEdit.razor.cs
+++ b/Source/Blazorise/Components/NumericEdit/NumericEdit.razor.cs
@@ -92,7 +92,9 @@ namespace Blazorise
                 Separator = DecimalsSeparator,
                 Step,
                 Min = Min.IsEqual( default ) ? minFromType : Min,
-                Max = Max.IsEqual( default ) ? maxFromType : Max
+                Max = Max.IsEqual( default ) ? maxFromType : Max,
+                TypeMin = minFromType,
+                TypeMax = maxFromType
             } );
 
             await base.OnFirstAfterRenderAsync();

--- a/Source/Blazorise/Components/NumericEdit/NumericEdit.razor.cs
+++ b/Source/Blazorise/Components/NumericEdit/NumericEdit.razor.cs
@@ -238,7 +238,9 @@ namespace Blazorise
             // make sure that null values also starts from zero
             value ??= Converters.ChangeType<TValue>( 0 );
 
-            return MathUtils<TValue>.Add( value, Converters.ChangeType<TValue>( Step.GetValueOrDefault( 1 ) * sign ) );
+            return sign > 0
+                ? MathUtils<TValue>.Add( value, Converters.ChangeType<TValue>( Step.GetValueOrDefault( 1 ) ) )
+                : MathUtils<TValue>.Subtract( value, Converters.ChangeType<TValue>( Step.GetValueOrDefault( 1 ) ) );
         }
 
         /// <summary>

--- a/Source/Blazorise/Components/NumericEdit/NumericEdit.razor.cs
+++ b/Source/Blazorise/Components/NumericEdit/NumericEdit.razor.cs
@@ -91,8 +91,8 @@ namespace Blazorise
                 Decimals,
                 Separator = DecimalsSeparator,
                 Step,
-                Min = Min.IsEqual( default ) ? minFromType : Min,
-                Max = Max.IsEqual( default ) ? maxFromType : Max,
+                Min = MinDefined ? (object)Min : null,
+                Max = MaxDefined ? (object)Max : null,
                 TypeMin = minFromType,
                 TypeMax = maxFromType
             } );

--- a/Source/Blazorise/wwwroot/blazorise.js
+++ b/Source/Blazorise/wwwroot/blazorise.js
@@ -732,44 +732,33 @@ window.blazorise = {
             let value = this.element.value,
                 selection = this.carret();
 
-            function toFixed(x) {
-                var result = '';
-                var xStr = x.toString(10);
-                var digitCount = xStr.indexOf('e') === -1 ? xStr.length : (parseInt(xStr.substr(xStr.indexOf('e') + 1)) + 1);
-
-                for (var i = 1; i <= digitCount; i++) {
-                    var mod = (x % Math.pow(10, i)).toString(10);
-                    var exponent = (mod.indexOf('e') === -1) ? 0 : parseInt(mod.substr(mod.indexOf('e') + 1));
-                    if ((exponent === 0 && mod.length !== i) || (exponent > 0 && exponent !== i - 1)) {
-                        result = '0' + result;
-                    }
-                    else {
-                        result = mod.charAt(0) + result;
-                    }
-                }
-                return result;
-            };
-
             if (value = value.substring(0, selection[0]) + currentValue + value.substring(selection[1]), !!this.regex().test(value)) {
+
                 value = (value || "").replace(this.separator, ".");
+
+                // Now that we know the number is valid we also need to make sure it can fit in the min-max range ot the TValue type.
                 let number = Number(value);
 
                 if (number > this.typeMax) {
-                    number = this.typeMax;
-                    value = toFixed(number);
+                    value = this.toFixed(this.typeMax);
+
+                    // Update input with new value and also make sure that Blazor knows it is changed.
                     this.element.value = value;
                     this.dotnetAdapter.invokeMethodAsync('SetValue', this.element.value);
-                    return false;
+
+                    return false; // This will make it fail the validation and do the preventDefault().
                 }
                 else if (number < this.typeMin) {
-                    number = this.typeMin;
-                    value = toFixed(number);
+                    value = this.toFixed(this.typeMin);
+
+                    // Update input with new value and also make sure that Blazor knows it is changed.
                     this.element.value = value;
                     this.dotnetAdapter.invokeMethodAsync('SetValue', this.element.value);
-                    return false;
+
+                    return false; // This will make it fail the validation and do the preventDefault().
                 }
 
-                return true;
+                return value;
             }
 
             return false;
@@ -780,6 +769,24 @@ window.blazorise = {
 
                 this.truncate();
             }
+        };
+        this.toFixed = function (number) {
+            var result = '';
+            var xStr = number.toString(10);
+            var digitCount = xStr.indexOf('e') === -1 ? xStr.length : (parseInt(xStr.substr(xStr.indexOf('e') + 1)) + 1);
+
+            for (var i = 1; i <= digitCount; i++) {
+                var mod = (number % Math.pow(10, i)).toString(10);
+                var exponent = (mod.indexOf('e') === -1) ? 0 : parseInt(mod.substr(mod.indexOf('e') + 1));
+                if ((exponent === 0 && mod.length !== i) || (exponent > 0 && exponent !== i - 1)) {
+                    result = '0' + result;
+                }
+                else {
+                    result = mod.charAt(0) + result;
+                }
+            }
+
+            return result;
         };
         this.truncate = function () {
             let value = (this.element.value || "").replace(this.separator, ".");


### PR DESCRIPTION
resolves #2876 Numeric value does not handle values too low or too high for type TValue

This PR tries to resolve the problem when we type a numeric value that is larger or smaller than the TValue can hold, eg. for `int` max value is 2147483647. The problem is that we handle numeric validations in JS and even if it passes, it will fail on the C# part once we try to parse it. Thing is, we shouldn't be able to write anything above max or min.

My approach is to handle the min and max of the actual type in JS. And if it fails it will prevent the input and replace the entered value with the min or max, depending on what failed. I'm still not sure if this is the right way but I don't have any other idea at the moment.

It is still ugly as it is just a concept. All unit tests are passing so in theory it shouldn't break people's code. 🤞

```cshtml
<CardBody>
    <div>
        byte: @ByteValue
    </div>
    <NumericEdit TValue="byte?" @bind-Value="ByteValue" Min="10" Max="20" />

    @code {
    byte? ByteValue;
    }
</CardBody>
<CardBody>
    <div>
        int? @NumericValue
    </div>
    <NumericEdit TValue="int?" @bind-Value="NumericValue" />

    @code
    {
    int? NumericValue;
    }
</CardBody>
<CardBody>
    <div>
        long? @LongValue
    </div>
    <NumericEdit TValue="long?" @bind-Value="LongValue" />

    @code
    {
    long? LongValue;
    }
</CardBody>
<CardBody>
    <div>
        decimal? @DecimalValue
    </div>
    <NumericEdit TValue="decimal?" @bind-Value="DecimalValue" Min="10" Max="20" />

    @code
    {
    decimal? DecimalValue;
    }
</CardBody>
```