### PR TITLE
Chart: Remove default value from options and datasets

### DIFF
--- a/Source/Extensions/Blazorise.Charts/Data/BarChartDataset.cs
+++ b/Source/Extensions/Blazorise.Charts/Data/BarChartDataset.cs
@@ -86,19 +86,19 @@ namespace Blazorise.Charts
         /// </list>
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public string BorderSkipped { get; set; } = "start";
+        public string BorderSkipped { get; set; }
 
         /// <summary>
         /// If this value is a number, it is applied to all corners of the rectangle (topLeft, topRight, bottomLeft, bottomRight), except corners touching the borderSkipped. If this value is an object, the topLeft property defines the top-left corners border radius. Similarly, the topRight, bottomLeft, and bottomRight properties can also be specified. Omitted corners and those touching the borderSkipped are skipped. For example if the top border is skipped, the border radius for the corners topLeft and topRight will be skipped as well.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public float? BorderRadius { get; set; } = 0f;
+        public float? BorderRadius { get; set; }
 
         /// <summary>
         /// Percent (0-1) of the available width each category should be within the sample width.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public float? CategoryPercentage { get; set; } = 0.8f;
+        public float? CategoryPercentage { get; set; }
 
         /// <summary>
         /// Should the bars be grouped on index axis. When true, all the datasets at same index value will be placed next
@@ -125,19 +125,19 @@ namespace Blazorise.Charts
         /// The bar border width when hovered (in pixels).
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public int? HoverBorderWidth { get; set; } = 1;
+        public int? HoverBorderWidth { get; set; }
 
         /// <summary>
         /// The bar border radius when hovered (in pixels).
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public int? HoverBorderRadius { get; set; } = 0;
+        public int? HoverBorderRadius { get; set; }
 
         /// <summary>
         /// The base axis of the dataset. 'x' for vertical bars and 'y' for horizontal bars.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public string IndexAxis { get; set; } = "x";
+        public string IndexAxis { get; set; }
 
         /// <summary>
         /// This option can be used to inflate the rects that are used to draw the bars. This can be used to hide artifacts
@@ -145,7 +145,7 @@ namespace Blazorise.Charts
         /// value 'auto' should work in most cases.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public object InflateAmount { get; set; } = "auto";
+        public object InflateAmount { get; set; }
 
         /// <summary>
         /// Set this to ensure that bars are not sized thicker than this.
@@ -163,7 +163,7 @@ namespace Blazorise.Charts
         /// Style of the point for legend. https://www.chartjs.org/docs/latest/configuration/elements.html#point-styles
         /// </summary>    
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public string PointStyle { get; set; } = "circle";
+        public string PointStyle { get; set; }
 
         /// <summary>
         /// If true, null or undefined values will not be used for spacing calculations when determining bar size.

--- a/Source/Extensions/Blazorise.Charts/Data/BubbleChartDataset.cs
+++ b/Source/Extensions/Blazorise.Charts/Data/BubbleChartDataset.cs
@@ -25,25 +25,25 @@ namespace Blazorise.Charts
         public IndexableOption<object> HoverBorderColor { get; set; }
 
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public int? HoverBorderWidth { get; set; } = 1;
+        public int? HoverBorderWidth { get; set; }
 
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public int? HoverRadius { get; set; } = 4;
+        public int? HoverRadius { get; set; }
 
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public int? HitRadius { get; set; } = 1;
+        public int? HitRadius { get; set; }
 
         /// <summary>
         /// Style of the point.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public string PointStyle { get; set; } = "circle";
+        public string PointStyle { get; set; }
 
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public double? Rotation { get; set; } = 0;
+        public double? Rotation { get; set; }
 
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public double? Radius { get; set; } = 3;
+        public double? Radius { get; set; }
     }
 
     public struct BubbleChartPoint

--- a/Source/Extensions/Blazorise.Charts/Data/ChartDataset.cs
+++ b/Source/Extensions/Blazorise.Charts/Data/ChartDataset.cs
@@ -68,7 +68,7 @@ namespace Blazorise.Charts
         /// Defines the border width.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public int? BorderWidth { get; set; } = 1;
+        public int? BorderWidth { get; set; }
 
         /// <summary>
         /// Defines the type of a chart dataset.
@@ -88,12 +88,12 @@ namespace Blazorise.Charts
         /// The drawing order of dataset. Also affects order for stacking, tooltip and legend.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public int? Order { get; set; } = 0;
+        public int? Order { get; set; }
 
         /// <summary>
         /// Configure the visibility of the dataset. Using <c>Hidden = true</c> will hide the dataset from being rendered in the Chart.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public bool? Hidden { get; set; } = false;
+        public bool? Hidden { get; set; }
     }
 }

--- a/Source/Extensions/Blazorise.Charts/Data/LineChartDataset.cs
+++ b/Source/Extensions/Blazorise.Charts/Data/LineChartDataset.cs
@@ -45,13 +45,13 @@ namespace Blazorise.Charts
         /// </list>
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public string BorderCapStyle { get; set; } = "butt";
+        public string BorderCapStyle { get; set; }
 
         /// <summary>
         /// Length and spacing of dashes. See <see href="https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/setLineDash">MDN</see>.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public List<int> BorderDash { get; set; } = new();
+        public List<int> BorderDash { get; set; }
 
         /// <summary>
         /// Offset for line dashes. See <see href="https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineDashOffset">MDN</see>.
@@ -63,7 +63,7 @@ namespace Blazorise.Charts
         /// Line joint style. See <see href="https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineJoin">MDN</see>.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public string BorderJoinStyle { get; set; } = "miter";
+        public string BorderJoinStyle { get; set; }
 
         /// <summary>
         /// <para>
