### PR TITLE
Fix NumericPicker null checks and Immediate mode

### DIFF
--- a/Documentation/Blazorise.Docs/Models/Snippets.generated.cs
+++ b/Documentation/Blazorise.Docs/Models/Snippets.generated.cs
@@ -1589,6 +1589,18 @@ namespace Blazorise.Docs.Models
 
         public const string NumericPickerGenericExample = @"<NumericPicker TValue=""decimal?"" />";
 
+        public const string NumericPickerIntegerExample = @"<NumericPicker @bind-Value=""@value"" Decimals=""0"" />
+
+@code{
+    int value;
+}";
+
+        public const string NumericPickerMinMaxExample = @"<NumericPicker @bind-Value=""@value"" Min=""10"" Max=""20"" />
+
+@code{
+    decimal value = 15;
+}";
+
         public const string NumericPickerStepExample = @"<NumericPicker @bind-Value=""@value"" Step=""10"" />
 
 @code{

--- a/Documentation/Blazorise.Docs/Pages/Docs/Components/Numerics/Code/NumericPickerIntegerExampleCode.html
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Components/Numerics/Code/NumericPickerIntegerExampleCode.html
@@ -1,0 +1,10 @@
+<div class="blazorise-codeblock">
+<div class="html"><pre>
+<span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">NumericPicker</span> <span class="htmlAttributeName"><span class="atSign">&#64;</span>bind-Value</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="sharpVariable"><span class="atSign">&#64;</span>value</span><span class="quot">&quot;</span> <span class="htmlAttributeName">Decimals</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">0</span><span class="quot">&quot;</span> <span class="htmlTagDelimiter">/&gt;</span>
+</pre></div>
+<div class="csharp"><pre>
+<span class="atSign">&#64;</span>code{
+    <span class="keyword">int</span> value;
+}
+</pre></div>
+</div>

--- a/Documentation/Blazorise.Docs/Pages/Docs/Components/Numerics/Code/NumericPickerMinMaxExampleCode.html
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Components/Numerics/Code/NumericPickerMinMaxExampleCode.html
@@ -1,0 +1,10 @@
+<div class="blazorise-codeblock">
+<div class="html"><pre>
+<span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">NumericPicker</span> <span class="htmlAttributeName"><span class="atSign">&#64;</span>bind-Value</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="sharpVariable"><span class="atSign">&#64;</span>value</span><span class="quot">&quot;</span> <span class="htmlAttributeName">Min</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">10</span><span class="quot">&quot;</span> <span class="htmlAttributeName">Max</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">20</span><span class="quot">&quot;</span> <span class="htmlTagDelimiter">/&gt;</span>
+</pre></div>
+<div class="csharp"><pre>
+<span class="atSign">&#64;</span>code{
+    <span class="keyword">decimal</span> value = <span class="number">15</span>;
+}
+</pre></div>
+</div>

--- a/Documentation/Blazorise.Docs/Pages/Docs/Components/Numerics/Examples/NumericPickerIntegerExample.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Components/Numerics/Examples/NumericPickerIntegerExample.razor
@@ -1,0 +1,7 @@
+﻿@namespace Blazorise.Docs.Docs.Examples
+
+<NumericPicker @bind-Value="@value" Decimals="0" />
+
+@code{
+    int value;
+}

--- a/Documentation/Blazorise.Docs/Pages/Docs/Components/Numerics/Examples/NumericPickerMinMaxExample.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Components/Numerics/Examples/NumericPickerMinMaxExample.razor
@@ -1,0 +1,7 @@
+﻿@namespace Blazorise.Docs.Docs.Examples
+
+<NumericPicker @bind-Value="@value" Min="10" Max="20" />
+
+@code{
+    decimal value = 15;
+}

--- a/Documentation/Blazorise.Docs/Pages/Docs/Components/Numerics/NumericPickerPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Components/Numerics/NumericPickerPage.razor
@@ -63,6 +63,26 @@
     <DocsPageSectionSource Code="NumericPickerStepExample" />
 </DocsPageSection>
 
