### PR TITLE
Extract hex digits cache regex

### DIFF
--- a/Source/Blazorise/Themes/ThemeGenerator.cs
+++ b/Source/Blazorise/Themes/ThemeGenerator.cs
@@ -1313,7 +1313,7 @@ namespace Blazorise
         /// <summary>
         /// Checks for characters that are Hexadecimal
         /// </summary>
-        protected static Regex isHexDigit = new( "[abcdefABCDEF\\d]+", RegexOptions.Compiled );
+        protected static Regex IsHexDigit = new( "[abcdefABCDEF\\d]+", RegexOptions.Compiled );
 
         /// <summary>
         /// Extract only the hex digits from a string.
@@ -1322,12 +1322,14 @@ namespace Blazorise
         /// <returns>A new hex string.</returns>
         protected static string ExtractHexDigits( string input )
         {
-            string newnum = string.Empty;
-            var result = isHexDigit.Matches( input );
+            var newnum = string.Empty;
+            var result = IsHexDigit.Matches( input );
+
             foreach ( System.Text.RegularExpressions.Match item in result )
             {
                 newnum += item.Value;
             }
+
             return newnum;
         }
 

--- a/Source/Blazorise/Themes/ThemeGenerator.cs
+++ b/Source/Blazorise/Themes/ThemeGenerator.cs
@@ -1205,6 +1205,7 @@ namespace Blazorise
             return ToHex( ThemeColorLevel( theme, inColor, level ) );
         }
 
+
         /// <summary>
         /// Parses the supplied string value and converts it to a <see cref="System.Drawing.Color"/>.
         /// </summary>
@@ -1310,19 +1311,23 @@ namespace Blazorise
         }
 
         /// <summary>
+        /// Checks for characters that are Hexadecimal
+        /// </summary>
+        protected static Regex isHexDigit = new( "[abcdefABCDEF\\d]+", RegexOptions.Compiled );
+
+        /// <summary>
         /// Extract only the hex digits from a string.
         /// </summary>
         /// <param name="input">A string to extract.</param>
         /// <returns>A new hex string.</returns>
         protected static string ExtractHexDigits( string input )
         {
-            // remove any characters that are not digits (like #)
-            Regex isHexDigit = new( "[abcdefABCDEF\\d]+", RegexOptions.Compiled );
             string newnum = "";
             foreach ( char c in input )
             {
-                if ( isHexDigit.IsMatch( c.ToString() ) )
-                    newnum += c.ToString();
+                var charAsString = c.ToString();
+                if ( isHexDigit.IsMatch( charAsString ) )
+                    newnum += charAsString;
             }
             return newnum;
         }

--- a/Source/Blazorise/Themes/ThemeGenerator.cs
+++ b/Source/Blazorise/Themes/ThemeGenerator.cs
@@ -1322,12 +1322,11 @@ namespace Blazorise
         /// <returns>A new hex string.</returns>
         protected static string ExtractHexDigits( string input )
         {
-            string newnum = "";
-            foreach ( char c in input )
+            string newnum = string.Empty;
+            var result = isHexDigit.Matches( input );
+            foreach ( System.Text.RegularExpressions.Match item in result )
             {
-                var charAsString = c.ToString();
-                if ( isHexDigit.IsMatch( charAsString ) )
-                    newnum += charAsString;
+                newnum += item.Value;
             }
             return newnum;
         }

--- a/Tests/Blazorise.Benchmark/Blazorise.Benchmark.csproj
+++ b/Tests/Blazorise.Benchmark/Blazorise.Benchmark.csproj
@@ -10,6 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\Source\Blazorise.Bootstrap5\Blazorise.Bootstrap5.csproj" />
     <ProjectReference Include="..\..\Source\Blazorise\Blazorise.csproj" />
     <ProjectReference Include="..\..\Source\Extensions\Blazorise.DataGrid\Blazorise.DataGrid.csproj" />
   </ItemGroup>

