### PR TITLE
Dropdown Fix RightAligned

### DIFF
--- a/Source/Blazorise.AntDesign/AntDesignClassProvider.cs
+++ b/Source/Blazorise.AntDesign/AntDesignClassProvider.cs
@@ -418,6 +418,8 @@ namespace Blazorise.AntDesign
 
         public override string DropdownGroup() => null;
 
+        public override string DropdownObserverShow() => DropdownMenuVisible( false );
+
         public override string DropdownShow() => null;
 
         public override string DropdownRight() => null;

--- a/Source/Blazorise.AntDesign/Dropdown.razor.cs
+++ b/Source/Blazorise.AntDesign/Dropdown.razor.cs
@@ -30,6 +30,13 @@ namespace Blazorise.AntDesign
             await base.OnAfterRenderAsync( firstRender );
         }
 
+        /// <summary>
+        /// Overridable class name to be listening on the target show element.
+        /// </summary>
+        /// <returns></returns>
+        protected override string GetShowClassName()
+             => ClassProvider.DropdownMenuVisible( false );
+
         #endregion
 
         #region Properties

--- a/Source/Blazorise.AntDesign/Dropdown.razor.cs
+++ b/Source/Blazorise.AntDesign/Dropdown.razor.cs
@@ -30,10 +30,6 @@ namespace Blazorise.AntDesign
             await base.OnAfterRenderAsync( firstRender );
         }
 
-        //inheritdoc
-        protected override string GetShowClassName()
-             => ClassProvider.DropdownMenuVisible( false );
-
         #endregion
 
         #region Properties

--- a/Source/Blazorise.AntDesign/Dropdown.razor.cs
+++ b/Source/Blazorise.AntDesign/Dropdown.razor.cs
@@ -30,10 +30,7 @@ namespace Blazorise.AntDesign
             await base.OnAfterRenderAsync( firstRender );
         }
 
-        /// <summary>
-        /// Overridable class name to be listening on the target show element.
-        /// </summary>
-        /// <returns></returns>
+        //inheritdoc
         protected override string GetShowClassName()
              => ClassProvider.DropdownMenuVisible( false );
 

--- a/Source/Blazorise.Bootstrap/BootstrapClassProvider.cs
+++ b/Source/Blazorise.Bootstrap/BootstrapClassProvider.cs
@@ -417,6 +417,8 @@ namespace Blazorise.Bootstrap
 
         public override string DropdownGroup() => "btn-group";
 
+        public override string DropdownObserverShow() => DropdownShow();
+
         public override string DropdownShow() => Show();
 
         public override string DropdownRight() => null;

--- a/Source/Blazorise.Bootstrap5/Bootstrap5ClassProvider.cs
+++ b/Source/Blazorise.Bootstrap5/Bootstrap5ClassProvider.cs
@@ -409,6 +409,8 @@ namespace Blazorise.Bootstrap5
 
         public override string DropdownGroup() => "btn-group";
 
+        public override string DropdownObserverShow() => DropdownShow();
+
         public override string DropdownShow() => Show();
 
         public override string DropdownRight() => null;

--- a/Source/Blazorise.Bulma/BulmaClassProvider.cs
+++ b/Source/Blazorise.Bulma/BulmaClassProvider.cs
@@ -421,6 +421,8 @@ namespace Blazorise.Bulma
 
         public override string DropdownGroup() => "field has-addons";
 
+        public override string DropdownObserverShow() => DropdownShow();
+
         public override string DropdownShow() => Active();
 
         public override string DropdownRight() => "is-right";

--- a/Source/Blazorise.Bulma/Config.cs
+++ b/Source/Blazorise.Bulma/Config.cs
@@ -47,6 +47,7 @@ namespace Blazorise.Bulma
             { typeof( Blazorise.Check<> ), typeof( Bulma.Check<> ) },
             { typeof( Blazorise.DateEdit<> ), typeof( Bulma.DateEdit<> ) },
             { typeof( Blazorise.DropdownDivider ), typeof( Bulma.DropdownDivider ) },
+            { typeof( Blazorise.Dropdown ), typeof( Bulma.Dropdown ) },
             { typeof( Blazorise.DropdownMenu ), typeof( Bulma.DropdownMenu ) },
             { typeof( Blazorise.DropdownToggle ), typeof( Bulma.DropdownToggle ) },
             { typeof( Blazorise.Field ), typeof( Bulma.Field ) },