@@ -84,13 +84,13 @@ namespace Blazorise.Charts
         /// </para>
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public string CubicInterpolationMode { get; set; } = "default";
+        public string CubicInterpolationMode { get; set; }
 
         /// <summary>
         /// Fill the area under the line. See <see href="https://www.chartjs.org/docs/latest/charts/area.html">area charts.</see>.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public bool? Fill { get; set; } = true;
+        public bool? Fill { get; set; }
 
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
         [JsonConverter( typeof( IndexableOptionsConverter<object> ) )]
@@ -136,13 +136,13 @@ namespace Blazorise.Charts
         /// The width of the point border in pixels.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public int? PointBorderWidth { get; set; } = 1;
+        public int? PointBorderWidth { get; set; }
 
         /// <summary>
         /// The pixel size of the non-displayed point that reacts to mouse events.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public int? PointHitRadius { get; set; } = 1;
+        public int? PointHitRadius { get; set; }
 
         /// <summary>
         /// Point background color when hovered.
@@ -162,37 +162,37 @@ namespace Blazorise.Charts
         /// Border width of point when hovered.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public float? PointHoverBorderWidth { get; set; } = 1f;
+        public float? PointHoverBorderWidth { get; set; }
 
         /// <summary>
         /// The radius of the point when hovered.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public float? PointHoverRadius { get; set; } = 4f;
+        public float? PointHoverRadius { get; set; }
 
         /// <summary>
         /// The radius of the point shape. If set to 0, the point is not rendered.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public float? PointRadius { get; set; } = 3.0f;
+        public float? PointRadius { get; set; }
 
         /// <summary>
         /// The radius of the point shape. If set to 0, the point is not rendered.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public float? PointRotation { get; set; } = 0f;
+        public float? PointRotation { get; set; }
 
         /// <summary>
         /// Style of the point.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public string PointStyle { get; set; } = "circle";
+        public string PointStyle { get; set; }
 
         /// <summary>
         /// If false, the line is not drawn for this dataset.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public bool? ShowLine { get; set; } = true;
+        public bool? ShowLine { get; set; }
 
         /// <summary>
         /// <para>
@@ -266,14 +266,14 @@ namespace Blazorise.Charts
         /// </para>
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public object Stepped { get; set; } = false;
+        public object Stepped { get; set; }
 
         /// <summary>
         /// Bezier curve tension of the line. Set to 0 to draw straightlines. This option is ignored if monotone cubic
         /// interpolation is used.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public float? Tension { get; set; } = 0f;
+        public float? Tension { get; set; }
 
         /// <summary>
         /// The ID of the x-axis to plot this dataset on.

--- a/Source/Extensions/Blazorise.Charts/Data/PieChartDataset.cs
+++ b/Source/Extensions/Blazorise.Charts/Data/PieChartDataset.cs
@@ -35,13 +35,13 @@ namespace Blazorise.Charts
         /// </list>
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public string BorderAlign { get; set; } = "center";
+        public string BorderAlign { get; set; }
 
         /// <summary>
         /// If this value is a number, it is applied to all corners of the arc (outerStart, outerEnd, innerStart, innerRight). If this value is an object, the outerStart property defines the outer-start corner's border radius. Similarly, the outerEnd, innerStart, and innerEnd properties can also be specified.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public object BorderRadius { get; set; } = 0f;
+        public object BorderRadius { get; set; }
 
         /// <summary>
         /// Per-dataset override for the sweep that the arcs cover.
@@ -68,19 +68,19 @@ namespace Blazorise.Charts
         /// </summary>
         /// <remarks>Default as per https://www.chartjs.org/docs/latest/configuration/elements.html#arc-configuration </remarks>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public int? HoverBorderWidth { get; set; } = 0;
+        public int? HoverBorderWidth { get; set; }
 
         /// <summary>
         /// Arc offset when hovered (in pixels).
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public int? HoverOffset { get; set; } = 0;
+        public int? HoverOffset { get; set; }
 
         /// <summary>
         /// Arc offset (in pixels).
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public int? Offset { get; set; } = 0;
+        public int? Offset { get; set; }
 
         /// <summary>
         /// Per-dataset override for the starting angle to draw arcs from.
@@ -92,13 +92,13 @@ namespace Blazorise.Charts
         /// Fixed arc offset (in pixels). Similar to offset but applies to all arcs.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public int? Spacing { get; set; } = 0;
+        public int? Spacing { get; set; }
 
         /// <summary>
         /// The relative thickness of the dataset. Providing a value for weight will cause the pie or doughnut dataset
         /// to be drawn with a thickness relative to the sum of all the dataset weight values.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public int? Weight { get; set; } = 1;
+        public int? Weight { get; set; }
     }
 }

--- a/Source/Extensions/Blazorise.Charts/Data/PolarAreaChartDataset.cs
+++ b/Source/Extensions/Blazorise.Charts/Data/PolarAreaChartDataset.cs
@@ -23,7 +23,7 @@ namespace Blazorise.Charts
         /// Defines the border alignment.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public string BorderAlign { get; set; } = "center";
+        public string BorderAlign { get; set; }
 
         /// <summary>
         /// The fill colour of the arcs when hovered.

--- a/Source/Extensions/Blazorise.Charts/Data/RadarChartDataset.cs
+++ b/Source/Extensions/Blazorise.Charts/Data/RadarChartDataset.cs
@@ -24,25 +24,25 @@ namespace Blazorise.Charts
         /// Cap style of the line. See <see href="https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineCap">MDN</see>.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public string BorderCapStyle { get; set; } = "butt";
+        public string BorderCapStyle { get; set; }
 
         /// <summary>
         /// Length and spacing of dashes. <see href="https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/setLineDash">MDN</see>.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public List<int> BorderDash { get; set; } = new();
