### PR TITLE
Autocomplete selected text bug fix

### DIFF
--- a/Demos/Blazorise.Demo/Pages/Tests/ComponentsPage.razor
+++ b/Demos/Blazorise.Demo/Pages/Tests/ComponentsPage.razor
@@ -42,13 +42,12 @@
                                       TValue="string"
                                       Data="@myDdlData"
                                       TextField="@(( item ) => item.MyTextField)"
-                                      ValueField="@(( item ) => item.MyTextField)"
-                                      SelectedValue="@selectedSearchValue"
-                                      SelectedValueChanged="@MySearchHandler"
+                                      ValueField="@(( item ) => item.MyValueField.ToString())"
+                                      @bind-SelectedValue="selectedSearchValue"
                                       @bind-SelectedText="selectedAutoCompleteText"
                                       Placeholder="Search..."
                                       Filter="AutocompleteFilter.StartsWith"
-                                      FreeTyping="true"
+                                      FreeTyping
                                       CustomFilter="@(( item, searchValue ) => item.MyTextField.IndexOf( searchValue, 0, StringComparison.CurrentCultureIgnoreCase ) >= 0 )">
                             <NotFoundContent> Sorry... @context was not found! :( </NotFoundContent>
                         </Autocomplete>
@@ -163,11 +162,6 @@
     void MyDropValueChangedHandler( int newValue )
     {
         selectedDropValue = newValue;
-    }
-
-    void MySearchHandler( string newValue )
-    {
-        selectedSearchValue = newValue;
     }
 
     private void ShuffleList()

--- a/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
+++ b/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
@@ -50,6 +50,26 @@ namespace Blazorise.Components
 
         #region Methods
 
+        public override async Task SetParametersAsync( ParameterView parameters )
+        {
+            var selectedValueHasChanged = parameters.TryGetValue<TValue>( nameof( SelectedValue ), out var paramSelectedValue ) 
+                && !paramSelectedValue.IsEqual( SelectedValue );
+            
+            await base.SetParametersAsync( parameters );
+
+            // Override after parameters have already been set.
+            // Avoids property setters running out of order
+            if ( selectedValueHasChanged )
+            {
+                var item = GetItemByValue( paramSelectedValue );
+                SelectedText = item != null
+                    ? TextField?.Invoke( item )
+                    : string.Empty;
+                await SelectedTextChanged.InvokeAsync( SelectedText );
+            }
+
+        }
+
         /// <summary>
         /// Handles the search field onchange or oninput event.
         /// </summary>
@@ -247,6 +267,11 @@ namespace Blazorise.Components
             textEditRef.Focus( scrollToElement );
         }
 
+        private TItem GetItemByValue( TValue value )
+            => Data != null
+                   ? Data.FirstOrDefault( x => ValueField( x ).IsEqual( value ) )
+                   : default;
+
         #endregion
 
         #region Properties
@@ -419,10 +444,6 @@ namespace Blazorise.Components
                     return;
 
                 selectedValue = value;
-
-                var item = Data != null
-                    ? Data.FirstOrDefault( x => ValueField( x ).IsEqual( value ) )
-                    : default;
             }
         }
 