--- a/Source/Blazorise.Bulma/Dropdown.razor.cs
+++ b/Source/Blazorise.Bulma/Dropdown.razor.cs
@@ -1,0 +1,28 @@
+﻿#region Using directives
+using System.Threading.Tasks;
+using Blazorise.Modules;
+using Microsoft.AspNetCore.Components;
+#endregion
+
+namespace Blazorise.Bulma
+{
+    public partial class Dropdown : Blazorise.Dropdown
+    {
+        #region Members
+
+        #endregion
+
+        #region Methods
+
+        //inheritdoc
+        protected override string GetShowElementId()
+             => ElementId;
+
+        #endregion
+
+        #region Properties
+
+
+        #endregion
+    }
+}

--- a/Source/Blazorise.Bulma/Dropdown.razor.cs
+++ b/Source/Blazorise.Bulma/Dropdown.razor.cs
@@ -1,7 +1,5 @@
 ﻿#region Using directives
-using System.Threading.Tasks;
-using Blazorise.Modules;
-using Microsoft.AspNetCore.Components;
+
 #endregion
 
 namespace Blazorise.Bulma

--- a/Source/Blazorise/Components/Dropdown/Dropdown.razor.cs
+++ b/Source/Blazorise/Components/Dropdown/Dropdown.razor.cs
@@ -73,6 +73,7 @@ namespace Blazorise
                     options: new
                     {
                         Direction = GetDropdownDirection().ToString( "g" ),
+                        RightAligned = RightAligned,
                         DropdownToggleClassNames = ClassProvider.DropdownToggle( IsDropdownSubmenu ),
                         DropdownMenuClassNames = ClassProvider.DropdownMenu(),
                         DropdownShowClassName = ClassProvider.DropdownShow()

--- a/Source/Blazorise/Components/Dropdown/Dropdown.razor.cs
+++ b/Source/Blazorise/Components/Dropdown/Dropdown.razor.cs
@@ -77,7 +77,7 @@ namespace Blazorise
                         RightAligned = RightAligned,
                         DropdownToggleClassNames = ClassProvider.DropdownToggle( IsDropdownSubmenu ),
                         DropdownMenuClassNames = ClassProvider.DropdownMenu(),
-                        DropdownShowClassName = GetShowClassName()
+                        DropdownShowClassName = ClassProvider.DropdownObserverShow()
                     } );
 
                 if ( childrenButtonList?.Count > 0 )
@@ -100,13 +100,6 @@ namespace Blazorise
         /// <returns></returns>
         protected virtual string GetShowElementId()
              => childrenDropdownMenus?.FirstOrDefault()?.ElementId;
-
-        /// <summary>
-        /// Overridable class name to be listening on the target show element.
-        /// </summary>
-        /// <returns></returns>
-        protected virtual string GetShowClassName()
-             => ClassProvider.DropdownShow();
 
         /// <inheritdoc/>
         protected override void BuildClasses( ClassBuilder builder )

--- a/Source/Blazorise/Components/Dropdown/Dropdown.razor.cs
+++ b/Source/Blazorise/Components/Dropdown/Dropdown.razor.cs
@@ -70,13 +70,14 @@ namespace Blazorise
                     targetElementId: childrenDropdownToggles?.FirstOrDefault()?.ElementId,
                     altTargetElementId: childrenButtonList?.FirstOrDefault()?.ElementId,
                     menuElementId: childrenDropdownMenus?.FirstOrDefault()?.ElementId,
+                    showElementId: GetShowElementId(),
                     options: new
                     {
                         Direction = GetDropdownDirection().ToString( "g" ),
                         RightAligned = RightAligned,
                         DropdownToggleClassNames = ClassProvider.DropdownToggle( IsDropdownSubmenu ),
                         DropdownMenuClassNames = ClassProvider.DropdownMenu(),
-                        DropdownShowClassName = ClassProvider.DropdownShow()
+                        DropdownShowClassName = GetShowClassName()
                     } );
 
                 if ( childrenButtonList?.Count > 0 )
@@ -92,6 +93,20 @@ namespace Blazorise
 
             base.OnAfterRender( firstRender );
         }
