### PR TITLE
DataGrid : Static data filter data only once on first load

### DIFF
--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -254,7 +254,9 @@ namespace Blazorise.DataGrid
                 paginationContext.SubscribeOnPageSizeChanged( OnPageSizeChanged );
                 paginationContext.SubscribeOnPageChanged( OnPageChanged );
 
-                await Reload();
+                if(ManualReadMode)
+                    await Reload();
+
                 return;
             }
 

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -254,7 +254,7 @@ namespace Blazorise.DataGrid
                 paginationContext.SubscribeOnPageSizeChanged( OnPageSizeChanged );
                 paginationContext.SubscribeOnPageChanged( OnPageChanged );
 
-                if(ManualReadMode)
+                if( ManualReadMode )
                     await Reload();
 
                 return;


### PR DESCRIPTION
Closes #3637

Somehwere in time `Reload`  substitued the explicit ReadData for code reuse. Well it does not make sense to `Reload` in the cases of static data, it will set the dirty flag again for apparently no reason.