+        public List<int> BorderDash { get; set; }
 
         /// <summary>
         /// Offset for line dashes. See <see href="https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineDashOffset">MDN</see>.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public float? BorderDashOffset { get; set; } = 0f;
+        public float? BorderDashOffset { get; set; }
 
         /// <summary>
         /// Line joint style. See <see href="https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineJoin">MDN</see>.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public string BorderJoinStyle { get; set; } = "miter";
+        public string BorderJoinStyle { get; set; }
 
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
         [JsonConverter( typeof( IndexableOptionsConverter<object> ) )]
@@ -77,13 +77,13 @@ namespace Blazorise.Charts
         /// Fill the area under the line. See <see href="https://www.chartjs.org/docs/latest/charts/area.html">area charts.</see>.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public bool? Fill { get; set; } = false;
+        public bool? Fill { get; set; }
 
         /// <summary>
         /// Bezier curve tension of the line. Set to 0 to draw straight lines.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public float? Tension { get; set; } = 0f;
+        public float? Tension { get; set; }
 
         /// <summary>
         /// The fill color for points.
@@ -103,13 +103,13 @@ namespace Blazorise.Charts
         /// The width of the point border in pixels.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public float? PointBorderWidth { get; set; } = 1f;
+        public float? PointBorderWidth { get; set; }
 
         /// <summary>
         /// The pixel size of the non-displayed point that reacts to mouse events.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public float? PointHitRadius { get; set; } = 1f;
+        public float? PointHitRadius { get; set; }
 
         /// <summary>
         /// Point background color when hovered.
@@ -129,31 +129,31 @@ namespace Blazorise.Charts
         /// Border width of point when hovered.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public float? PointHoverBorderWidth { get; set; } = 1f;
+        public float? PointHoverBorderWidth { get; set; }
 
         /// <summary>
         /// The radius of the point when hovered.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public float? PointHoverRadius { get; set; } = 4f;
+        public float? PointHoverRadius { get; set; }
 
         /// <summary>
         /// The radius of the point shape. If set to 0, the point is not rendered.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public float? PointRadius { get; set; } = 3f;
+        public float? PointRadius { get; set; }
 
         /// <summary>
         /// The rotation of the point in degrees.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public float? PointRotation { get; set; } = 0f;
+        public float? PointRotation { get; set; }
 
         /// <summary>
         /// Style of the point.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public string PointStyle { get; set; } = "circle";
+        public string PointStyle { get; set; }
 
         /// <summary>
         /// If true, lines will be drawn between points with no or null data. If false, points with null data will create a break in the line.

--- a/Source/Extensions/Blazorise.Charts/Data/ScatterChartDataset.cs
+++ b/Source/Extensions/Blazorise.Charts/Data/ScatterChartDataset.cs
@@ -67,13 +67,13 @@ namespace Blazorise.Charts
         /// The width of the point border in pixels.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public int? PointBorderWidth { get; set; } = 1;
+        public int? PointBorderWidth { get; set; }
 
         /// <summary>
         /// The pixel size of the non-displayed point that reacts to mouse events.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public int? PointHitRadius { get; set; } = 1;
+        public int? PointHitRadius { get; set; }
 
         /// <summary>
         /// Point background color when hovered.
@@ -93,31 +93,31 @@ namespace Blazorise.Charts
         /// Border width of point when hovered.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public float? PointHoverBorderWidth { get; set; } = 1f;
+        public float? PointHoverBorderWidth { get; set; }
 
         /// <summary>
         /// The radius of the point when hovered.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public float? PointHoverRadius { get; set; } = 4f;
+        public float? PointHoverRadius { get; set; }
 
         /// <summary>
         /// The radius of the point shape. If set to 0, the point is not rendered.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public float? PointRadius { get; set; } = 3.0f;
+        public float? PointRadius { get; set; }
 
         /// <summary>
         /// The radius of the point shape. If set to 0, the point is not rendered.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public float? PointRotation { get; set; } = 0f;
+        public float? PointRotation { get; set; }
 
         /// <summary>
         /// Style of the point.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public string PointStyle { get; set; } = "circle";
+        public string PointStyle { get; set; }
 
         /// <summary>
         /// The ID of the x-axis to plot this dataset on.

--- a/Source/Extensions/Blazorise.Charts/Options/ChartAnimation.cs
+++ b/Source/Extensions/Blazorise.Charts/Options/ChartAnimation.cs
@@ -13,13 +13,13 @@ namespace Blazorise.Charts
         /// The number of milliseconds an animation takes.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public int? Duration { get; set; } = 1000;
+        public int? Duration { get; set; }
 
         /// <summary>
         /// Easing function to use. <see href="https://www.chartjs.org/docs/latest/configuration/animations.html#easing">more...</see>
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public string Easing { get; set; } = "easeOutQuart";
+        public string Easing { get; set; }
 
         /// <summary>
         /// Delay before starting the animations.

--- a/Source/Extensions/Blazorise.Charts/Options/ChartAxis.cs
+++ b/Source/Extensions/Blazorise.Charts/Options/ChartAxis.cs
@@ -20,13 +20,13 @@ namespace Blazorise.Charts
         /// Align pixel values to device pixels.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public bool? AlignToPixels { get; set; } = false;
+        public bool? AlignToPixels { get; set; }
 
         /// <summary>
         /// Controls the axis global visibility (visible when <c>true</c>, hidden when <c>false</c>). When display: <c>"auto"</c>, the axis is visible only if at least one associated dataset is visible.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public object Display { get; set; } = true;
+        public object Display { get; set; }
 
         /// <summary>
         /// Grid line configuration. <see href="https://www.chartjs.org/docs/latest/axes/styling.html#grid-line-configuration">more...</see>