+
+        /// <summary>
+        /// Overridable Id for the target element that will be listening to the 'show event'.
+        /// </summary>
+        /// <returns></returns>
+        protected virtual string GetShowElementId()
+             => childrenDropdownMenus?.FirstOrDefault()?.ElementId;
+
+        /// <summary>
+        /// Overridable class name to be listening on the target show element.
+        /// </summary>
+        /// <returns></returns>
+        protected virtual string GetShowClassName()
+             => ClassProvider.DropdownShow();
 
         /// <inheritdoc/>
         protected override void BuildClasses( ClassBuilder builder )

--- a/Source/Blazorise/Components/Dropdown/Dropdown.razor.cs
+++ b/Source/Blazorise/Components/Dropdown/Dropdown.razor.cs
@@ -75,6 +75,7 @@ namespace Blazorise
                         Direction = GetDropdownDirection().ToString( "g" ),
                         DropdownToggleClassNames = ClassProvider.DropdownToggle( IsDropdownSubmenu ),
                         DropdownMenuClassNames = ClassProvider.DropdownMenu(),
+                        DropdownShowClassName = ClassProvider.DropdownShow()
                     } );
 
                 if ( childrenButtonList?.Count > 0 )
@@ -149,7 +150,6 @@ namespace Blazorise
 
             Visible = true;
 
-            await HandleJSVisibility();
             await InvokeAsync( StateHasChanged );
         }
 
@@ -168,7 +168,6 @@ namespace Blazorise
             if ( ParentDropdown is not null && ( ParentDropdown.ShouldClose || hideAll ) )
                 await ParentDropdown.Hide( hideAll );
 
-            await HandleJSVisibility();
             await InvokeAsync( StateHasChanged );
         }
 
@@ -201,25 +200,7 @@ namespace Blazorise
             SetSelectedDropdownElementId( dropdownToggleElementId );
             Visible = !Visible;
 
-            await HandleJSVisibility();
             await InvokeAsync( StateHasChanged );
-        }
-
-        /// <summary>
-        /// Handles the display of the dropdown with javascript assistance for clipping and overflow detections.
-        /// </summary>
-        /// <returns></returns>
-        internal ValueTask HandleJSVisibility()
-        {
-            if ( Rendered )
-            {
-                if ( Visible )
-                    return JSModule.Show( ElementRef, ElementId );
-                else
-                    return JSModule.Hide( ElementRef, ElementId );
-            }
-
-            return ValueTask.CompletedTask;
         }
 
         /// <summary>

--- a/Source/Blazorise/Interfaces/IClassProvider.cs
+++ b/Source/Blazorise/Interfaces/IClassProvider.cs
@@ -385,6 +385,8 @@ namespace Blazorise
 
         string DropdownGroup();
 
+        string DropdownObserverShow();
+
         string DropdownShow();
 
         string DropdownRight();

--- a/Source/Blazorise/Interfaces/Modules/IJSDropdownModule.cs
+++ b/Source/Blazorise/Interfaces/Modules/IJSDropdownModule.cs
@@ -19,9 +19,10 @@ namespace Blazorise.Modules
         /// <param name="targetElementId">Target element for the dropdown menu.</param>
         /// <param name="altTargetElementId">An alternative target element for the dropdown menu, usually for split dropdowns.</param>
         /// <param name="menuElementId">Dropdown menu element id.</param>
+        /// <param name="showElementId">Id for the target element that will be listening to the 'show event'.</param>
         /// <param name="options">Additional options for the button initialization.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
-        ValueTask Initialize( ElementReference elementRef, string elementId, string targetElementId, string altTargetElementId, string menuElementId, object options );
+        ValueTask Initialize( ElementReference elementRef, string elementId, string targetElementId, string altTargetElementId, string menuElementId, string showElementId, object options );
 
         /// <summary>
         /// Shows the dropdown menu.

--- a/Source/Blazorise/Modules/JSDropdownModule.cs
+++ b/Source/Blazorise/Modules/JSDropdownModule.cs
@@ -28,11 +28,11 @@ namespace Blazorise.Modules
         #region Methods
 
         /// <inheritdoc/>
-        public virtual async ValueTask Initialize( ElementReference elementRef, string elementId, string targetElementId, string altTargetElementId, string menuElementId, object options )
+        public virtual async ValueTask Initialize( ElementReference elementRef, string elementId, string targetElementId, string altTargetElementId, string menuElementId, string showElementId, object options )
         {
             var moduleInstance = await Module;
 
-            await moduleInstance.InvokeVoidAsync( "initialize", elementRef, elementId, targetElementId, altTargetElementId, menuElementId, options );
+            await moduleInstance.InvokeVoidAsync( "initialize", elementRef, elementId, targetElementId, altTargetElementId, menuElementId, showElementId, options );
         }
 
         /// <inheritdoc/>

