### PR TITLE
DatePicker: compare array values to prevent duplicate change events

### DIFF
--- a/Source/Blazorise/Base/BaseInputComponent.razor.cs
+++ b/Source/Blazorise/Base/BaseInputComponent.razor.cs
@@ -201,6 +201,13 @@ namespace Blazorise
             => value;
 
         /// <summary>
+        /// Check if the internal value is same as the new value.
+        /// </summary>
+        /// <param name="value">Value to check against the internal value.</param>
+        /// <returns>True if the internal value matched the supplied value.</returns>
+        protected virtual bool IsSameAsInternalValue( TValue value ) => value.IsEqual( InternalValue );
+
+        /// <summary>
         /// Raises and event that handles the edit value of Text, Date, Numeric etc.
         /// </summary>
         /// <param name="value">New edit value.</param>
@@ -361,7 +368,7 @@ namespace Blazorise
             get => InternalValue;
             set
             {
-                if ( !value.IsEqual( InternalValue ) )
+                if ( !IsSameAsInternalValue( value ) )
                 {
                     InternalValue = value;
                     InvokeAsync( () => OnInternalValueChanged( value ) );

--- a/Source/Blazorise/Components/DatePicker/DatePicker.razor.cs
+++ b/Source/Blazorise/Components/DatePicker/DatePicker.razor.cs
@@ -378,6 +378,9 @@ namespace Blazorise
             };
         }
 
+        /// <inheritdoc/>
+        protected override bool IsSameAsInternalValue( IReadOnlyList<TValue> value ) => value.AreEqual( InternalValue );
+
         #endregion
 
         #region Properties


### PR DESCRIPTION
Closes #3798

DatePicker's internal value is an array. So when `value.IsEqual( InternalValue )` was used in the base class, it would always fail. I have introduced a new API in the base input class, to be able to override the compare function. Currently, only DatePicker uses it. I think a `Select` should also benefit from it because it too uses an array internally.