+<DocsPageSection>
+    <DocsPageSectionHeader Title="Setting the Min & Max">
+        Set the <Code>Min</Code> & <Code>Max</Code> to limit the values allowed into the input.
+    </DocsPageSectionHeader>
+    <DocsPageSectionContent Outlined FullWidth>
+        <NumericPickerMinMaxExample />
+    </DocsPageSectionContent>
+    <DocsPageSectionSource Code="NumericPickerMinMaxExample" />
+</DocsPageSection>
+
+<DocsPageSection>
+    <DocsPageSectionHeader Title="Integer values">
+        To only allow the integer values without the decimals, you can set the <Code>Decimals="0"</Code>
+    </DocsPageSectionHeader>
+    <DocsPageSectionContent Outlined FullWidth>
+        <NumericPickerIntegerExample />
+    </DocsPageSectionContent>
+    <DocsPageSectionSource Code="NumericPickerIntegerExample" />
+</DocsPageSection>
+
 <DocsPageSubtitle>
     Attributes
 </DocsPageSubtitle>

--- a/Source/Blazorise.Bootstrap/NumericPicker.razor
+++ b/Source/Blazorise.Bootstrap/NumericPicker.razor
@@ -3,7 +3,7 @@
 @if ( IsShowStepButtons )
 {
     <div class="@NumericWrapperClassNames">
-        <input @ref="@ElementRef" id="@ElementId" inputmode="numeric" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" size="@VisibleCharacters" step="@Step" pattern="@Pattern" tabindex="@TabIndex" value="@CurrentValueAsString" @onchange="@OnChangeHandler" @oninput="@OnInputHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+        @InputTemplate
         <div class="b-numeric-handler-wrap">
             <Blazorise.Button Clicked="@OnSpinUpClicked" Class="b-numeric-handler b-numeric-handler-up" TabIndex="-1">
                 <Icon Name="IconName.SortUp" />
@@ -16,7 +16,21 @@
 }
 else
 {
-    <input @ref="@ElementRef" id="@ElementId" inputmode="numeric" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" size="@VisibleCharacters" step="@Step" pattern="@Pattern" tabindex="@TabIndex" value="@CurrentValueAsString" @onchange="@OnChangeHandler" @oninput="@OnInputHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+    @InputTemplate
 }
 @ChildContent
 @Feedback