--- a/Tests/Blazorise.Benchmark/Blazorise/ThemeBenchmark.cs
+++ b/Tests/Blazorise.Benchmark/Blazorise/ThemeBenchmark.cs
@@ -114,18 +114,18 @@ namespace Blazorise.Benchmark.Blazorise
 
         protected static string CachedExtractHexDigitsMatchesStringBuilder( string input )
         {
-            var sb = new StringBuilder(string.Empty);
+            var sb = new StringBuilder( string.Empty );
             var result = isHexDigit.Matches( input );
             foreach ( System.Text.RegularExpressions.Match item in result )
             {
-                sb.Append(item.Value);
+                sb.Append( item.Value );
             }
             return sb.ToString();
         }
 
         private static readonly string pattern = "[abcdefABCDEF\\d]+";
         private static Regex isHexDigit = new( "[abcdefABCDEF\\d]+", RegexOptions.Compiled );
-        private static Regex isHexDigitNoCompiled = new( "[abcdefABCDEF\\d]+");
+        private static Regex isHexDigitNoCompiled = new( "[abcdefABCDEF\\d]+" );
 
     }
 

--- a/Tests/Blazorise.Benchmark/Blazorise/ThemeBenchmark.cs
+++ b/Tests/Blazorise.Benchmark/Blazorise/ThemeBenchmark.cs
@@ -11,17 +11,17 @@ namespace Blazorise.Benchmark.Blazorise
     [MemoryDiagnoser]
     public class ThemeBenchmark
     {
-        IThemeGenerator _themeGenerator = new Bootstrap5.BootstrapThemeGenerator( new ThemeCache( new BlazoriseOptions( null, null ) ) );
-        private Theme theme = new();
+        //IThemeGenerator _themeGenerator = new Bootstrap5.BootstrapThemeGenerator( new ThemeCache( new BlazoriseOptions( null, null ) ) );
+        //private Theme theme = new() { };
 
+        //[Benchmark]
+        //public void GenerateStyles()
+        //    => _themeGenerator.GenerateStyles( theme );
 
-        [Benchmark]
-        public void GenerateStyles()
-            => _themeGenerator.GenerateStyles( theme );
+        //[Benchmark]
+        //public void GenerateVariables()
+        //    => _themeGenerator.GenerateVariables( theme );
 
-        [Benchmark]
-        public void GenerateVariables()
-            => _themeGenerator.GenerateVariables( theme );
 
         [Benchmark]
         public void ExtractHexDigitsBenchmark()
@@ -30,6 +30,15 @@ namespace Blazorise.Benchmark.Blazorise
         [Benchmark]
         public void CachedExtractHexDigitsBenchmark()
             => CachedExtractHexDigits( "#ffffff" );
+
+
+        [Benchmark]
+        public void CachedExtractHexDigitsAllocateOnlyOnceSpanBenchmark()
+            => CachedExtractHexDigitsAllocateOnlyOnce( "#ffffff" );
+
+        [Benchmark]
+        public void CachedExtractHexDigitsMatches()
+            => CachedExtractHexDigitsMatches( "#ffffff" );
 
         /// <summary>
         /// Extract only the hex digits from a string.
@@ -64,6 +73,46 @@ namespace Blazorise.Benchmark.Blazorise
             }
             return newnum;
         }
+
+        /// <summary>
+        /// Extract only the hex digits from a string.
+        /// </summary>
+        /// <param name="input">A string to extract.</param>
+        /// <returns>A new hex string.</returns>
+        protected static string CachedExtractHexDigitsAllocateOnlyOnce( string input )
+        {
+            string newnum = "";
+            foreach ( char c in input )
+            {
+                var charAsString = c.ToString();
+                if ( isHexDigit.IsMatch( charAsString ) )
+                    newnum += charAsString;
+            }
+
+            return newnum;
+        }
+
+
+        /// <summary>
+        /// Extract only the hex digits from a string.
+        /// </summary>
+        /// <param name="input">A string to extract.</param>
+        /// <returns>A new hex string.</returns>
+        //Need to setup tests with this to see if it's equivalent to the previous versions.
+        //Test values:
+        //#ffffff
+        //#
+        //no value
+        //null
+        //#12321321
+        //213123
+        //DFDASfçpqope
+        protected static string CachedExtractHexDigitsMatches( string input )
+        {
+            var result = isHexDigit.Matches( input );
+            return result.ToString(); 
+        }
+
 
 
         private static Regex isHexDigit = new( "[abcdefABCDEF\\d]+", RegexOptions.Compiled );

