### PR TITLE
MessageAlert: fix double-clicking invocation

### DIFF
--- a/Source/Blazorise/Adapters/CloseableAdapter.cs
+++ b/Source/Blazorise/Adapters/CloseableAdapter.cs
@@ -33,12 +33,6 @@ namespace Blazorise
 
                 await Task.Delay( animatedComponent.AnimationDuration );
 
-                // NOT SURE IF WE NEED THIS?
-                if ( visible )
-                    await animatedComponent.Show();
-                else
-                    await animatedComponent.Hide();
-
                 await animatedComponent.EndAnimation( visible );
             }
             else

--- a/Source/Blazorise/Components/MessageAlert/MessageAlert.razor.cs
+++ b/Source/Blazorise/Components/MessageAlert/MessageAlert.razor.cs
@@ -70,7 +70,7 @@ namespace Blazorise
             {
                 await ModalRef.Hide();
 
-                if ( IsConfirmation && Callback != null )
+                if ( IsConfirmation && Callback != null && !Callback.Task.IsCompleted )
                 {
                     await InvokeAsync( () => Callback.SetResult( true ) );
                 }
@@ -89,7 +89,7 @@ namespace Blazorise
             {
                 await ModalRef.Hide();
 
-                if ( IsConfirmation && Callback != null )
+                if ( IsConfirmation && Callback != null && !Callback.Task.IsCompleted )
                 {
                     await InvokeAsync( () => Callback.SetResult( false ) );
                 }


### PR DESCRIPTION
Recreation of #3797 because it was done on the wrong branch, and rebase would bring dev changes onto the stable release.

@Bobbar