### PR TITLE
Fix Autocomplete inside modal loosing focus on dropmenu scroll click

### DIFF
--- a/Source/Blazorise.Bootstrap/Modal.razor
+++ b/Source/Blazorise.Bootstrap/Modal.razor
@@ -1,7 +1,7 @@
 ﻿@inherits Blazorise.Modal
 <CascadingValue Value="@this" IsFixed="true">
     <CascadingValue Value="@State">
-        <div @ref="@ElementRef" id="@ElementId" class="@ClassNames" style="@StyleNames" tabindex="-1" role="dialog" @attributes="@Attributes">
+        <div @ref="@ElementRef" id="@ElementId" class="@ClassNames" style="@StyleNames" role="dialog" @attributes="@Attributes">
             @ChildContent
         </div>
         @if ( ShowBackdrop && IsVisible )

--- a/Source/Blazorise.Bootstrap5/Modal.razor
+++ b/Source/Blazorise.Bootstrap5/Modal.razor
@@ -1,7 +1,7 @@
 ﻿@inherits Blazorise.Modal
 <CascadingValue Value="@this" IsFixed="true">
     <CascadingValue Value="@State">
-        <div @ref="@ElementRef" id="@ElementId" class="@ClassNames" style="@StyleNames" tabindex="-1" role="dialog" @attributes="@Attributes">
+        <div @ref="@ElementRef" id="@ElementId" class="@ClassNames" style="@StyleNames" role="dialog" @attributes="@Attributes">
             @ChildContent
         </div>
         @if ( ShowBackdrop && IsVisible )

--- a/Source/Blazorise/Components/Modal/Modal.razor
+++ b/Source/Blazorise/Components/Modal/Modal.razor
@@ -2,7 +2,7 @@
 @inherits BaseComponent
 <CascadingValue Value="@this" IsFixed="true">
     <CascadingValue Value="@State">
-        <div @ref="@ElementRef" id="@ElementId" class="@ClassNames" style="@StyleNames" tabindex="-1" role="dialog" @attributes="@Attributes">
+        <div @ref="@ElementRef" id="@ElementId" class="@ClassNames" style="@StyleNames" role="dialog" @attributes="@Attributes">
             @if ( ShowBackdrop )
             {
                 <_ModalBackdrop />


### PR DESCRIPTION
Closes #3069

Removing it from the DIV does fix the problem. Don't see any problem with removing it. Tabbing keeps working normally. 
Also applying -1 seems pretty close to not having the attribute set at all, both ways make it so it's not tab targetable.
https://developer.mozilla.org/pt-BR/docs/Web/HTML/Global_attributes/tabindex