### PR TITLE
MessageAlert: Fix InvalidOperationException

### DIFF
--- a/Source/Blazorise/Components/MessageAlert/MessageAlert.razor.cs
+++ b/Source/Blazorise/Components/MessageAlert/MessageAlert.razor.cs
@@ -70,7 +70,7 @@ namespace Blazorise
             {
                 await ModalRef.Hide();
 
-                if ( IsConfirmation && Callback != null )
+                if ( IsConfirmation && Callback != null && !Callback.Task.IsCompleted )
                 {
                     await InvokeAsync( () => Callback.SetResult( true ) );
                 }
@@ -89,7 +89,7 @@ namespace Blazorise
             {
                 await ModalRef.Hide();
 
-                if ( IsConfirmation && Callback != null )
+                if ( IsConfirmation && Callback != null && !Callback.Task.IsCompleted )
                 {
                     await InvokeAsync( () => Callback.SetResult( false ) );
                 }


### PR DESCRIPTION
An InvalidOperationException can occur after rapidly double-clicking the confirm or cancel buttons. 

> Microsoft.AspNetCore.Components.Server.Circuits.RemoteRenderer[100]
>       Unhandled exception rendering component: An attempt was made to transition a task to a final state when it had already completed.
>       System.InvalidOperationException: An attempt was made to transition a task to a final state when it had already completed.
>          at System.Threading.Tasks.TaskCompletionSource`1.SetResult(TResult result)
>          at Blazorise.MessageAlert.<OnConfirmClicked\>b__4_1()
>          at Microsoft.AspNetCore.Components.Rendering.RendererSynchronizationContextDispatcher.InvokeAsync(Action workItem)
>          at Microsoft.AspNetCore.Components.ComponentBase.InvokeAsync(Action workItem)
>          at Blazorise.MessageAlert.<OnConfirmClicked\>b__4_0()
>          at Microsoft.AspNetCore.Components.ComponentBase.CallStateHasChangedOnAsyncCompletion(Task task)
>          at Blazorise.Button.ClickHandler()
>          at Microsoft.AspNetCore.Components.ComponentBase.CallStateHasChangedOnAsyncCompletion(Task task)
>          at Microsoft.AspNetCore.Components.RenderTree.Renderer.GetErrorHandledTask(Task taskToHandle, ComponentState owningComponentState)
> 