### PR TITLE
A couple fixes for bugs related to rapid double-clicking of MessageAlert and Modal buttons

### DIFF
--- a/Source/Blazorise/Adapters/CloseableAdapter.cs
+++ b/Source/Blazorise/Adapters/CloseableAdapter.cs
@@ -33,12 +33,6 @@ namespace Blazorise
 
                 await Task.Delay( animatedComponent.AnimationDuration );
 
-                // NOT SURE IF WE NEED THIS?
-                if ( visible )
-                    await animatedComponent.Show();
-                else
-                    await animatedComponent.Hide();
-
                 await animatedComponent.EndAnimation( visible );
             }
             else

--- a/Source/Blazorise/Components/MessageAlert/MessageAlert.razor.cs
+++ b/Source/Blazorise/Components/MessageAlert/MessageAlert.razor.cs
@@ -70,7 +70,7 @@ namespace Blazorise
             {
                 await ModalRef.Hide();
 
-                if ( IsConfirmation && Callback != null )
+                if ( IsConfirmation && Callback != null && !Callback.Task.IsCompleted )
                 {
                     await InvokeAsync( () => Callback.SetResult( true ) );
                 }
@@ -89,7 +89,7 @@ namespace Blazorise
             {
                 await ModalRef.Hide();
 
-                if ( IsConfirmation && Callback != null )
+                if ( IsConfirmation && Callback != null && !Callback.Task.IsCompleted )
                 {
                     await InvokeAsync( () => Callback.SetResult( false ) );
                 }


### PR DESCRIPTION
MessageAlert will throw an exception if any of the submit or close buttons are clicked twice in rapid succession. This results in client crashes/disconnects.

> Microsoft.AspNetCore.Components.Server.Circuits.RemoteRenderer[100]
> Unhandled exception rendering component: An attempt was made to transition a task to a final state when it had already completed.
> System.InvalidOperationException: An attempt was made to transition a task to a final state when it had already completed.
> at System.Threading.Tasks.TaskCompletionSource`1.SetResult(TResult result)
> at Blazorise.MessageAlert.<OnConfirmClicked\>b__4_1()
> at Microsoft.AspNetCore.Components.Rendering.RendererSynchronizationContextDispatcher.InvokeAsync(Action workItem)
> at Microsoft.AspNetCore.Components.ComponentBase.InvokeAsync(Action workItem)
> at Blazorise.MessageAlert.<OnConfirmClicked\>b__4_0()
> at Microsoft.AspNetCore.Components.ComponentBase.CallStateHasChangedOnAsyncCompletion(Task task)
> at Blazorise.Button.ClickHandler()
> at Microsoft.AspNetCore.Components.ComponentBase.CallStateHasChangedOnAsyncCompletion(Task task)
> at Microsoft.AspNetCore.Components.RenderTree.Renderer.GetErrorHandledTask(Task taskToHandle, ComponentState owningComponentState)

The Modal component will enter a (potentially) infinite loop if Hide is called immediately following a Show call. Easily reproducible on the demo site by quickly double-clicking any of the show modal buttons. This results in a flashing unresponsive page while also spamming the circuit with events.