### PR TITLE
DataGrid : Fix : Virtualize not reading data when EmptyTemplate is set.

### DIFF
--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -254,7 +254,7 @@ namespace Blazorise.DataGrid
                 paginationContext.SubscribeOnPageSizeChanged( OnPageSizeChanged );
                 paginationContext.SubscribeOnPageChanged( OnPageChanged );
 
-                if( ManualReadMode )
+                if( ManualReadMode || VirtualizeManualReadMode )
                     await Reload();
 
                 return;
@@ -975,10 +975,14 @@ namespace Blazorise.DataGrid
 
         /// <summary>
         /// Triggers the reload of the <see cref="DataGrid{TItem}"/> data.
+        /// Makes sure not to reload if the DataGrid is in a loading state.
         /// </summary>
         /// <returns>Returns the awaitable task.</returns>
         public async Task Reload( CancellationToken cancellationToken = default )
         {
+            if ( IsLoading )
+                return;
+
             SetDirty();
 
             if ( ManualReadMode )
@@ -1376,13 +1380,13 @@ namespace Blazorise.DataGrid
         /// Returns true if EmptyTemplate is set and Data is null or empty.
         /// </summary>
         protected bool IsEmptyTemplateVisible
-            => !IsLoadingTemplateVisible && !IsNewItemInGrid && EmptyTemplate != null && Data.IsNullOrEmpty();
+            => !IsLoading && !IsNewItemInGrid && EmptyTemplate != null && Data.IsNullOrEmpty() && Rendered;
 
         /// <summary>
         /// Returns true if EmptyFilterTemplate is set and FilteredData is null or empty.
         /// </summary>
         protected bool IsEmptyFilterTemplateVisible
-            => !IsLoadingTemplateVisible && !IsNewItemInGrid && EmptyFilterTemplate != null && ( !data.IsNullOrEmpty() && FilteredData.IsNullOrEmpty() );
+            => !IsLoading && !IsNewItemInGrid && EmptyFilterTemplate != null && ( !data.IsNullOrEmpty() && FilteredData.IsNullOrEmpty() ) && Rendered;
 
         /// <summary>
         /// Returns true if ShowPager is true and grid is not empty or loading.


### PR DESCRIPTION
Closes #3795

- Added an escape on `Reload` if DataGrid is already in Loading state.
- Added a new `OnAfterRenderAsync` first render condition to make sure to `Reload` the `DataGrid` if `VirtualizeManualReadMode` is set to obtain the data, since `EmptyTemplate` would fight over the `Virtualize` render since no data would still exist.
- On `IsEmptyTemplateVisible`/`IsEmptyFilterTemplateVisible` Prefer `IsLoading` over `IsLoadingTemplateVisible` as whenever the DataGrid is loading makes sense to not display this template.
- On `IsEmptyTemplateVisible`/`IsEmptyFilterTemplateVisible` add `Rendered` condition to make sure it's only ever true after the first rendering process has happened.