--- a/Source/Blazorise/Providers/ClassProvider.cs
+++ b/Source/Blazorise/Providers/ClassProvider.cs
@@ -386,6 +386,8 @@ namespace Blazorise
 
         public abstract string DropdownGroup();
 
+        public abstract string DropdownObserverShow();
+
         public abstract string DropdownShow();
 
         public abstract string DropdownRight();

--- a/Source/Blazorise/Providers/EmptyClassProvider.cs
+++ b/Source/Blazorise/Providers/EmptyClassProvider.cs
@@ -387,6 +387,8 @@ namespace Blazorise.Providers
 
         public string DropdownGroup() => null;
 
+        public string DropdownObserverShow() => null;
+
         public string DropdownShow() => null;
 
         public string DropdownRight() => null;

--- a/Source/Blazorise/wwwroot/dropdown.js
+++ b/Source/Blazorise/wwwroot/dropdown.js
@@ -62,7 +62,7 @@ export function initialize(element, elementId, targetElementId, altTargetElement
 
     instance.update();
 
-    createAttributesObserver(showElementId, (mutationsList) => observeClassChanged(mutationsList, options.dropdownShowClassName, () => instance.update()), true);
+    createAttributesObserver(showElementId, (mutationsList) => observeClassChanged(mutationsList, options.dropdownShowClassName, () => instance.update(), true));
 
     _instances[elementId] = instance;
 }

--- a/Source/Blazorise/wwwroot/dropdown.js
+++ b/Source/Blazorise/wwwroot/dropdown.js
@@ -9,17 +9,22 @@ const DIRECTION_UP = 'Up'
 const DIRECTION_END = 'End'
 const DIRECTION_START = 'Start'
 
