### PR TITLE
Trendline bugfix: don't call chart.update() after you add the trendlines

### DIFF
--- a/Source/Extensions/Blazorise.Charts.Trendline/wwwroot/charts.trendline.js
+++ b/Source/Extensions/Blazorise.Charts.Trendline/wwwroot/charts.trendline.js
@@ -5,10 +5,7 @@ export function addTrendlines(canvasId, trendlines) {
     const chart = getChart(canvasId);
 
     if (chart && trendlines) {
-
         trendlines.forEach(element => addTrendline(chart, element));
-        chart.update();
-
     }
     return true;
 


### PR DESCRIPTION
…. Doing so causes the line data to be rendered in the wrong part of the grid.