@@ -50,13 +50,13 @@ namespace Blazorise.Charts
         /// Reverse the scale.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public bool? Reverse { get; set; } = false;
+        public bool? Reverse { get; set; }
 
         /// <summary>
         /// Should the data be stacked.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public bool? Stacked { get; set; } = false;
+        public bool? Stacked { get; set; }
 
         /// <summary>
         /// Adjustment used when calculating the maximum data value. <see href="https://www.chartjs.org/docs/latest/axes/#axis-range-settings">more...</see>
@@ -86,7 +86,7 @@ namespace Blazorise.Charts
         /// The weight used to sort the axis. Higher weights are further away from the chart area.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public double? Weight { get; set; } = 0d;
+        public double? Weight { get; set; }
 
         /// <summary>
         /// Defines options for the scale title. Note that this only applies to cartesian axes.

--- a/Source/Extensions/Blazorise.Charts/Options/ChartAxisGridLine.cs
+++ b/Source/Extensions/Blazorise.Charts/Options/ChartAxisGridLine.cs
@@ -22,7 +22,7 @@ namespace Blazorise.Charts
         /// The width of the border line.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public double? BorderWidth { get; set; } = 1d;
+        public double? BorderWidth { get; set; }
 
         /// <summary>
         /// Length and spacing of dashes on grid lines
@@ -34,7 +34,7 @@ namespace Blazorise.Charts
         /// Offset for line dashes.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public double? BorderDashOffset { get; set; } = 0d;
+        public double? BorderDashOffset { get; set; }
 
         /// <summary>
         /// If true, gridlines are circular (on radar chart only).
@@ -53,31 +53,31 @@ namespace Blazorise.Charts
         /// If false, do not display grid lines for this axis.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public bool? Display { get; set; } = true;
+        public bool? Display { get; set; }
 
         /// <summary>
         /// If true, draw border at the edge between the axis and the chart area.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public bool? DrawBorder { get; set; } = true;
+        public bool? DrawBorder { get; set; }
 
         /// <summary>
         /// If true, draw lines on the chart area inside the axis lines. This is useful when there are multiple axes and you need to control which grid lines are drawn.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public bool? DrawOnChartArea { get; set; } = true;
+        public bool? DrawOnChartArea { get; set; }
 
         /// <summary>
         /// If true, draw lines beside the ticks in the axis area beside the chart.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public bool? DrawTicks { get; set; } = true;
+        public bool? DrawTicks { get; set; }
 
         /// <summary>
         /// Stroke width of grid lines.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public double? LineWidth { get; set; } = 1d;
+        public double? LineWidth { get; set; }
 
         /// <summary>
         /// If true, grid lines will be shifted to be between labels. This is set to true for a bar chart by default.
@@ -108,7 +108,7 @@ namespace Blazorise.Charts
         /// Length in pixels that the grid lines will draw into the axis area.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public double? TickLength { get; set; } = 8;
+        public double? TickLength { get; set; }
 
         /// <summary>
         /// Width of the tick mark in pixels. If unset, defaults to the grid line width.
@@ -121,6 +121,6 @@ namespace Blazorise.Charts
         /// </summary>
         [JsonPropertyName( "y" )]
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public double? Z { get; set; } = 0;
+        public double? Z { get; set; }
     }
 }

--- a/Source/Extensions/Blazorise.Charts/Options/ChartAxisMajorTick.cs
+++ b/Source/Extensions/Blazorise.Charts/Options/ChartAxisMajorTick.cs
@@ -13,6 +13,6 @@ namespace Blazorise.Charts
         /// If true, major tick options are used to show major ticks.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public bool? Enabled { get; set; } = false;
+        public bool? Enabled { get; set; }
     }
 }

--- a/Source/Extensions/Blazorise.Charts/Options/ChartAxisScaleLabel.cs
+++ b/Source/Extensions/Blazorise.Charts/Options/ChartAxisScaleLabel.cs
@@ -20,42 +20,42 @@ namespace Blazorise.Charts
         /// The text for the title. (i.e. "# of People" or "Response Choices").
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public string LabelString { get; set; } = "";
+        public string LabelString { get; set; }
 
         /// <summary>
         /// Height of an individual line of text (https://developer.mozilla.org/en-US/docs/Web/CSS/line-height).
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public double? LineHeight { get; set; } = 1.2d;
+        public double? LineHeight { get; set; }
 
         /// <summary>
         /// Font color for scale title.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public string FontColor { get; set; } = "#666";
+        public string FontColor { get; set; }
 
         /// <summary>
         /// Font family for the scale title, follows CSS font-family options.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public string FontFamily { get; set; } = "'Helvetica Neue', 'Helvetica', 'Arial', sans-serif";
+        public string FontFamily { get; set; }
 
         /// <summary>
         /// Font size for scale title.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public double? FontSize { get; set; } = 12;
+        public double? FontSize { get; set; }
 
         /// <summary>
         /// Font style for the scale title, follows CSS font-style options (i.e. normal, italic, oblique, initial, inherit).
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public string FontStyle { get; set; } = "normal";
+        public string FontStyle { get; set; }
 
         /// <summary>
         /// Padding to apply around scale labels. Only top and bottom are implemented.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public object Padding { get; set; } = 4;
+        public object Padding { get; set; }
     }
 }

--- a/Source/Extensions/Blazorise.Charts/Options/ChartAxisTicks.cs
+++ b/Source/Extensions/Blazorise.Charts/Options/ChartAxisTicks.cs
@@ -17,13 +17,13 @@ namespace Blazorise.Charts
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
         [JsonConverter( typeof( IndexableOptionsConverter<object> ) )]
-        public IndexableOption<object> BackdropColor { get; set; } = "rgba(255, 255, 255, 0.75)";
+        public IndexableOption<object> BackdropColor { get; set; }
 
         /// <summary>
