### PR TITLE
DataGrid: don't show default sort icon

### DIFF
--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor
@@ -59,9 +59,9 @@
                                         {
                                             @column.SortDirectionTemplate( column.CurrentSortDirection )
                                         }
-                                        else
+                                        else if ( column.CurrentSortDirection != SortDirection.Default )
                                         {
-                                            <Icon Name="@(column.CurrentSortDirection == SortDirection.Default ? IconName.Sort : ( column.CurrentSortDirection == SortDirection.Descending ? IconName.SortDown : IconName.SortUp ) )" />
+                                            <Icon Name="@(column.CurrentSortDirection == SortDirection.Descending ? IconName.SortDown : IconName.SortUp)" />
                                         }
                                     }
                                 </TableHeaderCell>


### PR DESCRIPTION
closes #3530

This PR reverts the empty sort icon for DataGrid while still allowing to use `SortDirectionTemplate`. The change was introduced by #3495 but it was too obtrusive for general users. In the future, we will ad an opt-in parameter for the sort icon.