### PR TITLE
Allow Sort Template when There is No Sort Direction, and Display a Default Sort Icon on Sortable Columns

### DIFF
--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor
@@ -53,7 +53,7 @@
                                             @column.Caption
                                         }
                                     }
-                                    @if ( Sortable && column.Sortable && column.CurrentSortDirection != SortDirection.Default )
+                                    @if ( Sortable && column.Sortable )
                                     {
                                         @if ( column.SortDirectionTemplate != null )
                                         {

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor
@@ -61,7 +61,7 @@
                                         }
                                         else
                                         {
-                                            <Icon Name="@(column.CurrentSortDirection == SortDirection.Descending ? IconName.SortDown : IconName.SortUp)" />
+                                            <Icon Name="@(column.CurrentSortDirection == SortDirection.Default ? IconName.Sort : ( column.CurrentSortDirection == SortDirection.Descending ? IconName.SortDown : IconName.SortUp ) )" />
                                         }
                                     }
                                 </TableHeaderCell>


### PR DESCRIPTION
Edited Datagrid component to allow a SortTemplate to render when `column.CurrentDirection == SortDirection.Default`. Additionally, columns that are sortable will now display the FontAwesome Sort icon `IconName.Sort`.

Passed all unit tests, visually inspected performance in the Bootstrap 5 Demo Client. Works as intended.

Resolves #3455 