-        /// Padding of label backdrop. See <see href="https://www.chartjs.org/docs/3.6.2/general/padding.html">Padding</see>.
+        /// Padding of label backdrop. See <see href="https://www.chartjs.org/docs/3.7.1/general/padding.html">Padding</see>.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public object BackdropPadding { get; set; } = 2;
+        public object BackdropPadding { get; set; }
 
         /// <summary>
         /// Defines the Expression which will be converted to JavaScript as a string representation of the tick value as it should be displayed on the chart.
@@ -36,7 +36,7 @@ namespace Blazorise.Charts
         /// If true, show tick marks.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public bool? Display { get; set; } = true;
+        public bool? Display { get; set; }
 
         /// <summary>
         /// Color of ticks.
@@ -61,13 +61,13 @@ namespace Blazorise.Charts
         /// Sets the offset of the tick labels from the axis.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public double? Padding { get; set; } = 3;
+        public double? Padding { get; set; }
 
         /// <summary>
         /// If true, draw a background behind the tick labels.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public bool? ShowLabelBackdrop { get; set; } = false;
+        public bool? ShowLabelBackdrop { get; set; }
 
         /// <summary>
         /// The color of the stroke around the text.
@@ -80,14 +80,14 @@ namespace Blazorise.Charts
         /// Stroke width around the text.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public double? TextStrokeWidth { get; set; } = 0;
+        public double? TextStrokeWidth { get; set; }
 
         /// <summary>
         /// z-index of tick layer. Useful when ticks are drawn on chart area. Values &lt;= 0 are drawn under datasets, &gt; 0 on top.
         /// </summary>
         [JsonPropertyName( "y" )]
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public double? Z { get; set; } = 0;
+        public double? Z { get; set; }
 
         #region Linear Axis specific tick options
 

--- a/Source/Extensions/Blazorise.Charts/Options/ChartAxisTime.cs
+++ b/Source/Extensions/Blazorise.Charts/Options/ChartAxisTime.cs
@@ -31,24 +31,24 @@ namespace Blazorise.Charts
         /// If defined, dates will be rounded to the start of this unit. See <see href="https://www.chartjs.org/docs/latest/axes/cartesian/time.html#time-units">Time Units</see> section below for details.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public object Round { get; set; } = false;
+        public object Round { get; set; }
 
         /// <summary>
         /// If defined, will force the unit to be a certain type. See <see href="https://www.chartjs.org/docs/latest/axes/cartesian/time.html#time-units">Time Units</see> section below for details.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public object Unit { get; set; } = false;
+        public object Unit { get; set; }
 
         /// <summary>
         /// The number of units between grid lines.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public int? StepSize { get; set; } = 1;
+        public int? StepSize { get; set; }
 
         /// <summary>
         /// The minimum display format to be used for a time unit.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public string MinUnit { get; set; } = "millisecond";
+        public string MinUnit { get; set; }
     }
 }

--- a/Source/Extensions/Blazorise.Charts/Options/ChartDecimation.cs
+++ b/Source/Extensions/Blazorise.Charts/Options/ChartDecimation.cs
@@ -10,13 +10,13 @@ namespace Blazorise.Charts
         /// s decimation enabled?
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public bool? Enabled { get; set; } = false;
+        public bool? Enabled { get; set; }
 
         /// <summary>
         /// Decimation algorithm to use. See <see href="https://www.chartjs.org/docs/latest/configuration/decimation.html#decimation-algorithms">more...</see>
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public string Algorithm { get; set; } = "min-max";
+        public string Algorithm { get; set; }
 
         /// <summary>
         /// If the <c>lttb</c> algorithm is used, this is the number of samples in the output dataset. Defaults to the canvas width to pick 1 sample per pixel.

--- a/Source/Extensions/Blazorise.Charts/Options/ChartFont.cs
+++ b/Source/Extensions/Blazorise.Charts/Options/ChartFont.cs
@@ -13,19 +13,19 @@ namespace Blazorise.Charts
         /// Default font family for all text, follows CSS font-family options.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public string Family { get; set; } = "'Helvetica Neue', 'Helvetica', 'Arial', sans-serif";
+        public string Family { get; set; }
 
         /// <summary>
         /// Default font size (in px) for text. Does not apply to radialLinear scale point labels.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public double? Size { get; set; } = 12;
+        public double? Size { get; set; }
 
         /// <summary>
         /// Default font style. Does not apply to tooltip title or footer. Does not apply to chart title. Follows CSS font-style options (i.e. normal, italic, oblique, initial, inherit).
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public string Style { get; set; } = "normal";
+        public string Style { get; set; }
 
         /// <summary>
         /// Default font weight (boldness). See <see href="https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight">MDN</see>.
@@ -37,6 +37,6 @@ namespace Blazorise.Charts
         /// Height of an individual line of text. See <see href="https://developer.mozilla.org/en-US/docs/Web/CSS/line-height">MDN</see>.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public double? LineHeight { get; set; } = 1.2d;
+        public double? LineHeight { get; set; }
     }
 }

--- a/Source/Extensions/Blazorise.Charts/Options/ChartInteractions.cs
+++ b/Source/Extensions/Blazorise.Charts/Options/ChartInteractions.cs
@@ -13,7 +13,7 @@ namespace Blazorise.Charts
         /// Sets which elements appear in the interaction.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public string Mode { get; set; } = "nearest";
+        public string Mode { get; set; }
 
         /// <summary>
         /// If true, the interaction mode only applies when the mouse position intersects an item on the chart.
@@ -25,6 +25,6 @@ namespace Blazorise.Charts
         /// Can be set to 'x', 'y', or 'xy' to define which directions are used in calculating distances. Defaults to 'x' for 'index' mode and 'xy' in dataset and 'nearest' modes.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public string Axis { get; set; } = "x";
