### PR TITLE
Dispose refactoring

### DIFF
--- a/Source/Blazorise.AntDesign/ModalContent.razor.cs
+++ b/Source/Blazorise.AntDesign/ModalContent.razor.cs
@@ -1,11 +1,12 @@
 ﻿#region Using directives
+using System;
 using System.Threading.Tasks;
 using Blazorise.Utilities;
 #endregion
 
 namespace Blazorise.AntDesign
 {
-    public partial class ModalContent : Blazorise.ModalContent
+    public partial class ModalContent : Blazorise.ModalContent, IDisposable, IAsyncDisposable
     {
         #region Members
 

--- a/Source/Blazorise.AntDesign/ModalContent.razor.cs
+++ b/Source/Blazorise.AntDesign/ModalContent.razor.cs
@@ -6,7 +6,7 @@ using Blazorise.Utilities;
 
 namespace Blazorise.AntDesign
 {
-    public partial class ModalContent : Blazorise.ModalContent, IDisposable, IAsyncDisposable
+    public partial class ModalContent : Blazorise.ModalContent, IDisposable
     {
         #region Members
 
@@ -35,26 +35,10 @@ namespace Blazorise.AntDesign
         {
             if ( disposing )
             {
-                DisposeResources();
+                ParentModal?.NotifyCloseActivatorIdRemoved( WrapperElementId );
             }
 
             base.Dispose( disposing );
-        }
-
-        /// <inheritdoc/>
-        protected override ValueTask DisposeAsync( bool disposing )
-        {
-            if ( disposing )
-            {
-                DisposeResources();
-            }
-
-            return base.DisposeAsync( disposing );
-        }
-
-        private void DisposeResources()
-        {
-            ParentModal.NotifyCloseActivatorIdRemoved( WrapperElementId );
         }
 
         protected internal override void DirtyClasses()

--- a/Source/Blazorise.AntDesign/Select.razor.cs
+++ b/Source/Blazorise.AntDesign/Select.razor.cs
@@ -13,7 +13,7 @@ using Microsoft.JSInterop;
 
 namespace Blazorise.AntDesign
 {
-    public partial class Select<TValue> : Blazorise.Select<TValue>, ICloseActivator
+    public partial class Select<TValue> : Blazorise.Select<TValue>, ICloseActivator, IAsyncDisposable
     {
         #region Members
 

--- a/Source/Blazorise.AntDesign/Select.razor.cs
+++ b/Source/Blazorise.AntDesign/Select.razor.cs
@@ -52,18 +52,18 @@ namespace Blazorise.AntDesign
             await InvokeAsync( StateHasChanged );
         }
 
-        protected override ValueTask DisposeAsync( bool disposing )
+        protected override async ValueTask DisposeAsync( bool disposing )
         {
             if ( disposing && Rendered )
             {
                 // TODO: switch to IAsyncDisposable
-                _ = JSClosableModule.Unregister( this );
+                await JSClosableModule.Unregister( this );
 
                 DisposeDotNetObjectRef( dotNetObjectRef );
                 dotNetObjectRef = null;
             }
 
-            return base.DisposeAsync( disposing );
+            await base.DisposeAsync( disposing );
         }
 
         protected Task OnSelectorClickHandler()

--- a/Source/Blazorise/Base/BaseAfterRenderComponent.cs
+++ b/Source/Blazorise/Base/BaseAfterRenderComponent.cs
@@ -10,7 +10,7 @@ namespace Blazorise
     /// <summary>
     /// Base render component that implements render-queue logic.
     /// </summary>
-    public abstract class BaseAfterRenderComponent : ComponentBase, IDisposable, IAsyncDisposable
+    public abstract class BaseAfterRenderComponent : ComponentBase
     {
         #region Members
 

--- a/Source/Blazorise/Base/BaseInputComponent.razor.cs
+++ b/Source/Blazorise/Base/BaseInputComponent.razor.cs
@@ -12,7 +12,7 @@ namespace Blazorise
     /// <summary>
     /// Base component for all the input component types.
     /// </summary>
-    public abstract class BaseInputComponent<TValue> : BaseComponent, IValidationInput, IFocusableComponent, IDisposable, IAsyncDisposable
+    public abstract class BaseInputComponent<TValue> : BaseComponent, IValidationInput, IFocusableComponent, IDisposable
     {
         #region Members
 
@@ -89,37 +89,21 @@ namespace Blazorise
         {
             if ( disposing )
             {
-                DisposeResources();
+                if ( ParentValidation != null )
+                {
+                    // To avoid leaking memory, it's important to detach any event handlers in Dispose()
+                    ParentValidation.ValidationStatusChanged -= OnValidationStatusChanged;
+                }
+
+                ParentModal?.NotifyFocusableComponentRemoved( this );
+
+                if ( Theme != null )
+                {
+                    Theme.Changed -= OnThemeChanged;
+                }
             }
 
             base.Dispose( disposing );
-        }
-
-        /// <inheritdoc/>
-        protected override ValueTask DisposeAsync( bool disposing )
-        {
-            if ( disposing )
-            {
-                DisposeResources();
-            }
-
-            return base.DisposeAsync( disposing );
-        }
-
-        private void DisposeResources()
-        {
-            if ( ParentValidation != null )
-            {
-                // To avoid leaking memory, it's important to detach any event handlers in Dispose()
-                ParentValidation.ValidationStatusChanged -= OnValidationStatusChanged;
-            }
-
-            ParentModal?.NotifyFocusableComponentRemoved( this );
-
-            if ( Theme != null )
-            {
-                Theme.Changed -= OnThemeChanged;
-            }
         }
 
         /// <summary>

--- a/Source/Blazorise/Base/BaseInputComponent.razor.cs
+++ b/Source/Blazorise/Base/BaseInputComponent.razor.cs
@@ -12,7 +12,7 @@ namespace Blazorise
     /// <summary>
     /// Base component for all the input component types.
     /// </summary>
-    public abstract class BaseInputComponent<TValue> : BaseComponent, IValidationInput, IFocusableComponent
+    public abstract class BaseInputComponent<TValue> : BaseComponent, IValidationInput, IFocusableComponent, IDisposable, IAsyncDisposable
     {
         #region Members
 

--- a/Source/Blazorise/Base/BaseTextInput.razor.cs
+++ b/Source/Blazorise/Base/BaseTextInput.razor.cs
@@ -12,7 +12,7 @@ namespace Blazorise
     /// Base component for inputs that are text-based.
     /// </summary>
     /// <typeparam name="TValue">Editable value type.</typeparam>
-    public abstract class BaseTextInput<TValue> : BaseInputComponent<TValue>, ISelectableComponent, IDisposable, IAsyncDisposable
+    public abstract class BaseTextInput<TValue> : BaseInputComponent<TValue>, ISelectableComponent, IDisposable
     {
         #region Members
 
@@ -41,30 +41,14 @@ namespace Blazorise
         {
             if ( disposing )
             {
-                DisposeResources();
+                if ( inputValueDebouncer != null )
+                {
+                    inputValueDebouncer.Debounced -= OnInputValueDebounced;
+                    inputValueDebouncer = null;
+                }
             }
 
             base.Dispose( disposing );
-        }
-
-        /// <inheritdoc/>
-        protected override ValueTask DisposeAsync( bool disposing )
-        {
-            if ( disposing )
-            {
-                DisposeResources();
-            }
-
-            return base.DisposeAsync( disposing );
-        }
-
-        private void DisposeResources()
-        {
-            if ( inputValueDebouncer != null )
-            {
-                inputValueDebouncer.Debounced -= OnInputValueDebounced;
-                inputValueDebouncer = null;
-            }
         }
 
         /// <summary>

--- a/Source/Blazorise/Base/BaseTextInput.razor.cs
+++ b/Source/Blazorise/Base/BaseTextInput.razor.cs
@@ -12,7 +12,7 @@ namespace Blazorise
     /// Base component for inputs that are text-based.
     /// </summary>
     /// <typeparam name="TValue">Editable value type.</typeparam>
-    public abstract class BaseTextInput<TValue> : BaseInputComponent<TValue>, ISelectableComponent
+    public abstract class BaseTextInput<TValue> : BaseInputComponent<TValue>, ISelectableComponent, IDisposable, IAsyncDisposable
     {
         #region Members
 

--- a/Source/Blazorise/Base/BaseValidationResult.cs
+++ b/Source/Blazorise/Base/BaseValidationResult.cs
@@ -9,7 +9,7 @@ namespace Blazorise
     /// <summary>
     /// Base class for validation result messages.
     /// </summary>
-    public abstract class BaseValidationResult : BaseComponent
+    public abstract class BaseValidationResult : BaseComponent, IDisposable, IAsyncDisposable
     {
         #region Members
 

--- a/Source/Blazorise/Base/BaseValidationResult.cs
+++ b/Source/Blazorise/Base/BaseValidationResult.cs
@@ -9,7 +9,7 @@ namespace Blazorise
     /// <summary>
     /// Base class for validation result messages.
     /// </summary>
-    public abstract class BaseValidationResult : BaseComponent, IDisposable, IAsyncDisposable
+    public abstract class BaseValidationResult : BaseComponent, IDisposable
     {
         #region Members
 
@@ -35,31 +35,15 @@ namespace Blazorise
         {
             if ( disposing )
             {
-                DisposeResources();
+                DetachValidationStatusChangedListener();
+
+                if ( ParentValidation is not null )
+                {
+                    ParentValidation.ValidationStatusChanged -= OnValidationStatusChanged;
+                }
             }
 
             base.Dispose( disposing );
-        }
-
-        /// <inheritdoc/>
-        protected override ValueTask DisposeAsync( bool disposing )
-        {
-            if ( disposing )
-            {
-                DisposeResources();
-            }
-
-            return base.DisposeAsync( disposing );
-        }
-
-        private void DisposeResources()
-        {
-            DetachValidationStatusChangedListener();
-
-            if ( ParentValidation is not null )
-            {
-                ParentValidation.ValidationStatusChanged -= OnValidationStatusChanged;
-            }
         }
 
         /// <inheritdoc/>

--- a/Source/Blazorise/Components/Addon/Addons.razor.cs
+++ b/Source/Blazorise/Components/Addon/Addons.razor.cs
@@ -11,7 +11,7 @@ namespace Blazorise
     /// <summary>
     /// Wrapper for text, buttons, or button groups on either side of textual inputs.
     /// </summary>
-    public partial class Addons : BaseComponent, IDisposable, IAsyncDisposable
+    public partial class Addons : BaseComponent, IDisposable
     {
         #region Members
 
@@ -54,29 +54,13 @@ namespace Blazorise
         {
             if ( disposing )
             {
-                DisposeResources();
+                if ( Theme != null )
+                {
+                    Theme.Changed -= OnThemeChanged;
+                }
             }
 
             base.Dispose( disposing );
-        }
-
-        /// <inheritdoc/>
-        protected override ValueTask DisposeAsync( bool disposing )
-        {
-            if ( disposing )
-            {
-                DisposeResources();
-            }
-
-            return base.DisposeAsync( disposing );
-        }
-
-        private void DisposeResources()
-        {
-            if ( Theme != null )
-            {
-                Theme.Changed -= OnThemeChanged;
-            }
         }
 
         /// <inheritdoc/>

--- a/Source/Blazorise/Components/Addon/Addons.razor.cs
+++ b/Source/Blazorise/Components/Addon/Addons.razor.cs
@@ -11,7 +11,7 @@ namespace Blazorise
     /// <summary>
     /// Wrapper for text, buttons, or button groups on either side of textual inputs.
     /// </summary>
-    public partial class Addons : BaseComponent
+    public partial class Addons : BaseComponent, IDisposable, IAsyncDisposable
     {
         #region Members
 

--- a/Source/Blazorise/Components/Bar/Bar.razor.cs
+++ b/Source/Blazorise/Components/Bar/Bar.razor.cs
@@ -1,4 +1,5 @@
 ﻿#region Using directives
+using System;
 using System.Threading.Tasks;
 using Blazorise.Modules;
 using Blazorise.States;
@@ -13,7 +14,7 @@ namespace Blazorise
     /// <summary>
     /// The <see cref="Bar"/> component is a wrapper that positions branding, navigation, and other elements into a concise header or sidebar.
     /// </summary>
-    public partial class Bar : BaseComponent, IBreakpointActivator
+    public partial class Bar : BaseComponent, IBreakpointActivator, IAsyncDisposable
     {
         #region Members
 

--- a/Source/Blazorise/Components/Bar/BarDropdown.razor.cs
+++ b/Source/Blazorise/Components/Bar/BarDropdown.razor.cs
@@ -1,4 +1,5 @@
 ﻿#region Using directives
+using System;
 using System.Threading.Tasks;
 using Blazorise.States;
 using Blazorise.Utilities;
@@ -10,7 +11,7 @@ namespace Blazorise
     /// <summary>
     /// The dropdown menu, which can include bar items and dividers.
     /// </summary>
-    public partial class BarDropdown : BaseComponent
+    public partial class BarDropdown : BaseComponent, IDisposable
     {
         #region Members
 

--- a/Source/Blazorise/Components/Bar/BarDropdownToggle.razor.cs
+++ b/Source/Blazorise/Components/Bar/BarDropdownToggle.razor.cs
@@ -1,4 +1,5 @@
 ﻿#region Using directives
+using System;
 using System.Threading.Tasks;
 using Blazorise.Modules;
 using Blazorise.States;
@@ -12,7 +13,7 @@ namespace Blazorise
     /// <summary>
     /// Toggles the visibility or collapse of <see cref="Bar"/> component.
     /// </summary>
-    public partial class BarDropdownToggle : BaseComponent, ICloseActivator
+    public partial class BarDropdownToggle : BaseComponent, ICloseActivator, IAsyncDisposable
     {
         #region Members
 

--- a/Source/Blazorise/Components/Breadcrumb/BreadcrumbItem.razor.cs
+++ b/Source/Blazorise/Components/Breadcrumb/BreadcrumbItem.razor.cs
@@ -1,4 +1,5 @@
 ﻿#region Using directives
+using System;
 using System.Threading.Tasks;
 using Blazorise.Utilities;
 using Microsoft.AspNetCore.Components;
@@ -10,7 +11,7 @@ namespace Blazorise
     /// <summary>
     /// Wrapper for a breadcrumb link.
     /// </summary>
-    public partial class BreadcrumbItem : BaseComponent
+    public partial class BreadcrumbItem : BaseComponent, IDisposable, IAsyncDisposable
     {
         #region Members
 

--- a/Source/Blazorise/Components/Breadcrumb/BreadcrumbItem.razor.cs
+++ b/Source/Blazorise/Components/Breadcrumb/BreadcrumbItem.razor.cs
@@ -11,7 +11,7 @@ namespace Blazorise
     /// <summary>
     /// Wrapper for a breadcrumb link.
     /// </summary>
-    public partial class BreadcrumbItem : BaseComponent, IDisposable, IAsyncDisposable
+    public partial class BreadcrumbItem : BaseComponent, IDisposable
     {
         #region Members
 
@@ -61,27 +61,11 @@ namespace Blazorise
         {
             if ( disposing )
             {
-                DisposeResources();
+                // To avoid leaking memory, it's important to detach any event handlers in Dispose()
+                NavigationManager.LocationChanged -= OnLocationChanged;
             }
 
             base.Dispose( disposing );
-        }
-
-        /// <inheritdoc/>
-        protected override ValueTask DisposeAsync( bool disposing )
-        {
-            if ( disposing )
-            {
-                DisposeResources();
-            }
-
-            return base.DisposeAsync( disposing );
-        }
-
-        private void DisposeResources()
-        {
-            // To avoid leaking memory, it's important to detach any event handlers in Dispose()
-            NavigationManager.LocationChanged -= OnLocationChanged;
         }
 
         /// <summary>

--- a/Source/Blazorise/Components/Button/Button.cs
+++ b/Source/Blazorise/Components/Button/Button.cs
@@ -15,7 +15,7 @@ namespace Blazorise
     /// <summary>
     /// Clickable button for actions in forms, dialogs, and more with support for multiple sizes, states, and more.
     /// </summary>
-    public partial class Button : BaseComponent
+    public partial class Button : BaseComponent, IAsyncDisposable
     {
         #region Members
 

--- a/Source/Blazorise/Components/Carousel/Carousel.razor.cs
+++ b/Source/Blazorise/Components/Carousel/Carousel.razor.cs
@@ -15,7 +15,7 @@ namespace Blazorise
     /// <summary>
     /// A slideshow component for cycling through elements - images or slides of text.
     /// </summary>
-    public partial class Carousel : BaseContainerComponent
+    public partial class Carousel : BaseContainerComponent, IDisposable, IAsyncDisposable
     {
         #region Members
 

--- a/Source/Blazorise/Components/Carousel/Carousel.razor.cs
+++ b/Source/Blazorise/Components/Carousel/Carousel.razor.cs
@@ -15,7 +15,7 @@ namespace Blazorise
     /// <summary>
     /// A slideshow component for cycling through elements - images or slides of text.
     /// </summary>
-    public partial class Carousel : BaseContainerComponent, IDisposable, IAsyncDisposable
+    public partial class Carousel : BaseContainerComponent, IDisposable
     {
         #region Members
 
@@ -100,38 +100,22 @@ namespace Blazorise
         {
             if ( disposing )
             {
-                DisposeResources();
+                if ( Timer != null )
+                {
+                    Timer.Stop();
+                    Timer.Dispose();
+                }
+
+                if ( TransitionTimer != null )
+                {
+                    TransitionTimer.Stop();
+                    TransitionTimer.Dispose();
+                }
+
+                LocalizerService.LocalizationChanged -= OnLocalizationChanged;
             }
 
             base.Dispose( disposing );
-        }
-
-        /// <inheritdoc/>
-        protected override ValueTask DisposeAsync( bool disposing )
-        {
-            if ( disposing )
-            {
-                DisposeResources();
-            }
-
-            return base.DisposeAsync( disposing );
-        }
-
-        private void DisposeResources()
-        {
-            if ( Timer != null )
-            {
-                Timer.Stop();
-                Timer.Dispose();
-            }
-
-            if ( TransitionTimer != null )
-            {
-                TransitionTimer.Stop();
-                TransitionTimer.Dispose();
-            }
-
-            LocalizerService.LocalizationChanged -= OnLocalizationChanged;
         }
 
         /// <inheritdoc/>

--- a/Source/Blazorise/Components/ColorPicker/ColorPicker.razor.cs
+++ b/Source/Blazorise/Components/ColorPicker/ColorPicker.razor.cs
@@ -18,7 +18,7 @@ namespace Blazorise
     /// <summary>
     /// The editor that allows you to select a color from a dropdown menu.
     /// </summary>
-    public partial class ColorPicker : BaseInputComponent<string>, ISelectableComponent
+    public partial class ColorPicker : BaseInputComponent<string>, ISelectableComponent, IAsyncDisposable
     {
         #region Members
 

--- a/Source/Blazorise/Components/DatePicker/DatePicker.razor.cs
+++ b/Source/Blazorise/Components/DatePicker/DatePicker.razor.cs
@@ -17,7 +17,7 @@ namespace Blazorise
     /// An editor that displays a date value and allows a user to edit the value.
     /// </summary>
     /// <typeparam name="TValue">Data-type to be binded by the <see cref="DatePicker{TValue}"/> property.</typeparam>
-    public partial class DatePicker<TValue> : BaseTextInput<TValue>
+    public partial class DatePicker<TValue> : BaseTextInput<TValue>, IAsyncDisposable
     {
         #region Methods
 

--- a/Source/Blazorise/Components/Divider/Divider.razor.cs
+++ b/Source/Blazorise/Components/Divider/Divider.razor.cs
@@ -10,7 +10,7 @@ namespace Blazorise
     /// <summary>
     /// A divider is a thin line that groups content in lists and layouts.
     /// </summary>
-    public partial class Divider : BaseComponent
+    public partial class Divider : BaseComponent, IDisposable, IAsyncDisposable
     {
         #region Members       
 

--- a/Source/Blazorise/Components/Divider/Divider.razor.cs
+++ b/Source/Blazorise/Components/Divider/Divider.razor.cs
@@ -10,7 +10,7 @@ namespace Blazorise
     /// <summary>
     /// A divider is a thin line that groups content in lists and layouts.
     /// </summary>
-    public partial class Divider : BaseComponent, IDisposable, IAsyncDisposable
+    public partial class Divider : BaseComponent, IDisposable
     {
         #region Members       
 
@@ -39,29 +39,13 @@ namespace Blazorise
         {
             if ( disposing )
             {
-                DisposeResources();
+                if ( Theme != null )
+                {
+                    Theme.Changed -= OnThemeChanged;
+                }
             }
 
             base.Dispose( disposing );
-        }
-
-        /// <inheritdoc/>
-        protected override ValueTask DisposeAsync( bool disposing )
-        {
-            if ( disposing )
-            {
-                DisposeResources();
-            }
-
-            return base.DisposeAsync( disposing );
-        }
-
-        private void DisposeResources()
-        {
-            if ( Theme != null )
-            {
-                Theme.Changed -= OnThemeChanged;
-            }
         }
 
         /// <inheritdoc/>

--- a/Source/Blazorise/Components/Dropdown/Dropdown.razor.cs
+++ b/Source/Blazorise/Components/Dropdown/Dropdown.razor.cs
@@ -1,4 +1,5 @@
 ﻿#region Using directives
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Blazorise.States;
@@ -11,7 +12,7 @@ namespace Blazorise
     /// <summary>
     /// Dropdown is toggleable, contextual overlay for displaying lists of links and more.
     /// </summary>
-    public partial class Dropdown : BaseComponent
+    public partial class Dropdown : BaseComponent, IDisposable
     {
         #region Members
 

--- a/Source/Blazorise/Components/Dropdown/DropdownMenu.razor.cs
+++ b/Source/Blazorise/Components/Dropdown/DropdownMenu.razor.cs
@@ -1,4 +1,5 @@
 ﻿#region Using directives
+using System;
 using System.Threading.Tasks;
 using Blazorise.States;
 using Blazorise.Utilities;
@@ -10,7 +11,7 @@ namespace Blazorise
     /// <summary>
     /// Main container for a <see cref="Dropdown"/> menu that can contain or or more <see cref="DropdownItem"/>'s.
     /// </summary>
-    public partial class DropdownMenu : BaseComponent
+    public partial class DropdownMenu : BaseComponent, IDisposable, IAsyncDisposable
     {
         #region Members
 

--- a/Source/Blazorise/Components/Dropdown/DropdownMenu.razor.cs
+++ b/Source/Blazorise/Components/Dropdown/DropdownMenu.razor.cs
@@ -38,13 +38,6 @@ namespace Blazorise
         {
             if ( disposing )
             {
-                if ( ParentDropdown is not null )
-                {
-                    ParentDropdown.RemoveDropdownMenu( this );
-                }
-            }
-
-            base.Dispose( disposing );
                 DisposeResources();
             }
 
@@ -64,9 +57,9 @@ namespace Blazorise
 
         private void DisposeResources()
         {
-            if ( ParentDropdown != null )
+            if ( ParentDropdown is not null )
             {
-                ParentDropdown.VisibleChanged -= OnVisibleChanged;
+                ParentDropdown.RemoveDropdownMenu( this );
             }
         }
 

--- a/Source/Blazorise/Components/Dropdown/DropdownMenu.razor.cs
+++ b/Source/Blazorise/Components/Dropdown/DropdownMenu.razor.cs
@@ -11,7 +11,7 @@ namespace Blazorise
     /// <summary>
     /// Main container for a <see cref="Dropdown"/> menu that can contain or or more <see cref="DropdownItem"/>'s.
     /// </summary>
-    public partial class DropdownMenu : BaseComponent, IDisposable, IAsyncDisposable
+    public partial class DropdownMenu : BaseComponent, IDisposable
     {
         #region Members
 
@@ -39,29 +39,13 @@ namespace Blazorise
         {
             if ( disposing )
             {
-                DisposeResources();
+                if ( ParentDropdown is not null )
+                {
+                    ParentDropdown.RemoveDropdownMenu( this );
+                }
             }
 
             base.Dispose( disposing );
-        }
-
-        /// <inheritdoc/>
-        protected override ValueTask DisposeAsync( bool disposing )
-        {
-            if ( disposing )
-            {
-                DisposeResources();
-            }
-
-            return base.DisposeAsync( disposing );
-        }
-
-        private void DisposeResources()
-        {
-            if ( ParentDropdown is not null )
-            {
-                ParentDropdown.RemoveDropdownMenu( this );
-            }
         }
 
         /// <inheritdoc/>

--- a/Source/Blazorise/Components/Dropdown/DropdownToggle.razor.cs
+++ b/Source/Blazorise/Components/Dropdown/DropdownToggle.razor.cs
@@ -13,7 +13,7 @@ namespace Blazorise
     /// <summary>
     /// Toggles the dropdown menu visibility on or off.
     /// </summary>
-    public partial class DropdownToggle : BaseComponent, ICloseActivator
+    public partial class DropdownToggle : BaseComponent, ICloseActivator, IAsyncDisposable
     {
         #region Members
 

--- a/Source/Blazorise/Components/Field/Field.razor.cs
+++ b/Source/Blazorise/Components/Field/Field.razor.cs
@@ -11,7 +11,7 @@ namespace Blazorise
     /// <summary>
     /// Wrapper for form input components like label, text, button, etc.
     /// </summary>
-    public partial class Field : BaseComponent, IDisposable, IAsyncDisposable
+    public partial class Field : BaseComponent, IDisposable
     {
         #region Members
 
@@ -66,31 +66,15 @@ namespace Blazorise
         {
             if ( disposing )
             {
-                DisposeResources();
+                DetachValidationStatusChangedListener();
+
+                if ( ParentValidation is not null )
+                {
+                    ParentValidation.ValidationStatusChanged -= OnValidationStatusChanged;
+                }
             }
 
             base.Dispose( disposing );
-        }
-
-        /// <inheritdoc/>
-        protected override ValueTask DisposeAsync( bool disposing )
-        {
-            if ( disposing )
-            {
-                DisposeResources();
-            }
-
-            return base.DisposeAsync( disposing );
-        }
-
-        private void DisposeResources()
-        {
-            DetachValidationStatusChangedListener();
-
-            if ( ParentValidation is not null )
-            {
-                ParentValidation.ValidationStatusChanged -= OnValidationStatusChanged;
-            }
         }
 
         /// <summary>

--- a/Source/Blazorise/Components/Field/Field.razor.cs
+++ b/Source/Blazorise/Components/Field/Field.razor.cs
@@ -11,7 +11,7 @@ namespace Blazorise
     /// <summary>
     /// Wrapper for form input components like label, text, button, etc.
     /// </summary>
-    public partial class Field : BaseComponent
+    public partial class Field : BaseComponent, IDisposable, IAsyncDisposable
     {
         #region Members
 

--- a/Source/Blazorise/Components/FileEdit/FileEdit.razor.cs
+++ b/Source/Blazorise/Components/FileEdit/FileEdit.razor.cs
@@ -33,7 +33,8 @@ namespace Blazorise
     /// </summary>
     public partial class FileEdit : BaseInputComponent<IFileEntry[]>, IFileEdit,
         IFileEntryOwner,
-        IFileEntryNotifier
+        IFileEntryNotifier,
+        IAsyncDisposable
     {
         #region Members
 

--- a/Source/Blazorise/Components/Link/Link.razor.cs
+++ b/Source/Blazorise/Components/Link/Link.razor.cs
@@ -14,7 +14,7 @@ namespace Blazorise
     /// A component that renders an anchor tag, automatically toggling its 'active'
     /// class based on whether its 'href' matches the current URI.
     /// </summary>
-    public partial class Link : BaseComponent
+    public partial class Link : BaseComponent, IDisposable, IAsyncDisposable
     {
         #region Members
 

--- a/Source/Blazorise/Components/Link/Link.razor.cs
+++ b/Source/Blazorise/Components/Link/Link.razor.cs
@@ -14,7 +14,7 @@ namespace Blazorise
     /// A component that renders an anchor tag, automatically toggling its 'active'
     /// class based on whether its 'href' matches the current URI.
     /// </summary>
-    public partial class Link : BaseComponent, IDisposable, IAsyncDisposable
+    public partial class Link : BaseComponent, IDisposable
     {
         #region Members
 
@@ -80,30 +80,14 @@ namespace Blazorise
         {
             if ( disposing )
             {
-                DisposeResources();
+                // To avoid leaking memory, it's important to detach any event handlers in Dispose()
+                if ( NavigationManager != null )
+                {
+                    NavigationManager.LocationChanged -= OnLocationChanged;
+                }
             }
 
             base.Dispose( disposing );
-        }
-
-        /// <inheritdoc/>
-        protected override ValueTask DisposeAsync( bool disposing )
-        {
-            if ( disposing )
-            {
-                DisposeResources();
-            }
-
-            return base.DisposeAsync( disposing );
-        }
-
-        private void DisposeResources()
-        {
-            // To avoid leaking memory, it's important to detach any event handlers in Dispose()
-            if ( NavigationManager != null )
-            {
-                NavigationManager.LocationChanged -= OnLocationChanged;
-            }
         }
 
         private void OnLocationChanged( object sender, LocationChangedEventArgs args )

--- a/Source/Blazorise/Components/MemoEdit/MemoEdit.razor.cs
+++ b/Source/Blazorise/Components/MemoEdit/MemoEdit.razor.cs
@@ -14,7 +14,7 @@ namespace Blazorise
     /// <summary>
     /// Component that allows you to display and edit multi-line text.
     /// </summary>
-    public partial class MemoEdit : BaseInputComponent<string>, ISelectableComponent
+    public partial class MemoEdit : BaseInputComponent<string>, ISelectableComponent, IAsyncDisposable
     {
         #region Members
 

--- a/Source/Blazorise/Components/MessageAlert/MessageAlert.razor.cs
+++ b/Source/Blazorise/Components/MessageAlert/MessageAlert.razor.cs
@@ -1,4 +1,5 @@
 ﻿#region Using directives
+using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 #endregion
@@ -8,7 +9,7 @@ namespace Blazorise
     /// <summary>
     /// Component that handles the <see cref="IMessageService"/> to show the message dialog.
     /// </summary>
-    public partial class MessageAlert : BaseComponent
+    public partial class MessageAlert : BaseComponent, IDisposable, IAsyncDisposable
     {
         #region Methods
 

--- a/Source/Blazorise/Components/MessageAlert/MessageAlert.razor.cs
+++ b/Source/Blazorise/Components/MessageAlert/MessageAlert.razor.cs
@@ -9,7 +9,7 @@ namespace Blazorise
     /// <summary>
     /// Component that handles the <see cref="IMessageService"/> to show the message dialog.
     /// </summary>
-    public partial class MessageAlert : BaseComponent, IDisposable, IAsyncDisposable
+    public partial class MessageAlert : BaseComponent, IDisposable
     {
         #region Methods
 
@@ -26,29 +26,13 @@ namespace Blazorise
         {
             if ( disposing )
             {
-                DisposeResources();
+                if ( MessageService != null )
+                {
+                    MessageService.MessageReceived -= OnMessageReceived;
+                }
             }
 
             base.Dispose( disposing );
-        }
-
-        /// <inheritdoc/>
-        protected override ValueTask DisposeAsync( bool disposing )
-        {
-            if ( disposing )
-            {
-                DisposeResources();
-            }
-
-            return base.DisposeAsync( disposing );
-        }
-
-        private void DisposeResources()
-        {
-            if ( MessageService != null )
-            {
-                MessageService.MessageReceived -= OnMessageReceived;
-            }
         }
 
         private async void OnMessageReceived( object sender, MessageEventArgs e )

--- a/Source/Blazorise/Components/Modal/Modal.razor.cs
+++ b/Source/Blazorise/Components/Modal/Modal.razor.cs
@@ -15,7 +15,7 @@ namespace Blazorise
     /// <summary>
     /// A classic modal overlay, in which you can include any content you want.
     /// </summary>
-    public partial class Modal : BaseComponent, ICloseActivator
+    public partial class Modal : BaseComponent, ICloseActivator, IAsyncDisposable
     {
         #region Members
 

--- a/Source/Blazorise/Components/NumericEdit/NumericEdit.razor.cs
+++ b/Source/Blazorise/Components/NumericEdit/NumericEdit.razor.cs
@@ -17,7 +17,7 @@ namespace Blazorise
     /// An editor that displays a numeric value and allows a user to edit the value.
     /// </summary>
     /// <typeparam name="TValue">Data-type to be binded by the <see cref="Value"/> property.</typeparam>
-    public partial class NumericEdit<TValue> : BaseTextInput<TValue>, INumericEdit
+    public partial class NumericEdit<TValue> : BaseTextInput<TValue>, INumericEdit, IAsyncDisposable
     {
         #region Members
 

--- a/Source/Blazorise/Components/Pagination/Pagination.razor.cs
+++ b/Source/Blazorise/Components/Pagination/Pagination.razor.cs
@@ -10,7 +10,7 @@ namespace Blazorise
     /// <summary>
     /// A responsive and flexible pagination component.
     /// </summary>
-    public partial class Pagination : BaseComponent, IDisposable, IAsyncDisposable
+    public partial class Pagination : BaseComponent, IDisposable
     {
         #region Members
 
@@ -38,29 +38,13 @@ namespace Blazorise
         {
             if ( disposing )
             {
-                DisposeResources();
+                if ( Theme != null )
+                {
+                    Theme.Changed -= OnThemeChanged;
+                }
             }
 
             base.Dispose( disposing );
-        }
-
-        /// <inheritdoc/>
-        protected override ValueTask DisposeAsync( bool disposing )
-        {
-            if ( disposing )
-            {
-                DisposeResources();
-            }
-
-            return base.DisposeAsync( disposing );
-        }
-
-        private void DisposeResources()
-        {
-            if ( Theme != null )
-            {
-                Theme.Changed -= OnThemeChanged;
-            }
         }
 
         /// <inheritdoc/>

--- a/Source/Blazorise/Components/Pagination/Pagination.razor.cs
+++ b/Source/Blazorise/Components/Pagination/Pagination.razor.cs
@@ -10,7 +10,7 @@ namespace Blazorise
     /// <summary>
     /// A responsive and flexible pagination component.
     /// </summary>
-    public partial class Pagination : BaseComponent
+    public partial class Pagination : BaseComponent, IDisposable, IAsyncDisposable
     {
         #region Members
 

--- a/Source/Blazorise/Components/Progress/PageProgressAlert.razor.cs
+++ b/Source/Blazorise/Components/Progress/PageProgressAlert.razor.cs
@@ -9,7 +9,7 @@ namespace Blazorise
     /// <summary>
     /// Component that handles the <see cref="IPageProgressService"/> to show the page progress.
     /// </summary>
-    public partial class PageProgressAlert : BaseComponent, IDisposable, IAsyncDisposable
+    public partial class PageProgressAlert : BaseComponent, IDisposable
     {
         #region Methods
 
@@ -26,29 +26,13 @@ namespace Blazorise
         {
             if ( disposing )
             {
-                DisposeResources();
+                if ( PageProgressService != null )
+                {
+                    PageProgressService.ProgressChanged -= OnProgressChanged;
+                }
             }
 
             base.Dispose( disposing );
-        }
-
-        /// <inheritdoc/>
-        protected override ValueTask DisposeAsync( bool disposing )
-        {
-            if ( disposing )
-            {
-                DisposeResources();
-            }
-
-            return base.DisposeAsync( disposing );
-        }
-
-        private void DisposeResources()
-        {
-            if ( PageProgressService != null )
-            {
-                PageProgressService.ProgressChanged -= OnProgressChanged;
-            }
         }
 
         /// <inheritdoc/>

--- a/Source/Blazorise/Components/Progress/PageProgressAlert.razor.cs
+++ b/Source/Blazorise/Components/Progress/PageProgressAlert.razor.cs
@@ -1,4 +1,5 @@
 ﻿#region Using directives
+using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 #endregion
@@ -8,7 +9,7 @@ namespace Blazorise
     /// <summary>
     /// Component that handles the <see cref="IPageProgressService"/> to show the page progress.
     /// </summary>
-    public partial class PageProgressAlert : BaseComponent
+    public partial class PageProgressAlert : BaseComponent, IDisposable, IAsyncDisposable
     {
         #region Methods
 

--- a/Source/Blazorise/Components/Progress/Progress.razor.cs
+++ b/Source/Blazorise/Components/Progress/Progress.razor.cs
@@ -11,7 +11,7 @@ namespace Blazorise
     /// <summary>
     /// Main component for stacked progress bars.
     /// </summary>
-    public partial class Progress : BaseComponent
+    public partial class Progress : BaseComponent, IDisposable, IAsyncDisposable
     {
         #region Members
 

--- a/Source/Blazorise/Components/Progress/Progress.razor.cs
+++ b/Source/Blazorise/Components/Progress/Progress.razor.cs
@@ -11,7 +11,7 @@ namespace Blazorise
     /// <summary>
     /// Main component for stacked progress bars.
     /// </summary>
-    public partial class Progress : BaseComponent, IDisposable, IAsyncDisposable
+    public partial class Progress : BaseComponent, IDisposable
     {
         #region Members
 
@@ -63,29 +63,13 @@ namespace Blazorise
         {
             if ( disposing )
             {
-                DisposeResources();
+                if ( Theme != null )
+                {
+                    Theme.Changed -= OnThemeChanged;
+                }
             }
 
             base.Dispose( disposing );
-        }
-
-        /// <inheritdoc/>
-        protected override ValueTask DisposeAsync( bool disposing )
-        {
-            if ( disposing )
-            {
-                DisposeResources();
-            }
-
-            return base.DisposeAsync( disposing );
-        }
-
-        private void DisposeResources()
-        {
-            if ( Theme != null )
-            {
-                Theme.Changed -= OnThemeChanged;
-            }
         }
 
         /// <inheritdoc/>

--- a/Source/Blazorise/Components/Radio/Radio.razor.cs
+++ b/Source/Blazorise/Components/Radio/Radio.razor.cs
@@ -13,7 +13,7 @@ namespace Blazorise
     /// Radio buttons allow the user to select one option from a set.
     /// </summary>
     /// <typeparam name="TValue">Checked value type.</typeparam>
-    public partial class Radio<TValue> : BaseCheckComponent<bool>
+    public partial class Radio<TValue> : BaseCheckComponent<bool>, IDisposable, IAsyncDisposable
     {
         #region Members
 

--- a/Source/Blazorise/Components/Radio/Radio.razor.cs
+++ b/Source/Blazorise/Components/Radio/Radio.razor.cs
@@ -13,7 +13,7 @@ namespace Blazorise
     /// Radio buttons allow the user to select one option from a set.
     /// </summary>
     /// <typeparam name="TValue">Checked value type.</typeparam>
-    public partial class Radio<TValue> : BaseCheckComponent<bool>, IDisposable, IAsyncDisposable
+    public partial class Radio<TValue> : BaseCheckComponent<bool>, IDisposable
     {
         #region Members
 
@@ -75,29 +75,13 @@ namespace Blazorise
         {
             if ( disposing )
             {
-                DisposeResources();
+                if ( ParentRadioGroup != null )
+                {
+                    ParentRadioGroup.RadioCheckedChanged -= OnRadioChanged;
+                }
             }
 
             base.Dispose( disposing );
-        }
-
-        /// <inheritdoc/>
-        protected override ValueTask DisposeAsync( bool disposing )
-        {
-            if ( disposing )
-            {
-                DisposeResources();
-            }
-
-            return base.DisposeAsync( disposing );
-        }
-
-        private void DisposeResources()
-        {
-            if ( ParentRadioGroup != null )
-            {
-                ParentRadioGroup.RadioCheckedChanged -= OnRadioChanged;
-            }
         }
 
         /// <inheritdoc/>

--- a/Source/Blazorise/Components/Select/SelectItem.razor.cs
+++ b/Source/Blazorise/Components/Select/SelectItem.razor.cs
@@ -1,4 +1,5 @@
 ﻿#region Using directives
+using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 #endregion
@@ -26,8 +27,7 @@ namespace Blazorise
     /// Option item in the <see cref="Select{TValue}"/> component.
     /// </summary>
     /// <typeparam name="TValue">The type of the <see cref="Value"/>.</typeparam>
-    public partial class SelectItem<TValue> : BaseComponent,
-        ISelectItem<TValue>
+    public partial class SelectItem<TValue> : BaseComponent, ISelectItem<TValue>, IDisposable, IAsyncDisposable
     {
         #region Methods
 

--- a/Source/Blazorise/Components/Select/SelectItem.razor.cs
+++ b/Source/Blazorise/Components/Select/SelectItem.razor.cs
@@ -27,7 +27,7 @@ namespace Blazorise
     /// Option item in the <see cref="Select{TValue}"/> component.
     /// </summary>
     /// <typeparam name="TValue">The type of the <see cref="Value"/>.</typeparam>
-    public partial class SelectItem<TValue> : BaseComponent, ISelectItem<TValue>, IDisposable, IAsyncDisposable
+    public partial class SelectItem<TValue> : BaseComponent, ISelectItem<TValue>, IDisposable
     {
         #region Methods
 
@@ -44,26 +44,10 @@ namespace Blazorise
         {
             if ( disposing )
             {
-                DisposeResources();
+                ParentSelect?.NotifySelectItemRemoved( this );
             }
 
             base.Dispose( disposing );
-        }
-
-        /// <inheritdoc/>
-        protected override ValueTask DisposeAsync( bool disposing )
-        {
-            if ( disposing )
-            {
-                DisposeResources();
-            }
-
-            return base.DisposeAsync( disposing );
-        }
-
-        private void DisposeResources()
-        {
-            ParentSelect?.NotifySelectItemRemoved( this );
         }
 
         #endregion

--- a/Source/Blazorise/Components/Steps/Step.razor.cs
+++ b/Source/Blazorise/Components/Steps/Step.razor.cs
@@ -11,7 +11,7 @@ namespace Blazorise
     /// <summary>
     /// Clickable item in a <see cref="Steps"/> component.
     /// </summary>
-    public partial class Step : BaseComponent, IDisposable, IAsyncDisposable
+    public partial class Step : BaseComponent, IDisposable
     {
         #region Members
 
@@ -51,26 +51,10 @@ namespace Blazorise
         {
             if ( disposing )
             {
-                DisposeResources();
+                ParentSteps?.NotifyStepRemoved( Name );
             }
 
             base.Dispose( disposing );
-        }
-
-        /// <inheritdoc/>
-        protected override ValueTask DisposeAsync( bool disposing )
-        {
-            if ( disposing )
-            {
-                DisposeResources();
-            }
-
-            return base.DisposeAsync( disposing );
-        }
-
-        private void DisposeResources()
-        {
-            ParentSteps?.NotifyStepRemoved( Name );
         }
 
         /// <inheritdoc/>

--- a/Source/Blazorise/Components/Steps/Step.razor.cs
+++ b/Source/Blazorise/Components/Steps/Step.razor.cs
@@ -11,7 +11,7 @@ namespace Blazorise
     /// <summary>
     /// Clickable item in a <see cref="Steps"/> component.
     /// </summary>
-    public partial class Step : BaseComponent
+    public partial class Step : BaseComponent, IDisposable, IAsyncDisposable
     {
         #region Members
 

--- a/Source/Blazorise/Components/Steps/StepPanel.razor.cs
+++ b/Source/Blazorise/Components/Steps/StepPanel.razor.cs
@@ -11,7 +11,7 @@ namespace Blazorise
     /// <summary>
     /// <see cref="Step"/> content area that is linked with a <see cref="Step"/> with the same name and that is placed within the <see cref="Steps"/> component.
     /// </summary>
-    public partial class StepPanel : BaseComponent, IDisposable, IAsyncDisposable
+    public partial class StepPanel : BaseComponent, IDisposable
     {
         #region Members
 
@@ -38,28 +38,12 @@ namespace Blazorise
         {
             if ( disposing )
             {
-                DisposeResources();
+                ParentSteps?.NotifyStepRemoved( Name );
+
+                ParentStepsContent?.NotifyStepPanelRemoved( Name );
             }
 
             base.Dispose( disposing );
-        }
-
-        /// <inheritdoc/>
-        protected override ValueTask DisposeAsync( bool disposing )
-        {
-            if ( disposing )
-            {
-                DisposeResources();
-            }
-
-            return base.DisposeAsync( disposing );
-        }
-
-        private void DisposeResources()
-        {
-            ParentSteps?.NotifyStepRemoved( Name );
-
-            ParentStepsContent?.NotifyStepPanelRemoved( Name );
         }
 
         /// <inheritdoc/>

--- a/Source/Blazorise/Components/Steps/StepPanel.razor.cs
+++ b/Source/Blazorise/Components/Steps/StepPanel.razor.cs
@@ -1,4 +1,5 @@
 ﻿#region Using directives
+using System;
 using System.Threading.Tasks;
 using Blazorise.States;
 using Blazorise.Utilities;
@@ -10,7 +11,7 @@ namespace Blazorise
     /// <summary>
     /// <see cref="Step"/> content area that is linked with a <see cref="Step"/> with the same name and that is placed within the <see cref="Steps"/> component.
     /// </summary>
-    public partial class StepPanel : BaseComponent
+    public partial class StepPanel : BaseComponent, IDisposable, IAsyncDisposable
     {
         #region Members
 

--- a/Source/Blazorise/Components/Tabs/TabPanel.razor.cs
+++ b/Source/Blazorise/Components/Tabs/TabPanel.razor.cs
@@ -11,7 +11,7 @@ namespace Blazorise
     /// <summary>
     /// A container for each <see cref="Tab"/> inside of <see cref="Tabs"/> component.
     /// </summary>
-    public partial class TabPanel : BaseComponent, IDisposable, IAsyncDisposable
+    public partial class TabPanel : BaseComponent, IDisposable
     {
         #region Members
 
@@ -66,28 +66,12 @@ namespace Blazorise
         {
             if ( disposing )
             {
-                DisposeResources();
+                ParentTabs?.NotifyTabPanelRemoved( Name );
+
+                ParentTabsContent?.NotifyTabPanelRemoved( Name );
             }
 
             base.Dispose( disposing );
-        }
-
-        /// <inheritdoc/>
-        protected override ValueTask DisposeAsync( bool disposing )
-        {
-            if ( disposing )
-            {
-                DisposeResources();
-            }
-
-            return base.DisposeAsync( disposing );
-        }
-
-        private void DisposeResources()
-        {
-            ParentTabs?.NotifyTabPanelRemoved( Name );
-
-            ParentTabsContent?.NotifyTabPanelRemoved( Name );
         }
 
         #endregion

--- a/Source/Blazorise/Components/Tabs/TabPanel.razor.cs
+++ b/Source/Blazorise/Components/Tabs/TabPanel.razor.cs
@@ -1,4 +1,5 @@
 ﻿#region Using directives
+using System;
 using System.Threading.Tasks;
 using Blazorise.States;
 using Blazorise.Utilities;
@@ -10,7 +11,7 @@ namespace Blazorise
     /// <summary>
     /// A container for each <see cref="Tab"/> inside of <see cref="Tabs"/> component.
     /// </summary>
-    public partial class TabPanel : BaseComponent
+    public partial class TabPanel : BaseComponent, IDisposable, IAsyncDisposable
     {
         #region Members
 

--- a/Source/Blazorise/Components/TextEdit/TextEdit.razor.cs
+++ b/Source/Blazorise/Components/TextEdit/TextEdit.razor.cs
@@ -13,7 +13,7 @@ namespace Blazorise
     /// <summary>
     /// Component that allows you to display and edit single-line text.
     /// </summary>
-    public partial class TextEdit : BaseTextInput<string>
+    public partial class TextEdit : BaseTextInput<string>, IAsyncDisposable
     {
         #region Methods
 

--- a/Source/Blazorise/Components/TimePicker/TimePicker.razor.cs
+++ b/Source/Blazorise/Components/TimePicker/TimePicker.razor.cs
@@ -15,7 +15,7 @@ namespace Blazorise
     /// An editor that displays a time value and allows a user to edit the value.
     /// </summary>
     /// <typeparam name="TValue">Data-type to be binded by the <see cref="TimePicker{TValue}"/> property.</typeparam>
-    public partial class TimePicker<TValue> : BaseTextInput<TValue>
+    public partial class TimePicker<TValue> : BaseTextInput<TValue>, IAsyncDisposable
     {
         #region Methods
 

--- a/Source/Blazorise/Components/Tooltip/Tooltip.razor.cs
+++ b/Source/Blazorise/Components/Tooltip/Tooltip.razor.cs
@@ -1,4 +1,5 @@
 ﻿#region Using directives
+using System;
 using System.Threading.Tasks;
 using Blazorise.Extensions;
 using Blazorise.Modules;
@@ -11,7 +12,7 @@ namespace Blazorise
     /// <summary>
     /// Tooltips display informative text when users hover over, focus on, or tap an element.
     /// </summary>
-    public partial class Tooltip : BaseComponent
+    public partial class Tooltip : BaseComponent, IAsyncDisposable
     {
         #region Members
 

--- a/Source/Blazorise/Components/Validation/ValidationSummary.razor.cs
+++ b/Source/Blazorise/Components/Validation/ValidationSummary.razor.cs
@@ -12,7 +12,7 @@ namespace Blazorise
     /// <summary>
     /// Placeholder for the list of <see cref="Validation"/> error messages.
     /// </summary>
-    public partial class ValidationSummary : BaseComponent, IDisposable, IAsyncDisposable
+    public partial class ValidationSummary : BaseComponent, IDisposable
     {
         #region Members
 
@@ -58,26 +58,10 @@ namespace Blazorise
         {
             if ( disposing )
             {
-                DisposeResources();
+                DetachAllListener();
             }
 
             base.Dispose( disposing );
-        }
-
-        /// <inheritdoc/>
-        protected override ValueTask DisposeAsync( bool disposing )
-        {
-            if ( disposing )
-            {
-                DisposeResources();
-            }
-
-            return base.DisposeAsync( disposing );
-        }
-
-        private void DisposeResources()
-        {
-            DetachAllListener();
         }
 
         /// <inheritdoc/>

--- a/Source/Blazorise/Components/Validation/ValidationSummary.razor.cs
+++ b/Source/Blazorise/Components/Validation/ValidationSummary.razor.cs
@@ -1,4 +1,5 @@
 ﻿#region Using directives
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -11,7 +12,7 @@ namespace Blazorise
     /// <summary>
     /// Placeholder for the list of <see cref="Validation"/> error messages.
     /// </summary>
-    public partial class ValidationSummary : BaseComponent
+    public partial class ValidationSummary : BaseComponent, IDisposable, IAsyncDisposable
     {
         #region Members
 

--- a/Source/Extensions/Blazorise.Charts.Streaming/ChartStreaming.razor.cs
+++ b/Source/Extensions/Blazorise.Charts.Streaming/ChartStreaming.razor.cs
@@ -19,7 +19,7 @@ namespace Blazorise.Charts.Streaming
     /// Provides the streaming capabilities to the supported chart types.
     /// </summary>
     /// <typeparam name="TItem">Data point type.</typeparam>
-    public partial class ChartStreaming<TItem> : BaseComponent, IChartStreaming
+    public partial class ChartStreaming<TItem> : BaseComponent, IChartStreaming, IAsyncDisposable
     {
         #region Methods
 

--- a/Source/Extensions/Blazorise.Charts.Streaming/ChartStreaming.razor.cs
+++ b/Source/Extensions/Blazorise.Charts.Streaming/ChartStreaming.razor.cs
@@ -63,22 +63,6 @@ namespace Blazorise.Charts.Streaming
             await base.DisposeAsync( disposing );
         }
 
-        /// <inheritdoc/>
-        protected override ValueTask DisposeAsync( bool disposing )
-        {
-            if ( disposing )
-            {
-                DisposeResources();
-            }
-
-            return base.DisposeAsync( disposing );
-        }
-
-        private void DisposeResources()
-        {
-            JS.DisposeDotNetObjectRef( dotNetObjectReference );
-        }
-
         public async Task Refresh()
         {
             if ( !Rendered )

--- a/Source/Extensions/Blazorise.Charts/BaseChartOfT.cs
+++ b/Source/Extensions/Blazorise.Charts/BaseChartOfT.cs
@@ -1,4 +1,5 @@
 ﻿#region Using directives
+using System;
 using System.Threading.Tasks;
 using Blazorise.Extensions;
 using Blazorise.Utilities;
@@ -12,7 +13,7 @@ namespace Blazorise.Charts
     /// Base class for all chart types.
     /// </summary>
     /// <typeparam name="TItem">Generic dataset value type.</typeparam>
-    public class BaseChart<TItem> : BaseComponent
+    public class BaseChart<TItem> : BaseComponent, IAsyncDisposable
     {
         #region Methods
 

--- a/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
+++ b/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
@@ -20,7 +20,7 @@ namespace Blazorise.Components
     /// </summary>
     /// <typeparam name="TItem">Type of an item filtered by the autocomplete component.</typeparam>
     /// <typeparam name="TValue">Type of an SelectedValue field.</typeparam>
-    public partial class Autocomplete<TItem, TValue> : BaseAfterRenderComponent, ICloseActivator
+    public partial class Autocomplete<TItem, TValue> : BaseAfterRenderComponent, ICloseActivator, IAsyncDisposable
     {
         #region Members
 

--- a/Source/Extensions/Blazorise.Components/NotificationAlert.razor.cs
+++ b/Source/Extensions/Blazorise.Components/NotificationAlert.razor.cs
@@ -10,7 +10,7 @@ namespace Blazorise.Components
     /// <summary>
     /// Component that handles the <see cref="INotificationService"/> to show the simple notifications.
     /// </summary>
-    public partial class NotificationAlert : BaseComponent, IDisposable, IAsyncDisposable
+    public partial class NotificationAlert : BaseComponent, IDisposable
     {
         #region Methods
 
@@ -27,29 +27,13 @@ namespace Blazorise.Components
         {
             if ( disposing )
             {
-                DisposeResources();
+                if ( NotificationService != null )
+                {
+                    NotificationService.NotificationReceived -= OnNotificationReceived;
+                }
             }
 
             base.Dispose( disposing );
-        }
-
-        /// <inheritdoc/>
-        protected override ValueTask DisposeAsync( bool disposing )
-        {
-            if ( disposing )
-            {
-                DisposeResources();
-            }
-
-            return base.DisposeAsync( disposing );
-        }
-
-        private void DisposeResources()
-        {
-            if ( NotificationService != null )
-            {
-                NotificationService.NotificationReceived -= OnNotificationReceived;
-            }
         }
 
         private async void OnNotificationReceived( object sender, NotificationEventArgs e )

--- a/Source/Extensions/Blazorise.Components/NotificationAlert.razor.cs
+++ b/Source/Extensions/Blazorise.Components/NotificationAlert.razor.cs
@@ -10,7 +10,7 @@ namespace Blazorise.Components
     /// <summary>
     /// Component that handles the <see cref="INotificationService"/> to show the simple notifications.
     /// </summary>
-    public partial class NotificationAlert : BaseComponent, IDisposable
+    public partial class NotificationAlert : BaseComponent, IDisposable, IAsyncDisposable
     {
         #region Methods
 

--- a/Source/Extensions/Blazorise.DataGrid/BaseDataGridComponent.cs
+++ b/Source/Extensions/Blazorise.DataGrid/BaseDataGridComponent.cs
@@ -1,4 +1,5 @@
 ﻿#region Using directives
+using System;
 using System.Threading.Tasks;
 using Blazorise.Extensions;
 using Microsoft.AspNetCore.Components;
@@ -10,7 +11,7 @@ namespace Blazorise.DataGrid
     /// <summary>
     /// Minimal base class for datagrid components.
     /// </summary>
-    public class BaseDataGridComponent : BaseAfterRenderComponent
+    public class BaseDataGridComponent : BaseAfterRenderComponent, IAsyncDisposable
     {
         #region Methods
 

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -20,7 +20,7 @@ namespace Blazorise.DataGrid
     /// The DataGrid component llows you to display and manage data in a tabular (rows/columns) format.
     /// </summary>
     /// <typeparam name="TItem">Type parameter for the model displayed in the <see cref="DataGrid{TItem}"/>.</typeparam>
-    public partial class DataGrid<TItem> : BaseDataGridComponent
+    public partial class DataGrid<TItem> : BaseDataGridComponent, IDisposable, IAsyncDisposable
     {
         #region Members
 

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -20,7 +20,7 @@ namespace Blazorise.DataGrid
     /// The DataGrid component llows you to display and manage data in a tabular (rows/columns) format.
     /// </summary>
     /// <typeparam name="TItem">Type parameter for the model displayed in the <see cref="DataGrid{TItem}"/>.</typeparam>
-    public partial class DataGrid<TItem> : BaseDataGridComponent, IDisposable, IAsyncDisposable
+    public partial class DataGrid<TItem> : BaseDataGridComponent, IDisposable
     {
         #region Members
 
@@ -251,30 +251,14 @@ namespace Blazorise.DataGrid
         {
             if ( disposing )
             {
-                DisposeResources();
+                if ( paginationContext != null )
+                {
+                    paginationContext.UnsubscribeOnPageSizeChanged( OnPageSizeChanged );
+                    paginationContext.UnsubscribeOnPageChanged( OnPageChanged );
+                }
             }
 
             base.Dispose( disposing );
-        }
-
-        /// <inheritdoc/>
-        protected override ValueTask DisposeAsync( bool disposing )
-        {
-            if ( disposing )
-            {
-                DisposeResources();
-            }
-
-            return base.DisposeAsync( disposing );
-        }
-
-        private void DisposeResources()
-        {
-            if ( paginationContext != null )
-            {
-                paginationContext.UnsubscribeOnPageSizeChanged( OnPageSizeChanged );
-                paginationContext.UnsubscribeOnPageChanged( OnPageChanged );
-            }
         }
 
         private async Task HandleSelectionModeChanged()

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -270,20 +270,11 @@ namespace Blazorise.DataGrid
 
         private void DisposeResources()
         {
-            paginationContext.UnsubscribeOnPageSizeChanged( OnPageSizeChanged );
-            paginationContext.UnsubscribeOnPageChanged( OnPageChanged );
-        protected override ValueTask DisposeAsync( bool disposing )
-        {
-            if ( disposing )
+            if ( paginationContext != null )
             {
-                if ( paginationContext != null )
-                {
-                    paginationContext.UnsubscribeOnPageSizeChanged( OnPageSizeChanged );
-                    paginationContext.UnsubscribeOnPageChanged( OnPageChanged );
-                }
+                paginationContext.UnsubscribeOnPageSizeChanged( OnPageSizeChanged );
+                paginationContext.UnsubscribeOnPageChanged( OnPageChanged );
             }
-
-            return base.DisposeAsync( disposing );
         }
 
         private async Task HandleSelectionModeChanged()

--- a/Source/Extensions/Blazorise.DataGrid/DataGridColumn.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGridColumn.cs
@@ -11,7 +11,7 @@ using Microsoft.AspNetCore.Components;
 
 namespace Blazorise.DataGrid
 {
-    public partial class DataGridColumn<TItem> : BaseDataGridColumn<TItem>
+    public partial class DataGridColumn<TItem> : BaseDataGridColumn<TItem>, IDisposable, IAsyncDisposable
     {
         #region Members
 

--- a/Source/Extensions/Blazorise.DataGrid/DataGridColumn.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGridColumn.cs
@@ -11,7 +11,7 @@ using Microsoft.AspNetCore.Components;
 
 namespace Blazorise.DataGrid
 {
-    public partial class DataGridColumn<TItem> : BaseDataGridColumn<TItem>, IDisposable, IAsyncDisposable
+    public partial class DataGridColumn<TItem> : BaseDataGridColumn<TItem>, IDisposable
     {
         #region Members
 
@@ -63,26 +63,10 @@ namespace Blazorise.DataGrid
         {
             if ( disposing )
             {
-                DisposeResources();
+                DisposeSubscriptions();
             }
 
             base.Dispose( disposing );
-        }
-
-        /// <inheritdoc/>
-        protected override ValueTask DisposeAsync( bool disposing )
-        {
-            if ( disposing )
-            {
-                DisposeResources();
-            }
-
-            return base.DisposeAsync( disposing );
-        }
-
-        private void DisposeResources()
-        {
-            DisposeSubscriptions();
         }
 
         private void DisposeSubscriptions()

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridPagination.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridPagination.razor.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Components;
 
 namespace Blazorise.DataGrid
 {
-    partial class _DataGridPagination<TItem> : BaseComponent, IDisposable, IAsyncDisposable
+    partial class _DataGridPagination<TItem> : BaseComponent, IDisposable
     {
         #region Methods
 
@@ -24,27 +24,12 @@ namespace Blazorise.DataGrid
         {
             if ( disposing )
             {
-                DisposeResources();
+                LocalizerService.LocalizationChanged -= OnLocalizationChanged;
             }
 
             base.Dispose( disposing );
         }
 
-        /// <inheritdoc/>
-        protected override ValueTask DisposeAsync( bool disposing )
-        {
-            if ( disposing )
-            {
-                DisposeResources();
-            }
-
-            return base.DisposeAsync( disposing );
-        }
-
-        private void DisposeResources()
-        {
-            LocalizerService.LocalizationChanged -= OnLocalizationChanged;
-        }
 
         private async void OnLocalizationChanged( object sender, EventArgs e )
         {

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridPagination.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridPagination.razor.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Components;
 
 namespace Blazorise.DataGrid
 {
-    partial class _DataGridPagination<TItem> : BaseComponent
+    partial class _DataGridPagination<TItem> : BaseComponent, IDisposable, IAsyncDisposable
     {
         #region Methods
 

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridRow.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridRow.razor.cs
@@ -10,7 +10,7 @@ using Microsoft.AspNetCore.Components;
 
 namespace Blazorise.DataGrid
 {
-    public abstract class _BaseDataGridRow<TItem> : BaseDataGridComponent
+    public abstract class _BaseDataGridRow<TItem> : BaseDataGridComponent, IDisposable, IAsyncDisposable
     {
         #region Members
 

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridRow.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridRow.razor.cs
@@ -10,7 +10,7 @@ using Microsoft.AspNetCore.Components;
 
 namespace Blazorise.DataGrid
 {
-    public abstract class _BaseDataGridRow<TItem> : BaseDataGridComponent, IDisposable, IAsyncDisposable
+    public abstract class _BaseDataGridRow<TItem> : BaseDataGridComponent, IDisposable
     {
         #region Members
 
@@ -178,17 +178,11 @@ namespace Blazorise.DataGrid
         protected override void Dispose( bool disposing )
         {
             if ( disposing )
-                ParentDataGrid.RemoveRow( this.RowInfo );
+            {
+                ParentDataGrid.RemoveRow( RowInfo );
+            }
 
             base.Dispose( disposing );
-        }
-
-        protected override ValueTask DisposeAsync( bool disposing )
-        {
-            if ( disposing )
-                ParentDataGrid.RemoveRow( this.RowInfo );
-
-            return base.DisposeAsync( disposing );
         }
 
         #endregion

--- a/Source/Extensions/Blazorise.Markdown/Markdown.razor.cs
+++ b/Source/Extensions/Blazorise.Markdown/Markdown.razor.cs
@@ -19,7 +19,8 @@ namespace Blazorise.Markdown
     /// </summary>
     public partial class Markdown : BaseComponent,
         IFileEntryOwner,
-        IFileEntryNotifier
+        IFileEntryNotifier,
+        IAsyncDisposable
     {
         #region Members
 

--- a/Source/Extensions/Blazorise.Markdown/MarkdownToolbarButton.razor.cs
+++ b/Source/Extensions/Blazorise.Markdown/MarkdownToolbarButton.razor.cs
@@ -1,4 +1,5 @@
 ﻿#region Using directives
+using System;
 using Blazorise.Markdown.Providers;
 using Blazorise.Utilities;
 using Microsoft.AspNetCore.Components;
@@ -9,7 +10,7 @@ namespace Blazorise.Markdown
     /// <summary>
     /// Defines the action button for the <see cref="Markdown"/> toolbar.
     /// </summary>
-    public partial class MarkdownToolbarButton : BaseComponent
+    public partial class MarkdownToolbarButton : BaseComponent, IDisposable
     {
         #region Members
 

--- a/Source/Extensions/Blazorise.RichTextEdit/RichTextEdit.razor.cs
+++ b/Source/Extensions/Blazorise.RichTextEdit/RichTextEdit.razor.cs
@@ -7,7 +7,7 @@ using Microsoft.JSInterop;
 
 namespace Blazorise.RichTextEdit
 {
-    public partial class RichTextEdit : BaseRichTextEditComponent
+    public partial class RichTextEdit : BaseRichTextEditComponent, IAsyncDisposable
     {
         #region Members
 

--- a/Source/Extensions/Blazorise.RichTextEdit/RichTextEdit.razor.cs
+++ b/Source/Extensions/Blazorise.RichTextEdit/RichTextEdit.razor.cs
@@ -1,6 +1,7 @@
 ﻿#region Using directives
 using System;
 using System.Threading.Tasks;
+using Blazorise.Extensions;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
 #endregion
@@ -26,15 +27,14 @@ namespace Blazorise.RichTextEdit
         #region Methods
 
         /// <inheritdoc/>
-        protected override ValueTask DisposeAsync( bool disposing )
+        protected override async ValueTask DisposeAsync( bool disposing )
         {
             if ( disposing && Rendered )
             {
-                // TODO: should be done in DisposeAsync() but it only works properly in .Net 6
-                _ = cleanup.DisposeAsync();
+                await cleanup.SafeDisposeAsync();
             }
 
-            return base.DisposeAsync( disposing );
+            await base.DisposeAsync( disposing );
         }
 
         /// <summary>

--- a/Source/Extensions/Blazorise.Snackbar/Snackbar.razor.cs
+++ b/Source/Extensions/Blazorise.Snackbar/Snackbar.razor.cs
@@ -12,7 +12,7 @@ namespace Blazorise.Snackbar
     /// <summary>
     /// Snackbars provide brief messages about app processes. The component is also known as a toast.
     /// </summary>
-    public partial class Snackbar : BaseComponent
+    public partial class Snackbar : BaseComponent, IDisposable, IAsyncDisposable
     {
         #region Members
 

--- a/Source/Extensions/Blazorise.Snackbar/Snackbar.razor.cs
+++ b/Source/Extensions/Blazorise.Snackbar/Snackbar.razor.cs
@@ -12,7 +12,7 @@ namespace Blazorise.Snackbar
     /// <summary>
     /// Snackbars provide brief messages about app processes. The component is also known as a toast.
     /// </summary>
-    public partial class Snackbar : BaseComponent, IDisposable, IAsyncDisposable
+    public partial class Snackbar : BaseComponent, IDisposable
     {
         #region Members
 
@@ -90,31 +90,15 @@ namespace Blazorise.Snackbar
         {
             if ( disposing )
             {
-                DisposeResources();
+                if ( countdownTimer != null )
+                {
+                    countdownTimer.Elapsed -= OnCountdownTimerElapsed;
+                    countdownTimer.Dispose();
+                    countdownTimer = null;
+                }
             }
 
             base.Dispose( disposing );
-        }
-
-        /// <inheritdoc/>
-        protected override ValueTask DisposeAsync( bool disposing )
-        {
-            if ( disposing )
-            {
-                DisposeResources();
-            }
-
-            return base.DisposeAsync( disposing );
-        }
-
-        private void DisposeResources()
-        {
-            if ( countdownTimer != null )
-            {
-                countdownTimer.Elapsed -= OnCountdownTimerElapsed;
-                countdownTimer.Dispose();
-                countdownTimer = null;
-            }
         }
 
         protected Task OnClickHandler()

--- a/Source/Extensions/Blazorise.Snackbar/SnackbarAction.razor.cs
+++ b/Source/Extensions/Blazorise.Snackbar/SnackbarAction.razor.cs
@@ -1,4 +1,5 @@
 ﻿#region Using directives
+using System;
 using System.Threading.Tasks;
 using Blazorise.Snackbar.Utils;
 using Blazorise.Utilities;
@@ -7,7 +8,7 @@ using Microsoft.AspNetCore.Components;
 
 namespace Blazorise.Snackbar
 {
-    public partial class SnackbarAction : BaseComponent
+    public partial class SnackbarAction : BaseComponent, IDisposable, IAsyncDisposable
     {
         #region Members
 

--- a/Source/Extensions/Blazorise.Snackbar/SnackbarAction.razor.cs
+++ b/Source/Extensions/Blazorise.Snackbar/SnackbarAction.razor.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Components;
 
 namespace Blazorise.Snackbar
 {
-    public partial class SnackbarAction : BaseComponent, IDisposable, IAsyncDisposable
+    public partial class SnackbarAction : BaseComponent, IDisposable
     {
         #region Members
 
@@ -28,26 +28,10 @@ namespace Blazorise.Snackbar
         {
             if ( disposing )
             {
-                DisposeResources();
+                ParentSnackbar?.NotifySnackbarActionRemoved( this );
             }
 
             base.Dispose( disposing );
-        }
-
-        /// <inheritdoc/>
-        protected override ValueTask DisposeAsync( bool disposing )
-        {
-            if ( disposing )
-            {
-                DisposeResources();
-            }
-
-            return base.DisposeAsync( disposing );
-        }
-
-        private void DisposeResources()
-        {
-            ParentSnackbar?.NotifySnackbarActionRemoved( this );
         }
 
         protected override void BuildClasses( ClassBuilder builder )


### PR DESCRIPTION
As we talked about in #3076, this PR introduces a new disposal pattern that forces us to opt-in only to specific components that need to be disposed of. All logic stays the same in the `BaseAfterRenderComponent` base class.

My initial tests seem to be much better than before. For example, a `Dropdown` that only has a `Dispose()` was previously never called because `BaseAfterRenderComponent` was implemented with `IAsyncDisposable`, and Blazor is calling that by default.

Also, my feeling is that now Blazorise should be somewhat faster since there is no need for Disposing of every component.

@David-Moreira We will definitely need to be more careful in the future since now we need to explicitly mark every component. But I think it is worth extra work. Please test and see how it goes.