### PR TITLE
Fix for Modal double-click infinite loop.

### DIFF
--- a/Source/Blazorise/Adapters/CloseableAdapter.cs
+++ b/Source/Blazorise/Adapters/CloseableAdapter.cs
@@ -33,11 +33,6 @@ namespace Blazorise
 
                 await Task.Delay( animatedComponent.AnimationDuration );
 
-                if ( visible )
-                    await animatedComponent.Show();
-                else
-                    await animatedComponent.Hide();
-
                 await animatedComponent.EndAnimation( visible );
             }
             else


### PR DESCRIPTION
I tested with all providers with backdrop visible & hidden and compared VisibleChanged events and CloseReason states and the fix does not appear to effect the behavior.