+        public string Axis { get; set; }
     }
 }

--- a/Source/Extensions/Blazorise.Charts/Options/ChartLegend.cs
+++ b/Source/Extensions/Blazorise.Charts/Options/ChartLegend.cs
@@ -10,19 +10,19 @@ namespace Blazorise.Charts
         /// Is the legend shown.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public bool? Display { get; set; } = true;
+        public bool? Display { get; set; }
 
         /// <summary>
         /// Position of the legend.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public string Position { get; set; } = "top";
+        public string Position { get; set; }
 
         /// <summary>
         /// Alignment of the legend.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public string Align { get; set; } = "center";
+        public string Align { get; set; }
 
         /// <summary>
         /// Maximum height of the legend, in pixels.
@@ -40,13 +40,13 @@ namespace Blazorise.Charts
         /// Marks that this box should take the full width/height of the canvas (moving other boxes). This is unlikely to need to be changed in day-to-day use.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public bool? FullSize { get; set; } = true;
+        public bool? FullSize { get; set; }
 
         /// <summary>
         /// Legend will show datasets in reverse order.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public bool? Reverse { get; set; } = false;
+        public bool? Reverse { get; set; }
 
         /// <summary>
         /// Options to change legend labels.

--- a/Source/Extensions/Blazorise.Charts/Options/ChartLegendLabel.cs
+++ b/Source/Extensions/Blazorise.Charts/Options/ChartLegendLabel.cs
@@ -13,13 +13,13 @@ namespace Blazorise.Charts
         /// Width of coloured box.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public double? BoxWidth { get; set; } = 40;
+        public double? BoxWidth { get; set; }
 
         /// <summary>
         /// Height of the coloured box.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public double? BoxHeight { get; set; } = 40;
+        public double? BoxHeight { get; set; }
 
         /// <summary>
         /// Color of label and the strikethrough.
@@ -38,24 +38,24 @@ namespace Blazorise.Charts
         /// Padding between rows of colored boxes.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public object Padding { get; set; } = 10;
+        public object Padding { get; set; }
 
         /// <summary>
         /// If specified, this style of point is used for the legend. Only used if usePointStyle is true.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public string PointStyle { get; set; } = "circle";
+        public string PointStyle { get; set; }
 
         /// <summary>
         /// Horizontal alignment of the label text. Options are: 'left', 'right' or 'center'.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public string TextAlign { get; set; } = "center";
+        public string TextAlign { get; set; }
 
         /// <summary>
         /// Label style will match corresponding point style (size is based on the minimum value between boxWidth and font.size).
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public bool? UsePointStyle { get; set; } = false;
+        public bool? UsePointStyle { get; set; }
     }
 }

--- a/Source/Extensions/Blazorise.Charts/Options/ChartLegendTitle.cs
+++ b/Source/Extensions/Blazorise.Charts/Options/ChartLegendTitle.cs
@@ -20,7 +20,7 @@ namespace Blazorise.Charts
         /// Is the legend title displayed.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public bool? Display { get; set; } = false;
+        public bool? Display { get; set; }
 
         /// <summary>
         /// Font of the text.
@@ -32,7 +32,7 @@ namespace Blazorise.Charts
         /// Padding around the title.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public object Padding { get; set; } = 0;
+        public object Padding { get; set; }
 
         /// <summary>
         /// The string title.

--- a/Source/Extensions/Blazorise.Charts/Options/ChartOptions.cs
+++ b/Source/Extensions/Blazorise.Charts/Options/ChartOptions.cs
@@ -28,26 +28,26 @@ namespace Blazorise.Charts
         /// Resizes the chart canvas when its container does.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public bool? Responsive { get; set; } = true;
+        public bool? Responsive { get; set; }
 
         /// <summary>
         /// Maintain the original canvas aspect ratio (width / height) when resizing.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public bool? MaintainAspectRatio { get; set; } = true;
+        public bool? MaintainAspectRatio { get; set; }
 
         /// <summary>
         /// Canvas aspect ratio (i.e. width / height, a value of 1 representing a square canvas).
         /// Note that this option is ignored if the height is explicitly defined either as attribute or via the style.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public double? AspectRatio { get; set; } = 2;
+        public double? AspectRatio { get; set; }
 
         /// <summary>
         /// Delay the resize update by give amount of milliseconds. This can ease the resize process by debouncing update of the elements.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public int? ResizeDelay { get; set; } = 0;
+        public int? ResizeDelay { get; set; }
 
         /// <summary>
         /// A string with a BCP 47 language tag, leveraging on <see href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat">INTL NumberFormat</see>

--- a/Source/Extensions/Blazorise.Charts/Options/ChartScaleTitle.cs
+++ b/Source/Extensions/Blazorise.Charts/Options/ChartScaleTitle.cs
@@ -13,13 +13,13 @@ namespace Blazorise.Charts
         /// If true, display the axis title.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public bool? Display { get; set; } = false;
+        public bool? Display { get; set; }
 
         /// <summary>
         /// Alignment of the axis title. Possible options are 'start', 'center' and 'end'.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public string Align { get; set; } = "center";
+        public string Align { get; set; }
 
         /// <summary>
         /// The text for the title. (i.e. "# of People" or "Response Choices").
@@ -45,6 +45,6 @@ namespace Blazorise.Charts
         /// Padding to apply around scale labels. Only top, bottom and y are implemented.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public object Padding { get; set; } = 10;
+        public object Padding { get; set; }
     }
 }

--- a/Source/Extensions/Blazorise.Charts/Options/ChartSubtitle.cs
+++ b/Source/Extensions/Blazorise.Charts/Options/ChartSubtitle.cs
@@ -13,7 +13,7 @@ namespace Blazorise.Charts
         /// Alignment of the subtitle.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public string Align { get; set; } = "center";