-function getPopperDirection(direction) {
-    if (direction == DIRECTION_DEFAULT || direction == DIRECTION_DOWN)
-        return "bottom-start";
-    else if (direction == DIRECTION_UP)
-        return "top-start";
-    else if (direction == DIRECTION_END)
-        return "right-start";
-    else if (direction == DIRECTION_START)
-        return "left-start";
+function getPopperDirection(direction, rightAligned) {
 
-    return "bottom-start";
+    let suffixAlignment = "start";
+    if (rightAligned)
+        suffixAlignment = "end";
+    
+    if (direction == DIRECTION_DEFAULT || direction == DIRECTION_DOWN)
+        return `bottom-${suffixAlignment}`;
+    else if (direction == DIRECTION_UP)
+        return `top-${suffixAlignment}`;
+    else if (direction == DIRECTION_END)
+        return `right-${suffixAlignment}`;
+    else if (direction == DIRECTION_START)
+        return `left-${suffixAlignment}`;
+
+    return `bottom-${suffixAlignment}`;
 }
 
 // optimize this
@@ -45,7 +50,7 @@ export function initialize(element, elementId, targetElementId, altTargetElement
         : element.querySelector(createSelector(options.dropdownMenuClassNames));
 
     const instance = createPopper(targetElement, menuElement, {
-        placement: getPopperDirection(options.direction),
+        placement: getPopperDirection(options.direction, options.rightAligned),
         strategy: "absolute",
         modifiers: [
             {

--- a/Source/Blazorise/wwwroot/dropdown.js
+++ b/Source/Blazorise/wwwroot/dropdown.js
@@ -65,7 +65,7 @@ export function initialize(element, elementId, targetElementId, altTargetElement
 
     instance.update();
 
-    createAttributesObserver(menuElement.id, (mutationsList) => observeClassChanged(mutationsList, options.dropdownShowClassName, () => instance.update()), true);
+    createAttributesObserver(showElementId, (mutationsList) => observeClassChanged(mutationsList, options.dropdownShowClassName, () => instance.update()), true);
 
     _instances[elementId] = instance;
 }

--- a/Source/Blazorise/wwwroot/dropdown.js
+++ b/Source/Blazorise/wwwroot/dropdown.js
@@ -1,8 +1,8 @@
 import { getRequiredElement } from "./utilities.js?v=1.0.2.0";
 import { createPopper } from "./popper.js?v=1.0.2.0";
+import { createAttributesObserver, observeClassChanged, destroyObserver } from "./observer.js?v=1.0.2.0";
 
 const _instances = [];
-
 const DIRECTION_DEFAULT = 'Default'
 const DIRECTION_DOWN = 'Down'
 const DIRECTION_UP = 'Up'
@@ -30,6 +30,7 @@ function createSelector(value) {
 }
 
 export function initialize(element, elementId, targetElementId, altTargetElementId, menuElementId, options) {
+
     element = getRequiredElement(element, elementId);
 
     if (!element)
@@ -45,17 +46,21 @@ export function initialize(element, elementId, targetElementId, altTargetElement
 
     const instance = createPopper(targetElement, menuElement, {
         placement: getPopperDirection(options.direction),
-        strategy: "fixed",
+        strategy: "absolute",
         modifiers: [
             {
                 name: "preventOverflow",
+                enabled: true,
                 options: {
                     padding: 0,
                 }
-            }]
+            }
+        ]
     });
 
     instance.update();
+
+    createAttributesObserver(menuElement.id, (mutationsList) => observeClassChanged(mutationsList, options.dropdownShowClassName, () => instance.update()));
 
     _instances[elementId] = instance;
 }
@@ -74,22 +79,8 @@ export function destroy(element, elementId) {
         instance.destroy();
 
         delete instances[elementId];
-    }
-}
 
-export function show(element, elementId) {
-    const instance = getInstance(elementId);
-
-    if (instance) {
-        instance.update();
-    }
-}
-
-export function hide(element, elementId) {
-    const instance = getInstance(elementId);
-
-    if (instance) {
-        instance.update();
+        destroyObserver(elementId);
     }
 }
 
@@ -98,3 +89,4 @@ export function getInstance(elementId) {
 
     return instances[elementId];
 }
+

--- a/Source/Blazorise/wwwroot/dropdown.js
+++ b/Source/Blazorise/wwwroot/dropdown.js
@@ -34,7 +34,7 @@ function createSelector(value) {
     return classNames;
 }
 
-export function initialize(element, elementId, targetElementId, altTargetElementId, menuElementId, options) {
+export function initialize(element, elementId, targetElementId, altTargetElementId, menuElementId, showElementId, options) {
 
     element = getRequiredElement(element, elementId);
 
@@ -65,7 +65,7 @@ export function initialize(element, elementId, targetElementId, altTargetElement
 
     instance.update();
 
-    createAttributesObserver(menuElement.id, (mutationsList) => observeClassChanged(mutationsList, options.dropdownShowClassName, () => instance.update()));
+    createAttributesObserver(menuElement.id, (mutationsList) => observeClassChanged(mutationsList, options.dropdownShowClassName, () => instance.update()), true);
 
     _instances[elementId] = instance;
 }

--- a/Source/Blazorise/wwwroot/observer.js
+++ b/Source/Blazorise/wwwroot/observer.js
@@ -1,0 +1,53 @@
+///https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver
+
+const _instances = [];
+
+///Creates a new observer on a given element, please follow the link below for usage
+///https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver/observe
+export function createObserver(elementId, callback, configuration) {
+    const observer = new MutationObserver(callback);
+    observer.observe(document.getElementById(elementId), configuration);
+    _instances[elementId] = observer;
+}
+
+///Creates a new observer that's setup to listen for attribute changes on a given element.
+export function createAttributesObserver(targetNode, callback) {
+    return createObserver(targetNode, callback, { attributes: true, attributeOldValue: false });
+}
+
+///Observer helper function, sets an observer callback based on a class name
+export function observeClassChanged(mutationsList, className, onChangedCallBack) {
+    if (mutationsList) {
+        for (const mutation of mutationsList) {
+            if (mutation.type === 'attributes' && mutation.attributeName === 'class' && mutation.target.classList.contains(className)) {
+                if (typeof (onChangedCallBack) === "function")
+                    onChangedCallBack();
+            }
+        }
+    }
+}
+
+///Observer helper function, sets an observer callback based on an attribute name
+export function observeAttributeChanged(mutationsList, attributeName, onChangedCallBack) {
+    if (mutationsList) {
+        for (const mutation of mutationsList) {
+            if (mutation.type === 'attributes' && mutation.attributeName === 'attribute' && mutation.target.classList.contains(attributeName)) {
+                if (typeof (onChangedCallBack) === "function")
+                    onChangedCallBack();
+            }
+        }
+    }
+}
+
+///Stops and clean ups the observer
+export function destroyObserver(elementId) {
+    const instances = _instances || {};
+
+    const instance = instances[elementId];
+
+    if (instance) {
+        instance.disconnect();
+
+        delete instances[elementId];
+    }
+}

--- a/Source/Blazorise/wwwroot/observer.js
+++ b/Source/Blazorise/wwwroot/observer.js
@@ -8,18 +8,19 @@ export function createObserver(elementId, callback, configuration) {
     const observer = new MutationObserver(callback);
     observer.observe(document.getElementById(elementId), configuration);
     _instances[elementId] = observer;
+    return observer;
 }
 
 ///Creates a new observer that's setup to listen for attribute changes on a given element.
 export function createAttributesObserver(targetNode, callback) {
-    return createObserver(targetNode, callback, { attributes: true, attributeOldValue: false });
+    return createObserver(targetNode, callback, { attributes: true, attributeOldValue: true });
 }
 
 ///Observer helper function, sets an observer callback based on a class name
-export function observeClassChanged(mutationsList, className, onChangedCallBack) {
+export function observeClassChanged(mutationsList, className, onChangedCallBack, triggerOnOldValue) {
     if (mutationsList) {
         for (const mutation of mutationsList) {
-            if (mutation.type === 'attributes' && mutation.attributeName === 'class' && mutation.target.classList.contains(className)) {
+            if (mutation.type === 'attributes' && mutation.attributeName === 'class' && (mutation.target.classList.contains(className)) || (triggerOnOldValue && mutation.oldValue && mutation.oldValue.includes(className))) {
                 if (typeof (onChangedCallBack) === "function")
                     onChangedCallBack();
             }

--- a/Source/Blazorise/wwwroot/observer.js
+++ b/Source/Blazorise/wwwroot/observer.js
@@ -18,7 +18,7 @@ export function createAttributesObserver(targetNode, callback) {
 
 ///Observer helper function, sets an observer callback based on a class name
 export function observeClassChanged(mutationsList, className, onChangedCallBack, triggerOnOldValue) {
-    if (mutationsList) {
+    if (mutationsList && className) {
         for (const mutation of mutationsList) {
             if (mutation.type === 'attributes' && mutation.attributeName === 'class' && (mutation.target.classList.contains(className)) || (triggerOnOldValue && mutation.oldValue && mutation.oldValue.includes(className))) {
                 if (typeof (onChangedCallBack) === "function")
@@ -30,7 +30,7 @@ export function observeClassChanged(mutationsList, className, onChangedCallBack,
 
 ///Observer helper function, sets an observer callback based on an attribute name
 export function observeAttributeChanged(mutationsList, attributeName, onChangedCallBack) {
-    if (mutationsList) {
+    if (mutationsList && attributeName) {
         for (const mutation of mutationsList) {
             if (mutation.type === 'attributes' && mutation.attributeName === 'attribute' && mutation.target.classList.contains(attributeName)) {
                 if (typeof (onChangedCallBack) === "function")

--- a/Tests/Blazorise.Tests/Components/DropdownComponentTest.cs
+++ b/Tests/Blazorise.Tests/Components/DropdownComponentTest.cs
@@ -27,13 +27,16 @@ namespace Blazorise.Tests.Components
             btnElement.Click();
 
             // validate
-            this.JSInterop.VerifyInvoke( "show" );
+            Assert.Contains( "show", drpElement.GetAttribute( "class" ) );
+            Assert.Contains( "show", mnuElement.GetAttribute( "class" ) );
 
             // test
             btnElement.Click();
 
             // validate
-            this.JSInterop.VerifyInvoke( "hide" );
+            this.JSInterop.VerifyInvoke( "registerClosableComponent" );
+            Assert.DoesNotContain( "show", drpElement.GetAttribute( "class" ) );
+            Assert.DoesNotContain( "show", mnuElement.GetAttribute( "class" ) );
         }
     }
 }


### PR DESCRIPTION
Closes #3682

FIxes RightAligned parameter no longer being considered, since we've introduced popper to handle dropdown menu positioning.
And like we've talked also sets up better popper overflow/out of bounds detection, moving the menu accordingly.