### PR TITLE
Modal: Fix Animations

### DIFF
--- a/Source/Blazorise.Bootstrap/Modal.razor
+++ b/Source/Blazorise.Bootstrap/Modal.razor
@@ -7,7 +7,7 @@
                 @ChildContent
             }
         </div>
-        @if ( ShowBackdrop && IsVisible )
+        @if ( ShowBackdrop && IsBackdropVisible )
         {
             <_ModalBackdrop CloseActivatorDisabled />
         }

--- a/Source/Blazorise.Bootstrap/Modal.razor
+++ b/Source/Blazorise.Bootstrap/Modal.razor
@@ -7,7 +7,7 @@
                 @ChildContent
             }
         </div>
-        @if ( ShowBackdrop && IsBackdropVisible )
+        @if ( ShowBackdrop && BackdropVisible )
         {
             <_ModalBackdrop CloseActivatorDisabled />
         }

--- a/Source/Blazorise.Bootstrap5/Modal.razor
+++ b/Source/Blazorise.Bootstrap5/Modal.razor
@@ -7,7 +7,7 @@
                 @ChildContent
             }
         </div>
-        @if ( ShowBackdrop && IsVisible )
+        @if ( ShowBackdrop && IsBackdropVisible )
         {
             <_ModalBackdrop CloseActivatorDisabled />
         }

--- a/Source/Blazorise.Bootstrap5/Modal.razor
+++ b/Source/Blazorise.Bootstrap5/Modal.razor
@@ -7,7 +7,7 @@
                 @ChildContent
             }
         </div>
-        @if ( ShowBackdrop && IsBackdropVisible )
+        @if ( ShowBackdrop && BackdropVisible )
         {
             <_ModalBackdrop CloseActivatorDisabled />
         }

--- a/Source/Blazorise/Adapters/CloseableAdapter.cs
+++ b/Source/Blazorise/Adapters/CloseableAdapter.cs
@@ -31,7 +31,13 @@ namespace Blazorise
             {
                 await animatedComponent.BeginAnimation( visible );
 
-                await Task.Delay( animatedComponent.AnimationDuration );
+                if ( visible )
+                    // The 10ms delay is selected based on testing.
+                    // Task.Yield works for Blazor WebAssembly, but not for Blazor Server apps.
+                    // A small delay works well for both.
+                    await Task.Delay( 10 );
+                else
+                    await Task.Delay( animatedComponent.AnimationDuration );
 
                 await animatedComponent.EndAnimation( visible );
             }

--- a/Source/Blazorise/Components/Modal/Modal.razor
+++ b/Source/Blazorise/Components/Modal/Modal.razor
@@ -5,7 +5,7 @@
         <div @ref="@ElementRef" id="@ElementId" class="@ClassNames" style="@StyleNames" role="dialog" @attributes="@Attributes">
             @if ( RenderMode == ModalRenderMode.Default || ( RenderMode == ModalRenderMode.LazyReload && IsVisible ) || ( RenderMode == ModalRenderMode.LazyLoad && lazyLoaded ) )
             {
-                @if ( ShowBackdrop )
+                @if ( ShowBackdrop && IsBackdropVisible )
                 {
                     <_ModalBackdrop />
                 }

--- a/Source/Blazorise/Components/Modal/Modal.razor
+++ b/Source/Blazorise/Components/Modal/Modal.razor
@@ -5,7 +5,7 @@
         <div @ref="@ElementRef" id="@ElementId" class="@ClassNames" style="@StyleNames" role="dialog" @attributes="@Attributes">
             @if ( RenderMode == ModalRenderMode.Default || ( RenderMode == ModalRenderMode.LazyReload && IsVisible ) || ( RenderMode == ModalRenderMode.LazyLoad && lazyLoaded ) )
             {
-                @if ( ShowBackdrop && IsBackdropVisible )
+                @if ( ShowBackdrop && BackdropVisible )
                 {
                     <_ModalBackdrop />
                 }

--- a/Source/Blazorise/Components/Modal/Modal.razor.cs
+++ b/Source/Blazorise/Components/Modal/Modal.razor.cs
@@ -199,7 +199,7 @@ namespace Blazorise
                     DirtyStyles();
 
                     if ( ShowBackdrop )
-                        IsBackdropVisible = true;
+                        BackdropVisible = true;
                 }
 
                 await InvokeAsync( StateHasChanged );
@@ -237,7 +237,7 @@ namespace Blazorise
                     DirtyStyles();
 
                     if ( ShowBackdrop )
-                        IsBackdropVisible = false;
+                        BackdropVisible = false;
                 }
 
                 // finally reset close reason so it doesn't interfere with internal closing by Visible property
@@ -436,7 +436,7 @@ namespace Blazorise
         {
             if ( visible )
             {
-                IsBackdropVisible = ShowBackdrop;
+                BackdropVisible = ShowBackdrop;
                 DirtyStyles();
             }
             else
@@ -453,7 +453,7 @@ namespace Blazorise
             else
                 DirtyStyles();
 
-            IsBackdropVisible = ShowBackdrop && visible;
+            BackdropVisible = ShowBackdrop && visible;
 
             return InvokeAsync( StateHasChanged );
         }
@@ -470,7 +470,7 @@ namespace Blazorise
         /// <summary>
         /// Returns true if the modal backdrop should be visible.
         /// </summary>
-        protected internal bool IsBackdropVisible = false;
+        protected internal bool BackdropVisible = false;
 
         /// <inheritdoc/>
         protected override bool ShouldAutoGenerateId => true;

--- a/Source/Blazorise/Components/Modal/Modal.razor.cs
+++ b/Source/Blazorise/Components/Modal/Modal.razor.cs
@@ -197,6 +197,9 @@ namespace Blazorise
                 {
                     DirtyClasses();
                     DirtyStyles();
+
+                    if ( ShowBackdrop )
+                        IsBackdropVisible = true;
                 }
 
                 await InvokeAsync( StateHasChanged );
@@ -232,6 +235,9 @@ namespace Blazorise
                 {
                     DirtyClasses();
                     DirtyStyles();
+
+                    if ( ShowBackdrop )
+                        IsBackdropVisible = false;
                 }
 
                 // finally reset close reason so it doesn't interfere with internal closing by Visible property
@@ -429,7 +435,10 @@ namespace Blazorise
         public Task BeginAnimation( bool visible )
         {
             if ( visible )
+            {
+                IsBackdropVisible = ShowBackdrop;
                 DirtyStyles();
+            }
             else
                 DirtyClasses();
 
@@ -444,6 +453,8 @@ namespace Blazorise
             else
                 DirtyStyles();
 
+            IsBackdropVisible = ShowBackdrop && visible;
+
             return InvokeAsync( StateHasChanged );
         }
 
@@ -455,6 +466,11 @@ namespace Blazorise
         /// Returns true if the modal should be visible.
         /// </summary>
         protected internal bool IsVisible => State.Visible == true;
+
+        /// <summary>
+        /// Returns true if the modal backdrop should be visible.
+        /// </summary>
+        protected internal bool IsBackdropVisible = false;
 
         /// <inheritdoc/>
         protected override bool ShouldAutoGenerateId => true;


### PR DESCRIPTION
Through testing I found that the full duration delay in the ClosableAdapter is not necessary when transitioning to a visible state. I also found that the modal backdrop fade can be restored by decoupling it from the parent modal visible state and only changing the backdrop visibility before or after the animation.

I tested with all providers and it seems to work well.  It definitely feels more snappy without the delay.