+        public string Align { get; set; }
 
         /// <summary>
         /// Color of the text.
@@ -26,19 +26,19 @@ namespace Blazorise.Charts
         /// Is the legend subtitle displayed.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public bool? Display { get; set; } = false;
+        public bool? Display { get; set; }
 
         /// <summary>
         /// Marks that this box should take the full width/height of the canvas. If false, the box is sized and placed above/beside the chart area.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public bool? FullSize { get; set; } = true;
+        public bool? FullSize { get; set; }
 
         /// <summary>
         /// Position of subtitle.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public string Position { get; set; } = "top";
+        public string Position { get; set; }
 
         /// <summary>
         /// Font of the text.
@@ -50,7 +50,7 @@ namespace Blazorise.Charts
         /// Padding around the subtitle.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public object Padding { get; set; } = 10;
+        public object Padding { get; set; }
 
         /// <summary>
         /// Subtitle text to display.

--- a/Source/Extensions/Blazorise.Charts/Options/ChartTitle.cs
+++ b/Source/Extensions/Blazorise.Charts/Options/ChartTitle.cs
@@ -13,7 +13,7 @@ namespace Blazorise.Charts
         /// Alignment of the title.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public string Align { get; set; } = "center";
+        public string Align { get; set; }
 
         /// <summary>
         /// Color of the text.
@@ -26,19 +26,19 @@ namespace Blazorise.Charts
         /// Is the legend title displayed.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public bool? Display { get; set; } = false;
+        public bool? Display { get; set; }
 
         /// <summary>
         /// Marks that this box should take the full width/height of the canvas. If false, the box is sized and placed above/beside the chart area.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public bool? FullSize { get; set; } = true;
+        public bool? FullSize { get; set; }
 
         /// <summary>
         /// Position of title.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public string Position { get; set; } = "top";
+        public string Position { get; set; }
 
         /// <summary>
         /// Font of the text.
@@ -50,7 +50,7 @@ namespace Blazorise.Charts
         /// Padding around the title.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public object Padding { get; set; } = 10;
+        public object Padding { get; set; }
 
         /// <summary>
         /// Title text to display.

--- a/Source/Extensions/Blazorise.Charts/Options/ChartTooltips.cs
+++ b/Source/Extensions/Blazorise.Charts/Options/ChartTooltips.cs
@@ -13,7 +13,7 @@ namespace Blazorise.Charts
         /// Are on-canvas tooltips enabled.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public bool? Enabled { get; set; } = true;
+        public bool? Enabled { get; set; }
 
         /// <summary>
         /// Sets which elements appear in the tooltip.
@@ -31,21 +31,21 @@ namespace Blazorise.Charts
         /// The mode for positioning the tooltip.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public string Position { get; set; } = "average";
+        public string Position { get; set; }
 
         /// <summary>
         /// Background color of the tooltip.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
         [JsonConverter( typeof( IndexableOptionsConverter<object> ) )]
-        public IndexableOption<object> BackgroundColor { get; set; } = "rgba(0, 0, 0, 0.8)";
+        public IndexableOption<object> BackgroundColor { get; set; }
 
         /// <summary>
         /// Color of title text.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
         [JsonConverter( typeof( IndexableOptionsConverter<object> ) )]
-        public IndexableOption<object> TitleColor { get; set; } = "#fff";
+        public IndexableOption<object> TitleColor { get; set; }
 
         /// <summary>
         /// See <see href="https://www.chartjs.org/docs/latest/general/fonts.html">Fonts</see>.
@@ -57,26 +57,26 @@ namespace Blazorise.Charts
         /// Horizontal alignment of the title text lines.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public string TitleAlign { get; set; } = "left";
+        public string TitleAlign { get; set; }
 
         /// <summary>
         /// Spacing to add to top and bottom of each title line.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public int? TitleSpacing { get; set; } = 2;
+        public int? TitleSpacing { get; set; }
 
         /// <summary>
         /// Margin to add on bottom of title section.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public int? TitleMarginBottom { get; set; } = 6;
+        public int? TitleMarginBottom { get; set; }
 
         /// <summary>
         /// Color of body text.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
         [JsonConverter( typeof( IndexableOptionsConverter<object> ) )]
-        public IndexableOption<object> BodyColor { get; set; } = "#fff";
+        public IndexableOption<object> BodyColor { get; set; }
 
         /// <summary>
         /// See <see href="https://www.chartjs.org/docs/latest/general/fonts.html">Fonts</see>.
@@ -88,20 +88,20 @@ namespace Blazorise.Charts
         /// Horizontal alignment of the body text lines.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public string BodyAlign { get; set; } = "left";
+        public string BodyAlign { get; set; }
 
         /// <summary>
         /// Spacing to add to top and bottom of each tooltip item.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public int? BodySpacing { get; set; } = 2;
+        public int? BodySpacing { get; set; }
 
         /// <summary>
         /// Color of footer text.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
         [JsonConverter( typeof( IndexableOptionsConverter<object> ) )]
-        public IndexableOption<object> FooterColor { get; set; } = "#fff";
+        public IndexableOption<object> FooterColor { get; set; }
 
         /// <summary>
         /// See <see href="https://www.chartjs.org/docs/latest/general/fonts.html">Fonts</see>.
@@ -113,56 +113,56 @@ namespace Blazorise.Charts
         /// Horizontal alignment of the footer text lines.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public string FooterAlign { get; set; } = "left";
+        public string FooterAlign { get; set; }
 
         /// <summary>
         /// Spacing to add to top and bottom of each footer line.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public int? FooterSpacing { get; set; } = 2;