--- a/Tests/BasicTestApp.Client/AutocompleteComponent.razor
+++ b/Tests/BasicTestApp.Client/AutocompleteComponent.razor
@@ -1,0 +1,28 @@
+﻿<Autocomplete TItem="MySelectModel"
+                TValue="int"
+                Data="@myDdlData"
+                TextField="@(( item ) => item.MyTextField)"
+                ValueField="@(( item ) => item.MyValueField)"
+                @bind-SelectedValue="selectedSearchValue"
+                @bind-SelectedText="selectedAutoCompleteText"
+                Placeholder="Search..."
+                FreeTyping>
+    <NotFoundContent> Sorry... @context was not found! :( </NotFoundContent>
+</Autocomplete>
+
+@code{
+    public class MySelectModel
+    {
+        public int MyValueField { get; set; }
+        public string MyTextField { get; set; }
+    }
+
+    static string[] Countries = { "Albania", "Andorra", "Armenia", "Austria", "Azerbaijan", "Belarus", "Belgium", "Bosnia & Herzegovina", "Bulgaria", "Croatia", "Cyprus", "Czech Republic", "Denmark", "Estonia", "Finland", "France", "Georgia", "Germany", "Greece", "Hungary", "Iceland", "Ireland", "Italy", "Kosovo", "Latvia", "Liechtenstein", "Lithuania", "Luxembourg", "Macedonia", "Malta", "Moldova", "Monaco", "Montenegro", "Netherlands", "Norway", "Poland", "Portugal", "Romania", "Russia", "San Marino", "Serbia", "Slovakia", "Slovenia", "Spain", "Sweden", "Switzerland", "Turkey", "Ukraine", "United Kingdom", "Vatican City" };
+    IEnumerable<MySelectModel> myDdlData = Enumerable.Range( 1, Countries.Length ).Select( x => new MySelectModel { MyTextField = Countries[x - 1], MyValueField = x } );
+
+    [Parameter]
+    public int selectedSearchValue { get; set; } = 2;
+
+    [Parameter]
+    public string selectedAutoCompleteText { get; set; }
+}

--- a/Tests/BasicTestApp.Client/BasicTestApp.Client.csproj
+++ b/Tests/BasicTestApp.Client/BasicTestApp.Client.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Source\Blazorise.Bootstrap\Blazorise.Bootstrap.csproj" />
     <ProjectReference Include="..\..\Source\Blazorise\Blazorise.csproj" />
+    <ProjectReference Include="..\..\Source\Extensions\Blazorise.Components\Blazorise.Components.csproj" />
     <ProjectReference Include="..\..\Source\Extensions\Blazorise.Icons.FontAwesome\Blazorise.Icons.FontAwesome.csproj" />
   </ItemGroup>
 

--- a/Tests/BasicTestApp.Client/_Imports.razor
+++ b/Tests/BasicTestApp.Client/_Imports.razor
@@ -1,3 +1,4 @@
 @using Microsoft.AspNetCore.Components.Rendering
 @using Microsoft.AspNetCore.Components.Web
 @using Blazorise
+@using Blazorise.Components

--- a/Tests/Blazorise.Tests/Components/AutoCompleteComponentTest.cs
+++ b/Tests/Blazorise.Tests/Components/AutoCompleteComponentTest.cs
@@ -1,0 +1,57 @@
+﻿#region Using directives
+using BasicTestApp.Client;
+using Blazorise.Tests.Helpers;
+using Bunit;
+using Xunit;
+#endregion
+
+namespace Blazorise.Tests.Components
+{
+    public class AutoCompleteComponentTest : TestContext
+    {
+        public AutoCompleteComponentTest()
+        {
+            BlazoriseConfig.AddBootstrapProviders( Services );
+        }
+
+
+        [Fact]
+        public void InitialSelectedValue_ShouldSet_SelectedText()
+        {
+            // setup
+            var comp = RenderComponent<AutocompleteComponent>();
+            var selectedText = comp.Instance.selectedAutoCompleteText;
+            var expectedSelectedText = "Andorra";
+
+            // test
+            var input = comp.Find( ".b-is-autocomplete input" );
+            var inputText = input.InnerHtml;
+
+            // validate
+            Assert.Equal( expectedSelectedText, selectedText );
+            Assert.Equal( expectedSelectedText, inputText );
+        }
+
+        [Theory]
+        [InlineData(2,"Andorra")]
+        [InlineData( 1, "Albania" )]
+        [InlineData(8, "Bosnia & Herzegovina" )]
+        public void ProgramaticallySetSelectedValue_ShouldSet_SelectedText(int selectedValue, string expectedSelectedText )
+        {
+            // setup
+            var comp = RenderComponent<AutocompleteComponent>(
+                 parameters  =>
+                    parameters.Add(x=> x.selectedSearchValue, selectedValue) );
+
+            var selectedText = comp.Instance.selectedAutoCompleteText;
+
+            // test
+            var input = comp.Find( ".b-is-autocomplete input" );
+            var inputText = input.InnerHtml;
+
+            // validate
+            Assert.Equal( expectedSelectedText, selectedText );
+            Assert.Equal( expectedSelectedText, inputText );
+        }
+    }
+}

--- a/Tests/Blazorise.Tests/Components/AutoCompleteComponentTest.cs
+++ b/Tests/Blazorise.Tests/Components/AutoCompleteComponentTest.cs
@@ -3,6 +3,7 @@ using BasicTestApp.Client;
 using Blazorise.Tests.Helpers;
 using Bunit;
 using Xunit;
+using static System.Net.Mime.MediaTypeNames;
 #endregion
 
 namespace Blazorise.Tests.Components
@@ -25,29 +26,28 @@ namespace Blazorise.Tests.Components
 
             // test
             var input = comp.Find( ".b-is-autocomplete input" );
-            var inputText = input.InnerHtml;
-
+            var inputText = input.GetAttribute( "value" );
             // validate
             Assert.Equal( expectedSelectedText, selectedText );
             Assert.Equal( expectedSelectedText, inputText );
         }
 
         [Theory]
-        [InlineData(2,"Andorra")]
+        [InlineData( 2, "Andorra" )]
         [InlineData( 1, "Albania" )]
-        [InlineData(8, "Bosnia & Herzegovina" )]
-        public void ProgramaticallySetSelectedValue_ShouldSet_SelectedText(int selectedValue, string expectedSelectedText )
+        [InlineData( 8, "Bosnia & Herzegovina" )]
+        public void ProgramaticallySetSelectedValue_ShouldSet_SelectedText( int selectedValue, string expectedSelectedText )
         {
             // setup
             var comp = RenderComponent<AutocompleteComponent>(
-                 parameters  =>
-                    parameters.Add(x=> x.selectedSearchValue, selectedValue) );
+                 parameters =>
+                    parameters.Add( x => x.selectedSearchValue, selectedValue ) );
 
             var selectedText = comp.Instance.selectedAutoCompleteText;
 
             // test
             var input = comp.Find( ".b-is-autocomplete input" );
-            var inputText = input.InnerHtml;
+            var inputText = input.GetAttribute( "value" );
 
             // validate
             Assert.Equal( expectedSelectedText, selectedText );


### PR DESCRIPTION
Closes #2991
Closes #2879
Closes #2993

I had infact removed 
```
SelectedText = item != null
    ? TextField?.Invoke( item )
    : string.Empty;
```
incorrectly like reported in #2991 

However, by reintroducing it, there would still be a minor bug, that when both `SelectedValue` and `SelectedText` are bound to `Autocomplete`. The `SelectedText` setter would run after the `SelectedValue` setter and set `SelectedText` to null (or whatever is set in the parameter initially) causing incoherent behaviour. So I moved the logic to `SetParametersAsync`.

Also introduced tests to support the PR, and will most likelly do so going forward so we start getting better coverage and can hopefully diminish the bugs caused by introducing new features.