--- a/Tests/Blazorise.Benchmark/Blazorise/ThemeBenchmark.cs
+++ b/Tests/Blazorise.Benchmark/Blazorise/ThemeBenchmark.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.RegularExpressions;
+using BenchmarkDotNet.Attributes;
+using Blazorise.DataGrid.Utils;
+
+namespace Blazorise.Benchmark.Blazorise
+{
+    [MemoryDiagnoser]
+    public class ThemeBenchmark
+    {
+        [Benchmark]
+        public void ExtractHexDigitsBenchmark()
+            => ExtractHexDigits( "#ffffff" );
+
+        [Benchmark]
+        public void CachedExtractHexDigitsBenchmark()
+            => CachedExtractHexDigits( "#ffffff" );
+
+        /// <summary>
+        /// Extract only the hex digits from a string.
+        /// </summary>
+        /// <param name="input">A string to extract.</param>
+        /// <returns>A new hex string.</returns>
+        protected static string ExtractHexDigits( string input )
+        {
+            // remove any characters that are not digits (like #)
+            Regex isHexDigit = new( "[abcdefABCDEF\\d]+", RegexOptions.Compiled );
+            string newnum = "";
+            foreach ( char c in input )
+            {
+                if ( isHexDigit.IsMatch( c.ToString() ) )
+                    newnum += c.ToString();
+            }
+            return newnum;
+        }
+
+        /// <summary>
+        /// Extract only the hex digits from a string.
+        /// </summary>
+        /// <param name="input">A string to extract.</param>
+        /// <returns>A new hex string.</returns>
+        protected static string CachedExtractHexDigits( string input )
+        {
+            string newnum = "";
+            foreach ( char c in input )
+            {
+                if ( isHexDigit.IsMatch( c.ToString() ) )
+                    newnum += c.ToString();
+            }
+            return newnum;
+        }
+
+
+        private static Regex isHexDigit = new( "[abcdefABCDEF\\d]+", RegexOptions.Compiled );
+
+    }
+
+}

