### PR TITLE
Fixed a reference

### DIFF
--- a/Documentation/Blazorise.Docs/Pages/Docs/Services/Notifications/NotificationPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Services/Notifications/NotificationPage.razor
@@ -34,7 +34,7 @@
     <DocsPageSectionHeader Title="Step 2. Define Usings">
         Since notification service is created as a wrapper around the <Code>Snackbar</Code> component so it is also required to define the namespace inside of your main <Badge Color="Color.Light">_Imports.razor</Badge> file.
     </DocsPageSectionHeader>
-    <DocsPageSectionSource Code="SnackbarImportsExample"></DocsPageSectionSource>
+    <DocsPageSectionSource Code="ComponentsImportExample"></DocsPageSectionSource>
 </DocsPageSection>
 
 <DocsPageSection>


### PR DESCRIPTION
Changed SnackbarImportsExample to ComponentsImportExample because NotificationAlert resides in Components namespace.