### PR TITLE
Expose DI types of Blazorise services

### DIFF
--- a/Source/Blazorise/Config.cs
+++ b/Source/Blazorise/Config.cs
@@ -1,5 +1,7 @@
 ﻿#region Using directives
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Blazorise.Localization;
 using Blazorise.Modules;
 using Blazorise.Providers;
@@ -28,48 +30,80 @@ namespace Blazorise
             serviceCollection.Replace( ServiceDescriptor.Transient<IComponentActivator, ComponentActivator>() );
 
             // If options handler is not defined we will get an exception so
-            // we need to initialize and empty action.
+            // we need to initialize an empty action.
             configureOptions ??= _ => { };
 
             serviceCollection.AddSingleton( configureOptions );
             serviceCollection.AddSingleton<BlazoriseOptions>();
             serviceCollection.AddSingleton<IVersionProvider, VersionProvider>();
-
             serviceCollection.AddSingleton<IIdGenerator, IdGenerator>();
             serviceCollection.AddSingleton<IThemeCache, ThemeCache>();
             serviceCollection.AddSingleton<IValidationMessageLocalizerAttributeFinder, ValidationMessageLocalizerAttributeFinder>();
-            serviceCollection.AddScoped<IEditContextValidator, EditContextValidator>();
-
-            serviceCollection.AddScoped<ITextLocalizerService, TextLocalizerService>();
-            serviceCollection.AddScoped( typeof( ITextLocalizer<> ), typeof( TextLocalizer<> ) );
-
-            serviceCollection.AddScoped<IValidationHandlerFactory, ValidationHandlerFactory>();
-            serviceCollection.AddScoped<ValidatorValidationHandler>();
-            serviceCollection.AddScoped<PatternValidationHandler>();
-            serviceCollection.AddScoped<DataAnnotationValidationHandler>();
-            serviceCollection.AddScoped<IMessageService, MessageService>();
-            serviceCollection.AddScoped<INotificationService, NotificationService>();
-            serviceCollection.AddScoped<IPageProgressService, PageProgressService>();
-
             serviceCollection.AddSingleton<IDateTimeFormatConverter, DateTimeFormatConverter>();
 
-            serviceCollection.AddScoped<IJSUtilitiesModule, JSUtilitiesModule>();
-            serviceCollection.AddScoped<IJSButtonModule, JSButtonModule>();
-            serviceCollection.AddScoped<IJSClosableModule, JSClosableModule>();
-            serviceCollection.AddScoped<IJSBreakpointModule, JSBreakpointModule>();
-            serviceCollection.AddScoped<IJSTextEditModule, JSTextEditModule>();
-            serviceCollection.AddScoped<IJSMemoEditModule, JSMemoEditModule>();
-            serviceCollection.AddScoped<IJSNumericEditModule, JSNumericEditModule>();
-            serviceCollection.AddScoped<IJSDatePickerModule, JSDatePickerModule>();
-            serviceCollection.AddScoped<IJSTimePickerModule, JSTimePickerModule>();
-            serviceCollection.AddScoped<IJSColorPickerModule, JSColorPickerModule>();
-            serviceCollection.AddScoped<IJSFileEditModule, JSFileEditModule>();
-            serviceCollection.AddScoped<IJSFileModule, JSFileModule>();
-            serviceCollection.AddScoped<IJSTableModule, JSTableModule>();
-            serviceCollection.AddScoped<IJSSelectModule, JSSelectModule>();
+            foreach ( var mapping in LocalizationMap
+                .Concat( ValidationMap )
+                .Concat( ServiceMap )
+                .Concat( JSModuleMap ) )
+            {
+
+                serviceCollection.AddScoped( mapping.Key, mapping.Value );
+            }
 
             return serviceCollection;
         }
+
+        /// <summary>
+        /// Gets the list of localization services that are ready for DI registration.
+        /// </summary>
+        public static IDictionary<Type, Type> LocalizationMap => new Dictionary<Type, Type>
+        {
+            { typeof( ITextLocalizerService ), typeof( TextLocalizerService ) },
+            { typeof( ITextLocalizer<> ), typeof( TextLocalizer<> ) },
+        };
+
+        /// <summary>
+        /// Gets the list of validation handlers and services that are ready for DI registration.
+        /// </summary>
+        public static IDictionary<Type, Type> ValidationMap => new Dictionary<Type, Type>
+        {
+            { typeof( IEditContextValidator ), typeof( EditContextValidator ) },
+            { typeof( IValidationHandlerFactory ), typeof( ValidationHandlerFactory ) },
+            { typeof( ValidatorValidationHandler ), typeof( ValidatorValidationHandler ) },
+            { typeof( PatternValidationHandler ), typeof( PatternValidationHandler ) },
+            { typeof( DataAnnotationValidationHandler ), typeof( DataAnnotationValidationHandler ) },
+        };
+
+        /// <summary>
+        /// Gets the list of services that are ready for DI registration.
+        /// </summary>
+        public static IDictionary<Type, Type> ServiceMap => new Dictionary<Type, Type>
+        {
+            { typeof( IMessageService ), typeof( MessageService ) },
+            { typeof( INotificationService ), typeof( NotificationService ) },
+            { typeof( IPageProgressService ), typeof( PageProgressService ) },
+        };
+
+        /// <summary>
+        /// Gets the list of JS modules that are ready for DI registration.
+        /// </summary>
+        public static IDictionary<Type, Type> JSModuleMap => new Dictionary<Type, Type>
+        {
+            { typeof( IJSUtilitiesModule ), typeof( JSUtilitiesModule ) },
+            { typeof( IJSButtonModule ), typeof( JSButtonModule ) },
+            { typeof( IJSClosableModule ), typeof( JSClosableModule ) },
+            { typeof( IJSBreakpointModule ), typeof( JSBreakpointModule ) },
+            { typeof( IJSTextEditModule ), typeof( JSTextEditModule ) },
+            { typeof( IJSMemoEditModule ), typeof( JSMemoEditModule ) },
+            { typeof( IJSNumericEditModule ), typeof( JSNumericEditModule ) },
+            { typeof( IJSDatePickerModule ), typeof( JSDatePickerModule ) },
+            { typeof( IJSTimePickerModule ), typeof( JSTimePickerModule ) },
+            { typeof( IJSColorPickerModule ), typeof( JSColorPickerModule ) },
+            { typeof( IJSFileEditModule ), typeof( JSFileEditModule ) },
+            { typeof( IJSFileModule ), typeof( JSFileModule ) },
+            { typeof( IJSTableModule ), typeof( JSTableModule ) },
+            { typeof( IJSSelectModule ), typeof( JSSelectModule ) },
+        };
 
         /// <summary>
         /// Registers an empty providers.


### PR DESCRIPTION
closes #2696 Scoped Services causes issues with Blazor in Maui

Instead of adding the `RegisterScopedAsSingleton` into `BlazoriseOptions`, I have decided to expose all the types themselves. This has the benefit of re-registering them based on the needs and project specifics.

Exposed types are defined as dictionaries and are separated into different categories:

- LocalizationMap
- ValidationMap
- ServiceMap
- JSModuleMap

They are located under the `Blazorise.Config.*`.