--- a/Tests/Blazorise.Benchmark/Blazorise/ThemeBenchmark.cs
+++ b/Tests/Blazorise.Benchmark/Blazorise/ThemeBenchmark.cs
@@ -11,17 +11,6 @@ namespace Blazorise.Benchmark.Blazorise
     [MemoryDiagnoser]
     public class ThemeBenchmark
     {
-        //IThemeGenerator _themeGenerator = new Bootstrap5.BootstrapThemeGenerator( new ThemeCache( new BlazoriseOptions( null, null ) ) );
-        //private Theme theme = new() { };
-
-        //[Benchmark]
-        //public void GenerateStyles()
-        //    => _themeGenerator.GenerateStyles( theme );
-
-        //[Benchmark]
-        //public void GenerateVariables()
-        //    => _themeGenerator.GenerateVariables( theme );
-
 
         [Benchmark]
         public void ExtractHexDigitsBenchmark()
@@ -33,18 +22,25 @@ namespace Blazorise.Benchmark.Blazorise
 
 
         [Benchmark]
-        public void CachedExtractHexDigitsAllocateOnlyOnceSpanBenchmark()
+        public void CachedExtractHexDigitsAllocateOnlyOnceBenchmark()
             => CachedExtractHexDigitsAllocateOnlyOnce( "#ffffff" );
 
         [Benchmark]
-        public void CachedExtractHexDigitsMatches()
+        public void CachedExtractHexDigitsMatchesBenchmark()
             => CachedExtractHexDigitsMatches( "#ffffff" );
 
-        /// <summary>
-        /// Extract only the hex digits from a string.
-        /// </summary>
-        /// <param name="input">A string to extract.</param>
-        /// <returns>A new hex string.</returns>
+        [Benchmark]
+        public void ExtractHexDigitsStaticBenchmark()
+            => ExtractHexDigitsStatic( "#ffffff" );
+
+        [Benchmark]
+        public void CachedExtractHexDigitsMatchesStringBuilderBenchmark()
+            => CachedExtractHexDigitsMatchesStringBuilder( "#ffffff" );
+
+        [Benchmark]
+        public void CachedExtractHexDigitsMatchesNoCompiledBenchmark()
+             => CachedExtractHexDigitsMatchesNoCompiled( "#ffffff" );
+
         protected static string ExtractHexDigits( string input )
         {
             // remove any characters that are not digits (like #)
@@ -58,11 +54,6 @@ namespace Blazorise.Benchmark.Blazorise
             return newnum;
         }
 
-        /// <summary>
-        /// Extract only the hex digits from a string.
-        /// </summary>
-        /// <param name="input">A string to extract.</param>
-        /// <returns>A new hex string.</returns>
         protected static string CachedExtractHexDigits( string input )
         {
             string newnum = "";
@@ -74,11 +65,17 @@ namespace Blazorise.Benchmark.Blazorise
             return newnum;
         }
 
-        /// <summary>
-        /// Extract only the hex digits from a string.
-        /// </summary>
-        /// <param name="input">A string to extract.</param>
-        /// <returns>A new hex string.</returns>
+        protected static string ExtractHexDigitsStatic( string input )
+        {
+            string newnum = "";
+            foreach ( char c in input )
+            {
+                if ( Regex.IsMatch( c.ToString(), pattern ) )
+                    newnum += c.ToString();
+            }
+            return newnum;
+        }
+
         protected static string CachedExtractHexDigitsAllocateOnlyOnce( string input )
         {
             string newnum = "";
@@ -93,29 +90,42 @@ namespace Blazorise.Benchmark.Blazorise
         }
 
 
-        /// <summary>
-        /// Extract only the hex digits from a string.
-        /// </summary>
-        /// <param name="input">A string to extract.</param>
-        /// <returns>A new hex string.</returns>
-        //Need to setup tests with this to see if it's equivalent to the previous versions.
-        //Test values:
-        //#ffffff
-        //#
-        //no value
-        //null
-        //#12321321
-        //213123
-        //DFDASfçpqope
         protected static string CachedExtractHexDigitsMatches( string input )
         {
+            string newnum = string.Empty;
             var result = isHexDigit.Matches( input );
-            return result.ToString(); 
+            foreach ( System.Text.RegularExpressions.Match item in result )
+            {
+                newnum += item.Value;
+            }
+            return newnum;
         }
 
+        protected static string CachedExtractHexDigitsMatchesNoCompiled( string input )
+        {
+            string newnum = string.Empty;
+            var result = isHexDigitNoCompiled.Matches( input );
+            foreach ( System.Text.RegularExpressions.Match item in result )
+            {
+                newnum += item.Value;
+            }
+            return newnum;
+        }
 
+        protected static string CachedExtractHexDigitsMatchesStringBuilder( string input )
+        {
+            var sb = new StringBuilder(string.Empty);
+            var result = isHexDigit.Matches( input );
+            foreach ( System.Text.RegularExpressions.Match item in result )
+            {
+                sb.Append(item.Value);
+            }
+            return sb.ToString();
+        }
 
+        private static readonly string pattern = "[abcdefABCDEF\\d]+";
         private static Regex isHexDigit = new( "[abcdefABCDEF\\d]+", RegexOptions.Compiled );
+        private static Regex isHexDigitNoCompiled = new( "[abcdefABCDEF\\d]+");
 
     }
 

--- a/Tests/Blazorise.Benchmark/Blazorise/ThemeBenchmark.cs
+++ b/Tests/Blazorise.Benchmark/Blazorise/ThemeBenchmark.cs
@@ -4,12 +4,25 @@ using System.Text;
 using System.Text.RegularExpressions;
 using BenchmarkDotNet.Attributes;
 using Blazorise.DataGrid.Utils;
