### PR TITLE
Update cla.yml

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -21,10 +21,11 @@ jobs:
           path-to-signatures: 'signatures/version1/cla.json'
           path-to-document: 'https://gist.github.com/stsrki/abfa5ce0f4a5cf1e6ac67b92f8eb5d63' # e.g. a CLA or a DCO document
           # branch should not be protected
-          branch: 'master'
-          allowlist: david-moreira,stsrki,bot*
+          branch: 'Blazorise'
+          allowlist: David-Moreira,stsrki,bot*
+          remote-repository-name: CLA-Signatures
 
-         #below are the optional inputs - If the optional inputs are not given, then default values will be taken
+          #below are the optional inputs - If the optional inputs are not given, then default values will be taken
           #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)
           #remote-repository-name:  enter the  remote repository name where the signatures should be stored (Default is storing the signatures in the same repository)
           #create-file-commit-message: 'For example: Creating file for storing CLA Signatures'


### PR DESCRIPTION
Branch where signatures are stored can't be protected.

Created a new Repository for storing signatures. Idea is that there will be a branch for each of our projects. Blazorise will be configured to submit the signatures to:
CLA-Signatures\Blazorise

(Also updated my tag as it did not seem to detect on my latest PR, maybe it's case sensitive)