### PR TITLE
Make sure SelectedRow/SelectedRows changes are always notificated to DatagridRow

### DIFF
--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor
@@ -214,9 +214,9 @@
 @code {
 
     private RenderFragment paginationFragment => __builder =>
-                        {
-                        <_DataGridPagination TItem="TItem" PaginationContext="@PaginationContext" PaginationTemplates="@PaginationTemplates" OnPaginationItemClick="@(EventCallback.Factory.Create<string>(this, Paginate))" SelectedRow="@SelectedRow" />
-                        };
+    {
+        <_DataGridPagination TItem="TItem" PaginationContext="@PaginationContext" PaginationTemplates="@PaginationTemplates" OnPaginationItemClick="@(EventCallback.Factory.Create<string>(this, Paginate))" SelectedRow="@SelectedRow" />
+    };
 
     protected RenderFragment<TItem> rowFragment => item => __builder =>
     {
@@ -226,7 +226,7 @@
         }
         else
         {
-            <_DataGridRow @key="@item" TItem="TItem" Item="@item" />
+            <_DataGridRow @key="@item" TItem="TItem" Item="@item" SelectedRows="SelectedRows" SelectedRow="SelectedRow" />
             if ( DetailRowTemplate != null && ( GetRowInfo( item )?.HasDetailRow ?? false ) )
             {
                 <_DataGridDetailRow TItem="TItem" Item="@item" Columns="@Columns">

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridRow.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridRow.razor.cs
@@ -59,6 +59,12 @@ namespace Blazorise.DataGrid
                     case nameof( ParentDataGrid ):
                         ParentDataGrid = (DataGrid<TItem>)parameter.Value;
                         break;
+                    case nameof( SelectedRow ):
+                        SelectedRow = (TItem)parameter.Value;
+                        break;
+                    case nameof( SelectedRows ):
+                        SelectedRows = (List<TItem>)parameter.Value;
+                        break;
                     default:
                         throw new ArgumentException( $"Unknown parameter: {parameter.Name}" );
                 }
@@ -247,6 +253,16 @@ namespace Blazorise.DataGrid
         [Parameter] public TItem Item { get; set; }
 
         [Parameter] public RenderFragment ChildContent { get; set; }
+
+        /// <summary>
+        /// Gets or sets currently selected row.
+        /// </summary>
+        [Parameter] public TItem SelectedRow { get; set; }
+
+        /// <summary>
+        /// Gets or sets currently selected rows.
+        /// </summary>
+        [Parameter] public List<TItem> SelectedRows { get; set; }
 
         #endregion
     }


### PR DESCRIPTION
Make sure SelectedRow/SelectedRows changes are always notificated to DatagridRow by re-setting them up as parameters.

I think there was one more issue related to this but I can't seem to find it now.
Closes #3386

**Code used for testing:** 
(Basically select rows, then mutate the SelectedRows...  see if it propagates successfully.)
```
<DataGrid 
@ref="dataGridRef"
            TItem="string" Data="@dataList" Narrow="true" FixedHeader="true" Virtualize="false"
          VirtualizeOptions="@(new Blazorise.DataGrid.Configuration.VirtualizeOptions() { DataGridHeight="calc(-8px + 70vh) !important", DataGridMaxHeight="calc(-8px + 70vh) !important" })"
          Striped="true" Bordered="true" Filterable="true" Sortable="false" SelectionMode="DataGridSelectionMode.Multiple"
          Responsive="true"
          SelectedRows="@myList"
          SelectedRowsChanged="@AddOrRemoveMyList">
    <DataGridColumn TItem="string" Caption="No">
        <DisplayTemplate>
            @context
        </DisplayTemplate>
    </DataGridColumn>
</DataGrid>
<Button Color="Color.Danger" Clicked="@ResetSelection">Reset</Button>
@String.Join(',' , myList)
@code {
    private DataGrid<string> dataGridRef;
    private List<string> dataList = new List<string>() { "a", "b", "c", "d", "e", "f" };
    private List<string> myList = new List<string>();

    private void AddOrRemoveMyList(List<string> someList)
    {
        myList = someList;
        StateHasChanged();
    }

    private void ResetSelection()
    {
        myList = new List<string>();
        //myList.Clear();
        StateHasChanged();
    }
}

```