+using Blazorise.Themes;
 
 namespace Blazorise.Benchmark.Blazorise
 {
     [MemoryDiagnoser]
     public class ThemeBenchmark
     {
+        IThemeGenerator _themeGenerator = new Bootstrap5.BootstrapThemeGenerator( new ThemeCache( new BlazoriseOptions( null, null ) ) );
+        private Theme theme = new();
+
+
+        [Benchmark]
+        public void GenerateStyles()
+            => _themeGenerator.GenerateStyles( theme );
+
+        [Benchmark]
+        public void GenerateVariables()
+            => _themeGenerator.GenerateVariables( theme );
+
         [Benchmark]
         public void ExtractHexDigitsBenchmark()
             => ExtractHexDigits( "#ffffff" );

--- a/Tests/Blazorise.Benchmark/Program.cs
+++ b/Tests/Blazorise.Benchmark/Program.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Running;
+using Blazorise.Benchmark.Blazorise;
 using Blazorise.Benchmark.DataGrid;
 using Blazorise.Extensions;
 #endregion
@@ -15,7 +16,8 @@ namespace Blazorise.Benchmark
         private static void Main( string[] args )
         {
             //_ = BenchmarkRunner.Run<SequenceEquals>();
-            _ = BenchmarkRunner.Run<ReflectionBenchmark>();
+            //_ = BenchmarkRunner.Run<ReflectionBenchmark>();
+            _ = BenchmarkRunner.Run<ThemeBenchmark>();
         }
 
         public class SequenceEquals

--- a/Tests/Blazorise.Tests/ThemeGeneratorTest.cs
+++ b/Tests/Blazorise.Tests/ThemeGeneratorTest.cs
@@ -23,7 +23,7 @@ namespace Blazorise.Tests
         [InlineData( "abcdef", "abcdef" )]
         [InlineData( "abcdeflol", "abcdef" )]
         [InlineData( "lolabcdeflol", "abcdef" )]
-        public void ExtractHexDigits_Returns_CorrectHexDigits( string colorInput, string expected)
+        public void ExtractHexDigits_Returns_CorrectHexDigits( string colorInput, string expected )
         {
             var result = MockThemeGenerator.ExtractHexDigitsTest( colorInput );
 

--- a/Tests/Blazorise.Tests/ThemeGeneratorTest.cs
+++ b/Tests/Blazorise.Tests/ThemeGeneratorTest.cs
@@ -1,0 +1,78 @@
+﻿using System.Text.RegularExpressions;
+using Blazorise.Themes;
+using Xunit;
+
+namespace Blazorise.Tests
+{
+    public class ThemeGeneratorTest
+    {
+
+        public ThemeGeneratorTest()
+        {
+        }
+
+        [Theory]
+        [InlineData( "", "" )]
+        [InlineData( "#", "" )]
+        [InlineData( "123", "123" )]
+        [InlineData( "#999999", "999999" )]
+        [InlineData( "#FFFFFF", "FFFFFF" )]
+        [InlineData( "#ABCDEF", "ABCDEF" )]
+        [InlineData( "#abcdef", "abcdef" )]
+        [InlineData( "abcdef", "abcdef" )]
+        [InlineData( "abcdeflol", "abcdef" )]
+        [InlineData( "lolabcdeflol", "abcdef" )]
+        public void CachedExtractHexDigitsMatches_Returns_CorrectHexDigits( string colorInput, string expected)
+        {
+            var result = CachedExtractHexDigitsMatches( colorInput );
+
+            Assert.Equal( expected, result );
+        }
+
+        [Theory]
+        [InlineData( "", "" )]
+        [InlineData( "#", "" )]
+        [InlineData( "123", "123" )]
+        [InlineData( "#999999", "999999" )]
+        [InlineData( "#FFFFFF", "FFFFFF" )]
+        [InlineData( "#ABCDEF", "ABCDEF" )]
+        [InlineData( "#abcdef", "abcdef" )]
+        [InlineData( "abcdef", "abcdef" )]
+        [InlineData( "abcdeflol", "abcdef" )]
+        [InlineData( "lolabcdeflol", "abcdef" )]
+        public void CachedExtractHexDigitsAllocateOnlyOnce_Returns_CorrectHexDigits( string colorInput, string expected )
+        {
+            var result = CachedExtractHexDigitsAllocateOnlyOnce( colorInput );
+
+            Assert.Equal( expected, result );
+        }
+
+        protected static string CachedExtractHexDigitsMatches( string input )
+        {
+            string newnum = string.Empty;
+            var result = isHexDigit.Matches( input );
+            foreach ( System.Text.RegularExpressions.Match item in result )
+            {
+                newnum += item.Value;
+            }
+            return newnum;
+        }
+
+        protected static string CachedExtractHexDigitsAllocateOnlyOnce( string input )
+        {
+            string newnum = "";
+            foreach ( char c in input )
+            {
+                var charAsString = c.ToString();
+                if ( isHexDigit.IsMatch( charAsString ) )
+                    newnum += charAsString;
+            }
+
+            return newnum;
+        }
+
+        private static Regex isHexDigit = new( "[abcdefABCDEF\\d]+", RegexOptions.Compiled );
+
+
+    }
+}

--- a/Tests/Blazorise.Tests/ThemeGeneratorTest.cs
+++ b/Tests/Blazorise.Tests/ThemeGeneratorTest.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.RegularExpressions;
+﻿using System.Text;
+using System.Text.RegularExpressions;
 using Blazorise.Themes;
 using Xunit;
 
@@ -22,57 +23,162 @@ namespace Blazorise.Tests
         [InlineData( "abcdef", "abcdef" )]
         [InlineData( "abcdeflol", "abcdef" )]
         [InlineData( "lolabcdeflol", "abcdef" )]
-        public void CachedExtractHexDigitsMatches_Returns_CorrectHexDigits( string colorInput, string expected)
+        public void ExtractHexDigits_Returns_CorrectHexDigits( string colorInput, string expected)
         {
-            var result = CachedExtractHexDigitsMatches( colorInput );
+            var result = MockThemeGenerator.ExtractHexDigitsTest( colorInput );
 
             Assert.Equal( expected, result );
         }
 
-        [Theory]
-        [InlineData( "", "" )]
-        [InlineData( "#", "" )]
-        [InlineData( "123", "123" )]
-        [InlineData( "#999999", "999999" )]
-        [InlineData( "#FFFFFF", "FFFFFF" )]
-        [InlineData( "#ABCDEF", "ABCDEF" )]
-        [InlineData( "#abcdef", "abcdef" )]
-        [InlineData( "abcdef", "abcdef" )]
-        [InlineData( "abcdeflol", "abcdef" )]
-        [InlineData( "lolabcdeflol", "abcdef" )]
-        public void CachedExtractHexDigitsAllocateOnlyOnce_Returns_CorrectHexDigits( string colorInput, string expected )
-        {
-            var result = CachedExtractHexDigitsAllocateOnlyOnce( colorInput );
 
-            Assert.Equal( expected, result );
-        }
-
-        protected static string CachedExtractHexDigitsMatches( string input )
+        public class MockThemeGenerator : ThemeGenerator
         {
-            string newnum = string.Empty;
-            var result = isHexDigit.Matches( input );
-            foreach ( System.Text.RegularExpressions.Match item in result )
+            public MockThemeGenerator( IThemeCache themeCache ) : base( themeCache )
             {
-                newnum += item.Value;
-            }
-            return newnum;
-        }
-
-        protected static string CachedExtractHexDigitsAllocateOnlyOnce( string input )
-        {
-            string newnum = "";
-            foreach ( char c in input )
-            {
-                var charAsString = c.ToString();
-                if ( isHexDigit.IsMatch( charAsString ) )
-                    newnum += charAsString;
             }
 
-            return newnum;
+            internal static string ExtractHexDigitsTest( string input )
+                => ExtractHexDigits( input );
+
+            protected override void GenerateAlertStyles( StringBuilder sb, Theme theme, ThemeAlertOptions options )
+            {
+                throw new System.NotImplementedException();
+            }
+
+            protected override void GenerateAlertVariantStyles( StringBuilder sb, Theme theme, string variant, string inBackgroundColor, string inBorderColor, string inColor, ThemeAlertOptions options )
+            {
+                throw new System.NotImplementedException();
+            }
+
+            protected override void GenerateBackgroundVariantStyles( StringBuilder sb, Theme theme, string variant )
+            {
+                throw new System.NotImplementedException();
+            }
+
+            protected override void GenerateBadgeStyles( StringBuilder sb, Theme theme, ThemeBadgeOptions options )
+            {
+                throw new System.NotImplementedException();
+            }
+
+            protected override void GenerateBadgeVariantStyles( StringBuilder sb, Theme theme, string variant, string inBackgroundColor )
+            {
+                throw new System.NotImplementedException();
+            }
+
+            protected override void GenerateBarStyles( StringBuilder sb, Theme theme, ThemeBarOptions options )
+            {
+                throw new System.NotImplementedException();
+            }
+
+            protected override void GenerateBorderVariantStyles( StringBuilder sb, Theme theme, string variant )
+            {
+                throw new System.NotImplementedException();
+            }
+
+            protected override void GenerateBreadcrumbStyles( StringBuilder sb, Theme theme, ThemeBreadcrumbOptions options )
+            {
+                throw new System.NotImplementedException();
+            }
+
+            protected override void GenerateButtonOutlineVariantStyles( StringBuilder sb, Theme theme, string variant, ThemeButtonOptions options )
+            {
+                throw new System.NotImplementedException();
+            }
+
+            protected override void GenerateButtonStyles( StringBuilder sb, Theme theme, ThemeButtonOptions options )
+            {
+                throw new System.NotImplementedException();
+            }
+
+            protected override void GenerateButtonVariantStyles( StringBuilder sb, Theme theme, string variant, ThemeButtonOptions options )
+            {
+                throw new System.NotImplementedException();
+            }
+
+            protected override void GenerateCardStyles( StringBuilder sb, Theme theme, ThemeCardOptions options )
+            {
+                throw new System.NotImplementedException();
+            }
+
+            protected override void GenerateDropdownStyles( StringBuilder sb, Theme theme, ThemeDropdownOptions options )
+            {
+                throw new System.NotImplementedException();
+            }
+
+            protected override void GenerateInputStyles( StringBuilder sb, Theme theme, ThemeInputOptions options )
+            {
+                throw new System.NotImplementedException();
+            }
+
+            protected override void GenerateInputVariantStyles( StringBuilder sb, Theme theme, string variant, string color )
+            {
+                throw new System.NotImplementedException();
+            }
+
+            protected override void GenerateListGroupItemStyles( StringBuilder sb, Theme theme, ThemeListGroupItemOptions options )
+            {
+                throw new System.NotImplementedException();
+            }
+
+            protected override void GenerateListGroupItemVariantStyles( StringBuilder sb, Theme theme, string variant, string inBackgroundColor, string inColor, ThemeListGroupItemOptions options )
+            {
+                throw new System.NotImplementedException();
+            }
+
+            protected override void GenerateModalStyles( StringBuilder sb, Theme theme, ThemeModalOptions options )
+            {
+                throw new System.NotImplementedException();
+            }
+
+            protected override void GeneratePaginationStyles( StringBuilder sb, Theme theme, ThemePaginationOptions options )
+            {
+                throw new System.NotImplementedException();
+            }
+
+            protected override void GenerateParagraphVariantStyles( StringBuilder sb, Theme theme, string variant, string color )
+            {
+                throw new System.NotImplementedException();
+            }
+
+            protected override void GenerateRatingStyles( StringBuilder sb, Theme theme, ThemeRatingOptions options )
+            {
+                throw new System.NotImplementedException();
+            }
+
+            protected override void GenerateRatingVariantStyles( StringBuilder sb, Theme theme, string variant, string inBackgroundColor, ThemeRatingOptions ratingOptions )
+            {
+                throw new System.NotImplementedException();
+            }
+
+            protected override void GenerateSpacingStyles( StringBuilder sb, Theme theme, ThemeSpacingOptions options )
+            {
+                throw new System.NotImplementedException();
+            }
+
+            protected override void GenerateStepsStyles( StringBuilder sb, Theme theme, ThemeStepsOptions options )
+            {
+                throw new System.NotImplementedException();
+            }
+
+            protected override void GenerateStepsVariantStyles( StringBuilder sb, Theme theme, string variant, string inBackgroundColor, ThemeStepsOptions stepsOptions )
+            {
+                throw new System.NotImplementedException();
+            }
+
+            protected override void GenerateSwitchVariantStyles( StringBuilder sb, Theme theme, string variant, string inBackgroundColor, ThemeSwitchOptions switchOptions )
+            {
+                throw new System.NotImplementedException();
+            }
+
+            protected override void GenerateTableVariantStyles( StringBuilder sb, Theme theme, string variant, string inBackgroundColor, string inBorderColor )
+            {
+                throw new System.NotImplementedException();
+            }
+
+            protected override void GenerateTabsStyles( StringBuilder sb, Theme theme, ThemeTabsOptions options )
+            {
+                throw new System.NotImplementedException();
+            }
         }
-
-        private static Regex isHexDigit = new( "[abcdefABCDEF\\d]+", RegexOptions.Compiled );
-
-
     }
 }


### PR DESCRIPTION
Closes #3133 

Didn't have time to finish yet.
Need to test Regex.Matches vs our version as I am not 100% it's 100% logically equivalent. If it is, then it's way faster.

![image](https://user-images.githubusercontent.com/22283161/142513601-d6d44fa3-782c-47af-9c7e-ea79403042fa.png)

Also need to do some reading up on https://docs.microsoft.com/en-us/dotnet/standard/base-types/best-practices as static method `Regex.IsMatch` might also be worth considering...
**Edit:** I'm not sure if additional steps need to be taken to actually take advantage of `RegexOptions.Compiled` ?


Also consider using Span in the future to do internal optimizations in string manipulation... might be worth it for 1.0.0
A good resource: 
https://www.youtube.com/watch?v=FM5dpxJMULY&ab_channel=NickChapsas