+@code
+{
+    protected RenderFragment InputTemplate => __builder =>
+    {
+        @if ( IsImmediate && IsDebounce )
+        {
+            <input @ref="@ElementRef" id="@ElementId" inputmode="numeric" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" size="@VisibleCharacters" step="@Step" pattern="@Pattern" tabindex="@TabIndex" value="@CurrentValueAsString" @oninput="@OnInputHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+        }
+        else
+        {
+            <input @ref="@ElementRef" id="@ElementId" inputmode="numeric" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" size="@VisibleCharacters" step="@Step" pattern="@Pattern" tabindex="@TabIndex" @bind-value="@CurrentValueAsString" @bind-value:event="@BindValueEventName" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+        }
+    };
+}

--- a/Source/Blazorise.Bootstrap5/NumericPicker.razor
+++ b/Source/Blazorise.Bootstrap5/NumericPicker.razor
@@ -3,7 +3,7 @@
 @if ( IsShowStepButtons )
 {
     <div class="@NumericWrapperClassNames">
-        <input @ref="@ElementRef" id="@ElementId" inputmode="numeric" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" size="@VisibleCharacters" step="@Step" pattern="@Pattern" tabindex="@TabIndex" value="@CurrentValueAsString" @onchange="@OnChangeHandler" @oninput="@OnInputHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+        @InputTemplate
         <div class="b-numeric-handler-wrap">
             <Blazorise.Button Clicked="@OnSpinUpClicked" Class="b-numeric-handler b-numeric-handler-up" TabIndex="-1">
                 <Icon Name="IconName.SortUp" />
@@ -16,7 +16,21 @@
 }
 else
 {
-    <input @ref="@ElementRef" id="@ElementId" inputmode="numeric" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" size="@VisibleCharacters" step="@Step" pattern="@Pattern" tabindex="@TabIndex" value="@CurrentValueAsString" @onchange="@OnChangeHandler" @oninput="@OnInputHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+    @InputTemplate
 }
 @ChildContent
 @Feedback
+@code
+{
+    protected RenderFragment InputTemplate => __builder =>
+    {
+        @if ( IsImmediate && IsDebounce )
+        {
+            <input @ref="@ElementRef" id="@ElementId" inputmode="numeric" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" size="@VisibleCharacters" step="@Step" pattern="@Pattern" tabindex="@TabIndex" value="@CurrentValueAsString" @oninput="@OnInputHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+        }
+        else
+        {
+            <input @ref="@ElementRef" id="@ElementId" inputmode="numeric" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" size="@VisibleCharacters" step="@Step" pattern="@Pattern" tabindex="@TabIndex" @bind-value="@CurrentValueAsString" @bind-value:event="@BindValueEventName" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+        }
+    };
+}

--- a/Source/Blazorise.Bulma/NumericPicker.razor
+++ b/Source/Blazorise.Bulma/NumericPicker.razor
@@ -4,7 +4,7 @@
 {
     <div class="field">
         <div class="control">
-            <input @ref="@ElementRef" id="@ElementId" inputmode="numeric" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" size="@VisibleCharacters" step="@Step" pattern="@Pattern" tabindex="@TabIndex" value="@CurrentValueAsString" @onchange="@OnChangeHandler" @oninput="@OnInputHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+            @InputTemplate
             @ChildContent
         </div>
         @Feedback
@@ -13,8 +13,22 @@
 else
 {
     <div class="control">
-        <input @ref="@ElementRef" id="@ElementId" inputmode="numeric" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" size="@VisibleCharacters" step="@Step" pattern="@Pattern" tabindex="@TabIndex" value="@CurrentValueAsString" @onchange="@OnChangeHandler" @oninput="@OnInputHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+        @InputTemplate
         @ChildContent
     </div>
     @Feedback
+}
+@code
+{
+    protected RenderFragment InputTemplate => __builder =>
+    {
+        @if ( IsImmediate && IsDebounce )
+        {
+            <input @ref="@ElementRef" id="@ElementId" inputmode="numeric" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" size="@VisibleCharacters" step="@Step" pattern="@Pattern" tabindex="@TabIndex" value="@CurrentValueAsString" @oninput="@OnInputHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+        }
+        else
+        {
+            <input @ref="@ElementRef" id="@ElementId" inputmode="numeric" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" size="@VisibleCharacters" step="@Step" pattern="@Pattern" tabindex="@TabIndex" @bind-value="@CurrentValueAsString" @bind-value:event="@BindValueEventName" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+        }
+    };
 }

--- a/Source/Blazorise.Material/NumericPicker.razor
+++ b/Source/Blazorise.Material/NumericPicker.razor
@@ -1,5 +1,12 @@
 ﻿@typeparam TValue
 @inherits Blazorise.NumericPicker<TValue>
-<input @ref="@ElementRef" id="@ElementId" inputmode="numeric" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" size="@VisibleCharacters" step="@Step" pattern="@Pattern" tabindex="@TabIndex" value="@CurrentValueAsString" @onchange="@OnChangeHandler" @oninput="@OnInputHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+@if ( IsImmediate && IsDebounce )
+{
+    <input @ref="@ElementRef" id="@ElementId" inputmode="numeric" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" size="@VisibleCharacters" step="@Step" pattern="@Pattern" tabindex="@TabIndex" value="@CurrentValueAsString" @oninput="@OnInputHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+}
+else
+{
+    <input @ref="@ElementRef" id="@ElementId" inputmode="numeric" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" size="@VisibleCharacters" step="@Step" pattern="@Pattern" tabindex="@TabIndex" @bind-value="@CurrentValueAsString" @bind-value:event="@BindValueEventName" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+}
 @ChildContent
 @Feedback

--- a/Source/Blazorise/Base/BaseDebounceTextInput.cs
+++ b/Source/Blazorise/Base/BaseDebounceTextInput.cs
@@ -1,0 +1,191 @@
+﻿#region Using directives
+using System;
+using System.Threading.Tasks;
+using Blazorise.Utilities;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+#endregion
+
+namespace Blazorise
+{
+    public abstract class BaseDebounceTextInput<TValue> : BaseTextInput<TValue>, IDisposable
+    {
+        #region Members
+
+        private ValueDebouncer inputValueDebouncer;
+
+        #endregion
+
+        #region Methods
+
+        /// <inheritdoc/>
+        protected override void OnInitialized()
+        {
+            if ( IsDebounce )
+            {
+                inputValueDebouncer = new( DebounceIntervalValue );
+                inputValueDebouncer.Debounce += OnInputValueDebounce;
+            }
+
+            base.OnInitialized();
+        }
+
+        /// <inheritdoc/>
+        protected override void Dispose( bool disposing )
+        {
+            if ( disposing )
+            {
+                ReleaseResources();
+            }
+
+            base.Dispose( disposing );
+        }
+
+        /// <inheritdoc/>
+        protected override ValueTask DisposeAsync( bool disposing )
+        {
+            if ( disposing )
+            {
+                ReleaseResources();
+            }
+
+            return base.DisposeAsync( disposing );
+        }
+
+        /// <summary>
+        /// Shared code to dispose of any internal resources.
+        /// </summary>
+        protected override void ReleaseResources()
+        {
+            if ( inputValueDebouncer != null )
+            {
+                inputValueDebouncer.Debounce -= OnInputValueDebounce;
+                inputValueDebouncer = null;
+            }
+
+            base.ReleaseResources();
+        }
+
+        /// <summary>
+        /// Handler for @onchange event.
+        /// </summary>
+        /// <param name="eventArgs">Information about the changed event.</param>
+        /// <returns>Returns awaitable task</returns>
+        protected virtual Task OnChangeHandler( ChangeEventArgs eventArgs )
+        {
+            if ( !IsImmediate )
+            {
+                return CurrentValueHandler( eventArgs?.Value?.ToString() );
+            }
+
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Handler for @oninput event.
+        /// </summary>
+        /// <param name="eventArgs">Information about the changed event.</param>
+        /// <returns>Returns awaitable task</returns>
+        protected virtual Task OnInputHandler( ChangeEventArgs eventArgs )
+        {
+            if ( IsImmediate )
+            {
+                var value = eventArgs?.Value?.ToString();
+
+                if ( IsDebounce )
+                {
+                    inputValueDebouncer?.Update( value );
+                }
+                else
+                {
+                    return CurrentValueHandler( value );
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+
+        /// <inheritdoc/>
+        protected override Task OnKeyPressHandler( KeyboardEventArgs eventArgs )
+        {
+            if ( IsImmediate
+                && IsDebounce
+                && ( eventArgs?.Key?.Equals( "Enter", StringComparison.OrdinalIgnoreCase ) ?? false ) )
+            {
+                inputValueDebouncer?.Flush();
+            }
+
+            return base.OnKeyPressHandler( eventArgs );
+        }
+
+        /// <inheritdoc/>
+        protected override Task OnBlurHandler( FocusEventArgs eventArgs )
+        {
+            if ( IsImmediate
+                && IsDebounce )
+            {
+                inputValueDebouncer?.Flush();
+            }
+
+            return base.OnBlurHandler( eventArgs );
+        }
+
+        /// <summary>
+        /// Event raised after the delayed value time has expired.
+        /// </summary>
+        /// <param name="sender">Object that raised an event.</param>
+        /// <param name="value">Latest received value.</param>
+        private void OnInputValueDebounce( object sender, string value )
+        {
+            InvokeAsync( () => CurrentValueHandler( value ) );
+        }
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Returns true if internal value should be updated with each key press.
+        /// </summary>
+        protected bool IsImmediate
+            => Immediate.GetValueOrDefault( Options?.Immediate ?? true );
+
+        /// <summary>
+        /// Returns true if updating of internal value should be delayed.
+        /// </summary>
+        protected bool IsDebounce
+            => Debounce.GetValueOrDefault( Options?.Debounce ?? false );
+
+        /// <summary>
+        /// Time in milliseconds by which internal value update should be delayed.
+        /// </summary>
+        protected int DebounceIntervalValue
+            => DebounceInterval.GetValueOrDefault( Options?.DebounceInterval ?? 300 );
+
+        /// <summary>
+        /// the name of the event for the input element.
+        /// </summary>
+        protected string BindValueEventName
+            => IsImmediate ? "oninput" : "onchange";
+
+        /// <summary>
+        /// If true the text in will be changed after each key press.
+        /// </summary>
+        /// <remarks>
+        /// Note that setting this will override global settings in <see cref="BlazoriseOptions.Immediate"/>.
+        /// </remarks>
+        [Parameter] public bool? Immediate { get; set; }
+
+        /// <summary>
+        /// If true the entered text will be slightly delayed before submitting it to the internal value.
+        /// </summary>
+        [Parameter] public bool? Debounce { get; set; }
+
+        /// <summary>
+        /// Interval in milliseconds that entered text will be delayed from submitting to the internal value.
+        /// </summary>
+        [Parameter] public int? DebounceInterval { get; set; }
+
+        #endregion
+    }
+}

--- a/Source/Blazorise/Components/NumericPicker/NumericPicker.razor
+++ b/Source/Blazorise/Components/NumericPicker/NumericPicker.razor
@@ -1,6 +1,13 @@
 ﻿@namespace Blazorise
 @typeparam TValue
 @inherits Blazorise.BaseTextInput<TValue>
-<input @ref="@ElementRef" id="@ElementId" inputmode="numeric" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" size="@VisibleCharacters" step="@Step" pattern="@Pattern" tabindex="@TabIndex" value="@CurrentValueAsString" @onchange="@OnChangeHandler" @oninput="@OnInputHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+@if ( IsImmediate && IsDebounce )
+{
+    <input @ref="@ElementRef" id="@ElementId" inputmode="numeric" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" size="@VisibleCharacters" step="@Step" pattern="@Pattern" tabindex="@TabIndex" value="@CurrentValueAsString" @oninput="@OnInputHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+}
+else
+{
+    <input @ref="@ElementRef" id="@ElementId" inputmode="numeric" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" size="@VisibleCharacters" step="@Step" pattern="@Pattern" tabindex="@TabIndex" @bind-value="@CurrentValueAsString" @bind-value:event="@BindValueEventName" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+}
 @ChildContent
 @Feedback

--- a/Source/Blazorise/wwwroot/numericPicker.js
+++ b/Source/Blazorise/wwwroot/numericPicker.js
@@ -1,4 +1,4 @@
-﻿import { getRequiredElement, fromExponential } from "./utilities.js";
+﻿import { getRequiredElement, fromExponential, firstNonNull } from "./utilities.js";
 
 import './vendors/autoNumeric.js';
 
@@ -11,29 +11,29 @@ export function initialize(dotnetAdapter, element, elementId, options) {
         return;
 
     const instance = new AutoNumeric(element, {
-        decimalPlaces: options.decimals || AutoNumeric.options.decimalPlaces.two,
-        decimalPlacesRawValue: options.decimals || AutoNumeric.options.decimalPlaces.two,
-        decimalPlacesShownOnBlur: options.decimals || AutoNumeric.options.decimalPlaces.two,
-        decimalPlacesShownOnFocus: options.decimals || AutoNumeric.options.decimalPlaces.two,
-        decimalCharacter: options.decimalSeparator || AutoNumeric.options.decimalCharacter.dot,
-        decimalCharacterAlternative: options.alternativeDecimalSeparator || AutoNumeric.options.decimalCharacter.comma,
+        decimalPlaces: firstNonNull(options.decimals, AutoNumeric.options.decimalPlaces.two),
+        decimalPlacesRawValue: firstNonNull(options.decimals, AutoNumeric.options.decimalPlaces.two),
+        decimalPlacesShownOnBlur: firstNonNull(options.decimals, AutoNumeric.options.decimalPlaces.two),
+        decimalPlacesShownOnFocus: firstNonNull(options.decimals, AutoNumeric.options.decimalPlaces.two),
+        decimalCharacter: firstNonNull(options.decimalSeparator, AutoNumeric.options.decimalCharacter.dot),
+        decimalCharacterAlternative: firstNonNull(options.alternativeDecimalSeparator, AutoNumeric.options.decimalCharacter.comma),
 
-        digitGroupSeparator: options.groupSeparator || AutoNumeric.options.digitGroupSeparator.noSeparator,
-        digitalGroupSpacing: options.groupSpacing || AutoNumeric.options.digitalGroupSpacing.three,
+        digitGroupSeparator: firstNonNull(options.groupSeparator, AutoNumeric.options.digitGroupSeparator.noSeparator),
+        digitalGroupSpacing: firstNonNull(options.groupSpacing, AutoNumeric.options.digitalGroupSpacing.three),
 
-        wheelStep: options.step || 1,
-        minimumValue: fromExponential(options.min || options.typeMin) || AutoNumeric.options.minimumValue.tenTrillions,
-        maximumValue: fromExponential(options.max || options.typeMax) || AutoNumeric.options.maximumValue.tenTrillions,
-        overrideMinMaxLimits: options.minMaxLimitsOverride || AutoNumeric.options.overrideMinMaxLimits.doNotOverride,
-        roundingMethod: options.roundingMethod || AutoNumeric.options.roundingMethod.halfUpSymmetric,
+        wheelStep: firstNonNull(options.step, 1),
+        minimumValue: firstNonNull(fromExponential(firstNonNull(options.min, options.typeMin)), AutoNumeric.options.minimumValue.tenTrillions),
+        maximumValue: firstNonNull(fromExponential(firstNonNull(options.max, options.typeMax)), AutoNumeric.options.maximumValue.tenTrillions),
+        overrideMinMaxLimits: firstNonNull(options.minMaxLimitsOverride, AutoNumeric.options.overrideMinMaxLimits.doNotOverride),
+        roundingMethod: firstNonNull(options.roundingMethod, AutoNumeric.options.roundingMethod.halfUpSymmetric),
 
-        currencySymbol: options.currencySymbol || AutoNumeric.options.currencySymbol.none,
-        currencySymbolPlacement: options.currencySymbolPlacement || AutoNumeric.options.currencySymbolPlacement.suffix,
+        currencySymbol: firstNonNull(options.currencySymbol, AutoNumeric.options.currencySymbol.none),
+        currencySymbolPlacement: firstNonNull(options.currencySymbolPlacement, AutoNumeric.options.currencySymbolPlacement.suffix),
 
-        selectOnFocus: options.selectAllOnFocus || AutoNumeric.options.selectOnFocus.doNotSelect,
+        selectOnFocus: firstNonNull(options.selectAllOnFocus, AutoNumeric.options.selectOnFocus.doNotSelect),
 
-        allowDecimalPadding: options.allowDecimalPadding || AutoNumeric.options.allowDecimalPadding.always,
-        alwaysAllowDecimalCharacter: options.alwaysAllowDecimalSeparator || AutoNumeric.options.alwaysAllowDecimalCharacter.doNotAllow,
+        allowDecimalPadding: firstNonNull(options.allowDecimalPadding, AutoNumeric.options.allowDecimalPadding.always),
+        alwaysAllowDecimalCharacter: firstNonNull(options.alwaysAllowDecimalSeparator, AutoNumeric.options.alwaysAllowDecimalCharacter.doNotAllow),
 
         onInvalidPaste: 'ignore',
     });
@@ -57,61 +57,61 @@ export function updateOptions(element, elementId, options) {
     if (instance && options) {
         if (options.decimals.changed) {
             //instance.options.decimalPlaces(options.decimals.value || AutoNumeric.options.decimalPlaces.two);
-            instance.options.decimalPlacesRawValue(options.decimals.value || AutoNumeric.options.decimalPlaces.two);
-            instance.options.decimalPlacesShownOnFocus(options.decimals.value || AutoNumeric.options.decimalPlaces.two);
-            instance.options.decimalPlacesShownOnBlur(options.decimals.value || AutoNumeric.options.decimalPlaces.two);
+            instance.options.decimalPlacesRawValue(firstNonNull(options.decimals.value, AutoNumeric.options.decimalPlaces.two));
+            instance.options.decimalPlacesShownOnFocus(firstNonNull(options.decimals.value, AutoNumeric.options.decimalPlaces.two));
+            instance.options.decimalPlacesShownOnBlur(firstNonNull(options.decimals.value, AutoNumeric.options.decimalPlaces.two));
         }
 
         if (options.decimalSeparator.changed) {
-            instance.options.decimalCharacter(options.decimalSeparator.value || AutoNumeric.options.decimalCharacter.dot);
+            instance.options.decimalCharacter(firstNonNull(options.decimalSeparator.value, AutoNumeric.options.decimalCharacter.dot));
         }
 
         if (options.alternativeDecimalSeparator.changed) {
-            instance.options.decimalCharacterAlternative(options.alternativeDecimalSeparator.value || AutoNumeric.options.decimalCharacter.comma);
+            instance.options.decimalCharacterAlternative(firstNonNull(options.alternativeDecimalSeparator.value, AutoNumeric.options.decimalCharacter.comma));
         }
 
         if (options.groupSeparator.changed) {
-            instance.options.digitGroupSeparator(options.groupSeparator.value || AutoNumeric.options.digitGroupSeparator.noSeparator);
+            instance.options.digitGroupSeparator(firstNonNull(options.groupSeparator.value, AutoNumeric.options.digitGroupSeparator.noSeparator));
         }
 
         if (options.groupSpacing.changed) {
-            instance.options.digitalGroupSpacing(options.groupSpacing.value || AutoNumeric.options.digitalGroupSpacing.three);
+            instance.options.digitalGroupSpacing(firstNonNull(options.groupSpacing.value, AutoNumeric.options.digitalGroupSpacing.three));
         }
 
         if (options.currencySymbol.changed) {
-            instance.options.currencySymbol(options.currencySymbol.value || AutoNumeric.options.currencySymbol.none);
+            instance.options.currencySymbol(firstNonNull(options.currencySymbol.value, AutoNumeric.options.currencySymbol.none));
         }
 
         if (options.currencySymbolPlacement.changed) {
-            instance.options.currencySymbolPlacement(options.currencySymbolPlacement.value || AutoNumeric.options.currencySymbolPlacement.suffix);
+            instance.options.currencySymbolPlacement(firstNonNull(options.currencySymbolPlacement.value, AutoNumeric.options.currencySymbolPlacement.suffix));
         }
 
         if (options.roundingMethod.changed) {
-            instance.options.roundingMethod(options.roundingMethod.value || AutoNumeric.options.roundingMethod.halfUpSymmetric);
+            instance.options.roundingMethod(firstNonNull(options.roundingMethod.value, AutoNumeric.options.roundingMethod.halfUpSymmetric));
         }
 
         if (options.min.changed) {
-            instance.options.minimumValue(options.min.value || AutoNumeric.options.minimumValue.tenTrillions);
+            instance.options.minimumValue(firstNonNull(options.min.value, AutoNumeric.options.minimumValue.tenTrillions));
         }
 
         if (options.max.changed) {
-            instance.options.maximumValue(options.max.value || AutoNumeric.options.maximumValue.tenTrillions);
+            instance.options.maximumValue(firstNonNull(options.max.value, AutoNumeric.options.maximumValue.tenTrillions));
         }
 
         if (options.minMaxLimitsOverride.changed) {
-            instance.options.overrideMinMaxLimits(options.minMaxLimitsOverride.value || AutoNumeric.options.overrideMinMaxLimits.doNotOverride);
+            instance.options.overrideMinMaxLimits(firstNonNull(options.minMaxLimitsOverride.value, AutoNumeric.options.overrideMinMaxLimits.doNotOverride));
         }
 
         if (options.selectAllOnFocus.changed) {
-            instance.options.selectOnFocus(options.selectAllOnFocus.value || AutoNumeric.options.selectOnFocus.doNotSelect);
+            instance.options.selectOnFocus(firstNonNull(options.selectAllOnFocus.value, AutoNumeric.options.selectOnFocus.doNotSelect));
         }
 
         if (options.allowDecimalPadding.changed) {
-            instance.options.allowDecimalPadding(options.allowDecimalPadding.value || AutoNumeric.options.allowDecimalPadding.always);
+            instance.options.allowDecimalPadding(firstNonNull(options.allowDecimalPadding.value, AutoNumeric.options.allowDecimalPadding.always));
         }
 
         if (options.alwaysAllowDecimalSeparator.changed) {
-            instance.options.alwaysAllowDecimalCharacter(options.alwaysAllowDecimalSeparator.value || AutoNumeric.options.alwaysAllowDecimalCharacter.doNotAllow);
+            instance.options.alwaysAllowDecimalCharacter(firstNonNull(options.alwaysAllowDecimalSeparator.value, AutoNumeric.options.alwaysAllowDecimalCharacter.doNotAllow));
         }
     }
 }

--- a/Source/Blazorise/wwwroot/utilities.js
+++ b/Source/Blazorise/wwwroot/utilities.js
@@ -246,3 +246,10 @@ export function isString(value) {
     const type = typeof value
     return type === 'string' || (type === 'object' && value != null && !Array.isArray(value) && getTag(value) == '[object String]')
 }
+
+export function firstNonNull(value, fallbackValue) {
+    if (value === null || value === undefined)
+        return fallbackValue;
+
+    return value;
+}


### PR DESCRIPTION
Adds a null check function for null and undefined in JS. the problem with `||` was that `0` would also fail as a value.