### PR TITLE
DataGrid : Fixes Modal Closing not being called correctly on Cancel.

### DIFF
--- a/Source/Extensions/Blazorise.DataGrid/_DataGridModal.razor
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridModal.razor
@@ -81,7 +81,7 @@
                     {
                         @ParentDataGrid.CommandColumn.CancelCommandTemplate( new()
                         {
-                            Clicked = EventCallback.Factory.Create(this, CloseModal),
+                            Clicked = EventCallback.Factory.Create( this, CloseModal ),
                             LocalizationString = cancelButtonString,
                             Item = EditItem,
                         } )

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridModal.razor
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridModal.razor
@@ -1,6 +1,6 @@
 ﻿@typeparam TItem
 @inherits _BaseDataGridModal<TItem>
-<Modal Visible="@PopupVisible" Closing="@PopupClosing" Closed="@Cancel">
+<Modal @ref="modalRef" Visible="@PopupVisible" Closing="@PopupClosing" Closed="@Cancel">
     <ModalContent Size="@PopupSize">
         <Form>
             <ModalHeader>
@@ -18,7 +18,7 @@
                             : Localizer.Localize( ParentDataGrid.Localizers?.ModalRowCreateLocalizer, "Row Create" ))
                     }
                 </ModalTitle>
-                <CloseButton Clicked="@Cancel" AutoClose="false" />
+                <CloseButton Clicked="@CloseModal" AutoClose="false" />
             </ModalHeader>
             <ModalBody>
                 <Validations @ref="validations" Mode="ValidationMode.Manual" StatusChanged="@ValidationsStatusChanged" Model="@ValidationItem">
@@ -81,14 +81,14 @@
                     {
                         @ParentDataGrid.CommandColumn.CancelCommandTemplate( new()
                         {
-                            Clicked = Cancel,
+                            Clicked = EventCallback.Factory.Create(this, CloseModal),
                             LocalizationString = cancelButtonString,
                             Item = EditItem,
                         } )
                     }
                     else
                     {
-                        <Button Color="Color.Link" Clicked="@Cancel">
+                        <Button Color="Color.Link" Clicked="@CloseModal">
                             @cancelButtonString
                         </Button>
                     }

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridModal.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridModal.razor.cs
@@ -13,6 +13,8 @@ namespace Blazorise.DataGrid
     {
         #region Members
 
+        protected Modal modalRef;
+
         protected EventCallbackFactory callbackFactory = new();
 
         protected Validations validations;
@@ -59,6 +61,9 @@ namespace Blazorise.DataGrid
                 await ParentDataGrid.Save();
             }
         }
+
+        protected Task CloseModal()
+            => modalRef.Hide();
 
         #endregion
 


### PR DESCRIPTION
Closes #3149

This one has probably been there for a while haha. Problem only with Datagrid internal modal which wasn't going through the Modal.Hide/Close pipeline on Cancel button press.