### PR TITLE
Markdown: add missing actions

### DIFF
--- a/Source/Extensions/Blazorise.Markdown/Enums.cs
+++ b/Source/Extensions/Blazorise.Markdown/Enums.cs
@@ -3,7 +3,8 @@
     /// <summary>
     /// Markdown toolbar actions.
     /// </summary>
-    /// <seealso href="https://github.com/Ionaru/easy-markdown-editor#toolbar-icons"/>
+    /// <seealso href="https://github.com/Ionaru/easy-markdown-editor#toolbar-icons"/> and
+    /// <seealso href="https://github.com/Ionaru/easy-markdown-editor/blob/master/src/js/easymde.js"/>
     public enum MarkdownAction
     {
         Bold,
@@ -28,5 +29,7 @@
         SideBySide,
         Fullscreen,
         Guide,
+        Undo,
+        Redo,
     }
 }

--- a/Source/Extensions/Blazorise.Markdown/Enums.cs
+++ b/Source/Extensions/Blazorise.Markdown/Enums.cs
@@ -31,5 +31,6 @@
         Guide,
         Undo,
         Redo,
+        UploadImage,
     }
 }

--- a/Source/Extensions/Blazorise.Markdown/Providers/MarkdownActionProvider.cs
+++ b/Source/Extensions/Blazorise.Markdown/Providers/MarkdownActionProvider.cs
@@ -39,6 +39,8 @@ namespace Blazorise.Markdown.Providers
                 MarkdownAction.SideBySide => "side-by-side",
                 MarkdownAction.Fullscreen => "fullscreen",
                 MarkdownAction.Guide => "guide",
+                MarkdownAction.Undo => "undo",
+                MarkdownAction.Redo => "redo",
                 _ => name
             };
         }
@@ -71,6 +73,8 @@ namespace Blazorise.Markdown.Providers
                 MarkdownAction.SideBySide => "toggleSideBySide",
                 MarkdownAction.Fullscreen => "toggleFullScreen",
                 MarkdownAction.Guide => "https://www.markdownguide.org/basic-syntax/",
+                MarkdownAction.Undo => "undo",
+                MarkdownAction.Redo => "redo",
                 _ => null
             };
 
@@ -106,6 +110,8 @@ namespace Blazorise.Markdown.Providers
                 MarkdownAction.SideBySide => "fa fa-columns no-disable no-mobile",
                 MarkdownAction.Fullscreen => "fa fa-arrows-alt no-disable no-mobile",
                 MarkdownAction.Guide => "fa fa-question-circle",
+                MarkdownAction.Undo => "fa fa-undo",
+                MarkdownAction.Redo => "fa fa-repeat fa-redo",
                 _ => icon
             };
         }

--- a/Source/Extensions/Blazorise.Markdown/Providers/MarkdownActionProvider.cs
+++ b/Source/Extensions/Blazorise.Markdown/Providers/MarkdownActionProvider.cs
@@ -41,6 +41,7 @@ namespace Blazorise.Markdown.Providers
                 MarkdownAction.Guide => "guide",
                 MarkdownAction.Undo => "undo",
                 MarkdownAction.Redo => "redo",
+                MarkdownAction.UploadImage => "upload-image",
                 _ => name
             };
         }
@@ -75,6 +76,7 @@ namespace Blazorise.Markdown.Providers
                 MarkdownAction.Guide => "https://www.markdownguide.org/basic-syntax/",
                 MarkdownAction.Undo => "undo",
                 MarkdownAction.Redo => "redo",
+                MarkdownAction.UploadImage => "drawUploadedImage",
                 _ => null
             };
 
@@ -112,6 +114,7 @@ namespace Blazorise.Markdown.Providers
                 MarkdownAction.Guide => "fa fa-question-circle",
                 MarkdownAction.Undo => "fa fa-undo",
                 MarkdownAction.Redo => "fa fa-repeat fa-redo",
+                MarkdownAction.UploadImage => "fa fa-image",
                 _ => icon
             };
         }


### PR DESCRIPTION
EasyMDE has three actions not described in the [readme](https://github.com/Ionaru/easy-markdown-editor#toolbar-icons), yet.
They are in the code:
https://github.com/Ionaru/easy-markdown-editor/blob/master/src/js/easymde.js#L1614-L1626 (undo/redo)
https://github.com/Ionaru/easy-markdown-editor/blob/master/src/js/easymde.js#L1553-L1558 (upload-image)

Undo/Redo is already available through shortcuts.

(Another approach to support this would be to allow custom actions that are passed through to EasyMDE - currently that's restricted by the internal [MarkdownActionProvider](https://github.com/Megabit/Blazorise/blob/master/Source/Extensions/Blazorise.Markdown/Providers/MarkdownActionProvider.cs)).