### PR TITLE
DataGrid : ToggleDetailRow : Fix stale/disposed row info being used on ToggleDetailRow logic

### DIFF
--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -714,9 +714,10 @@ namespace Blazorise.DataGrid
             => ToggleDetailRow( item, DetailRowTriggerType.Manual, forceDetailRow, true );
 
         protected internal Task ToggleDetailRow( TItem item, DetailRowTriggerType detailRowTriggerType, bool forceDetailRow = false, bool skipDetailRowTriggerType = false )
-        {
-            var rowInfo = GetRowInfo( item );
+            => ToggleDetailRow( GetRowInfo( item ), detailRowTriggerType, forceDetailRow, skipDetailRowTriggerType );
 
+        protected internal Task ToggleDetailRow( DataGridRowInfo<TItem> rowInfo, DetailRowTriggerType detailRowTriggerType, bool forceDetailRow = false, bool skipDetailRowTriggerType = false )
+        {
             if ( rowInfo is not null )
             {
                 if ( forceDetailRow )
@@ -725,7 +726,7 @@ namespace Blazorise.DataGrid
                 }
                 else if ( DetailRowTrigger is not null )
                 {
-                    var detailRowTriggerContext = new DetailRowTriggerEventArgs<TItem>( item );
+                    var detailRowTriggerContext = new DetailRowTriggerEventArgs<TItem>( rowInfo.Item );
                     var detailRowTriggerResult = DetailRowTrigger( detailRowTriggerContext );
 
                     if ( !skipDetailRowTriggerType && detailRowTriggerType != detailRowTriggerContext.DetailRowTriggerType )
@@ -1271,7 +1272,7 @@ namespace Blazorise.DataGrid
         }
 
         private DataGridRowInfo<TItem> GetRowInfo( TItem item )
-            => Rows.FirstOrDefault( x => x.Item.IsEqual( item ) );
+            => Rows.LastOrDefault( x => x.Item.IsEqual( item ) );
 
         #endregion
 

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridRow.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridRow.razor.cs
@@ -81,7 +81,7 @@ namespace Blazorise.DataGrid
             ParentDataGrid.AddRow( RowInfo );
 
             if ( ParentDataGrid.DetailRowStartsVisible )
-                await ParentDataGrid.ToggleDetailRow( Item, DetailRowTriggerType.Manual, false, true );
+                await ParentDataGrid.ToggleDetailRow( RowInfo, DetailRowTriggerType.Manual, false, true );
 
             await base.OnInitializedAsync();
         }


### PR DESCRIPTION
Closes #3704

`GetRowInfo` was returning a `RowInfo` that is in the process of being disposed. 
When `RowInfo` is first created, use it straight up as a parameter for `DataGrid.ToggleDetailRow`, no point in doing another lookup.
Change `GetRowInfo` to grab the last row instead, making it safer to grab an actual non stale row if something similar could happen.

Also this does happen because the row is being re-rendered (Disposed of && re-Initialized), in this case it was just a filter so it probably should have kept the same row instance, instead of rendering a new one... going to open an issue so we can take a look if there's some optimization we can do here, we do have `@key="@item"` but it might not be working in certain cases, due to conditional renderings. Not sure if we can do something about it.