+        public int? FooterSpacing { get; set; }
 
         /// <summary>
         /// Margin to add before drawing the footer.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public int? FooterMarginTop { get; set; } = 6;
+        public int? FooterMarginTop { get; set; }
 
         /// <summary>
         /// Padding inside the tooltip.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public object Padding { get; set; } = 6;
+        public object Padding { get; set; }
 
         /// <summary>
         /// Extra distance to move the end of the tooltip arrow away from the tooltip point.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public object CaretPadding { get; set; } = 2;
+        public object CaretPadding { get; set; }
 
         /// <summary>
         /// Size, in px, of the tooltip arrow.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public int? CaretSize { get; set; } = 5;
+        public int? CaretSize { get; set; }
 
         /// <summary>
         /// Radius of tooltip corner curves.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public int? CornerRadius { get; set; } = 6;
+        public int? CornerRadius { get; set; }
 
         /// <summary>
         /// Color to draw behind the colored boxes when multiple items are in the tooltip.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
         [JsonConverter( typeof( IndexableOptionsConverter<object> ) )]
-        public IndexableOption<object> MultiKeyBackground { get; set; } = "#fff";
+        public IndexableOption<object> MultiKeyBackground { get; set; }
 
         /// <summary>
         /// If true, color boxes are shown in the tooltip.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public bool? DisplayColors { get; set; } = true;
+        public bool? DisplayColors { get; set; }
 
         /// <summary>
         /// Width of the color box if displayColors is true.
@@ -180,26 +180,26 @@ namespace Blazorise.Charts
         /// Padding between the color box and the text.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public int? BoxPadding { get; set; } = 1;
+        public int? BoxPadding { get; set; }
 
         /// <summary>
         /// Use the corresponding point style (from dataset options) instead of color boxes, ex: star, triangle etc. (size is based on the minimum value between boxWidth and boxHeight).
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public bool? UsePointStyle { get; set; } = false;
+        public bool? UsePointStyle { get; set; }
 
         /// <summary>
         /// Color of the border.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
         [JsonConverter( typeof( IndexableOptionsConverter<object> ) )]
-        public IndexableOption<object> BorderColor { get; set; } = "rgba(0, 0, 0, 0)";
+        public IndexableOption<object> BorderColor { get; set; }
 
         /// <summary>
         /// Size of the border.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public int? BorderWidth { get; set; } = 0;
+        public int? BorderWidth { get; set; }
 
         /// <summary>
         /// true for rendering the tooltip from right to left.

--- a/Source/Extensions/Blazorise.Charts/Options/Specifics/BarChartOptions.cs
+++ b/Source/Extensions/Blazorise.Charts/Options/Specifics/BarChartOptions.cs
@@ -10,12 +10,12 @@ namespace Blazorise.Charts
         /// Percent (0-1) of the available width each bar should be within the category width. 1.0 will take the whole category width and put the bars right next to each other.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public float? BarPercentage { get; set; } = 0.9f;
+        public float? BarPercentage { get; set; }
 
         /// <summary>
         /// Percent (0-1) of the available width each category should be within the sample width. 
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public float? CategoryPercentage { get; set; } = 0.8f;
+        public float? CategoryPercentage { get; set; }
     }
 }

--- a/Source/Extensions/Blazorise.Charts/Options/Specifics/DoughnutChartOptions.cs
+++ b/Source/Extensions/Blazorise.Charts/Options/Specifics/DoughnutChartOptions.cs
@@ -10,6 +10,6 @@ namespace Blazorise.Charts
         /// The percentage of the chart that is cut out of the middle.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public new int? CutoutPercentage { get; set; } = 50;
+        public new int? CutoutPercentage { get; set; }
     }
 }

--- a/Source/Extensions/Blazorise.Charts/Options/Specifics/LineChartOptions.cs
+++ b/Source/Extensions/Blazorise.Charts/Options/Specifics/LineChartOptions.cs
@@ -10,12 +10,12 @@ namespace Blazorise.Charts
         /// If false, the lines between points are not drawn.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public bool? ShowLines { get; set; } = true;
+        public bool? ShowLines { get; set; }
 
         /// <summary>
         /// If false, NaN data causes a break in the line.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public bool? SpanGaps { get; set; } = false;
+        public bool? SpanGaps { get; set; }
     }
 }

--- a/Source/Extensions/Blazorise.Charts/Options/Specifics/PieChartOptions.cs
+++ b/Source/Extensions/Blazorise.Charts/Options/Specifics/PieChartOptions.cs
@@ -11,18 +11,18 @@ namespace Blazorise.Charts
         /// The percentage of the chart that is cut out of the middle.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public int? CutoutPercentage { get; set; } = 0;
+        public int? CutoutPercentage { get; set; }
 
         /// <summary>
         /// Starting angle to draw arcs from.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public double? Rotation { get; set; } = -0.5 * Math.PI;
+        public double? Rotation { get; set; }
 
         /// <summary>
         /// Sweep to allow arcs to cover.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public double? Circumference { get; set; } = 2 * Math.PI;
+        public double? Circumference { get; set; }
     }
 }

--- a/Source/Extensions/Blazorise.Charts/Options/Specifics/PolarAreaChartOptions.cs
+++ b/Source/Extensions/Blazorise.Charts/Options/Specifics/PolarAreaChartOptions.cs
@@ -11,6 +11,6 @@ namespace Blazorise.Charts
         /// Starting angle to draw arcs for the first item in a dataset.
         /// </summary>
         [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-        public double? StartAngle { get; set; } = -0.5 * Math.PI;
+        public double? StartAngle { get; set; }
     }
 }


### PR DESCRIPTION
resolves #3703

This is the continuation from #3701. Generally, we want to only serialize exactly what is defined by the user. Everything else will be handled by the ChartJS and by removing default values this will be possible.