### PR TITLE
AutoComplete : Loading Flag

### DIFF
--- a/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
+++ b/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
@@ -178,7 +178,10 @@ namespace Blazorise.Components
             if ( string.IsNullOrEmpty( text ) )
                 await Clear();
 
+            IsLoading = true;
             await SearchChanged.InvokeAsync( CurrentSearch );
+            IsLoading = false;
+
             await SelectedTextChanged.InvokeAsync( SelectedText );
 
             if ( FilteredData?.Count == 0 && NotFound.HasDelegate )
@@ -282,7 +285,9 @@ namespace Blazorise.Components
             else
             {
                 CurrentSearch = null;
+                IsLoading = true;
                 await SearchChanged.InvokeAsync( CurrentSearch );
+                IsLoading = false;
             }
 
             SelectedValue = Converters.ChangeType<TValue>( value );
@@ -579,6 +584,11 @@ namespace Blazorise.Components
         #region Properties
 
         /// <summary>
+        /// Returns true if SearchChanged has yet to finish.
+        /// </summary>
+        protected bool IsLoading { get; set; }
+
+        /// <summary>
         /// Gets the DropdownMenu reference.
         /// </summary>
         public DropdownMenu DropdownMenuRef { get; set; }
@@ -638,7 +648,7 @@ namespace Blazorise.Components
         /// True if the not found content should be visible.
         /// </summary>
         protected bool NotFoundVisible
-            => FilteredData?.Count == 0 && IsTextSearchable && TextFocused && NotFoundContent != null;
+            => FilteredData?.Count == 0 && IsTextSearchable && TextFocused && NotFoundContent != null && !IsLoading;
 
         /// <summary>
         /// True if the component has the pre-requirements to search

--- a/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
+++ b/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
@@ -178,9 +178,9 @@ namespace Blazorise.Components
             if ( string.IsNullOrEmpty( text ) )
                 await Clear();
 
-            IsLoading = true;
+            Loading = true;
             await SearchChanged.InvokeAsync( CurrentSearch );
-            IsLoading = false;
+            Loading = false;
 
             await SelectedTextChanged.InvokeAsync( SelectedText );
 
@@ -285,9 +285,9 @@ namespace Blazorise.Components
             else
             {
                 CurrentSearch = null;
-                IsLoading = true;
+                Loading = true;
                 await SearchChanged.InvokeAsync( CurrentSearch );
-                IsLoading = false;
+                Loading = false;
             }
 
             SelectedValue = Converters.ChangeType<TValue>( value );
@@ -586,7 +586,7 @@ namespace Blazorise.Components
         /// <summary>
         /// Returns true if SearchChanged has yet to finish.
         /// </summary>
-        protected bool IsLoading { get; set; }
+        protected bool Loading { get; set; }
 
         /// <summary>
         /// Gets the DropdownMenu reference.
@@ -648,7 +648,7 @@ namespace Blazorise.Components
         /// True if the not found content should be visible.
         /// </summary>
         protected bool NotFoundVisible
-            => FilteredData?.Count == 0 && IsTextSearchable && TextFocused && NotFoundContent != null && !IsLoading;
+            => FilteredData?.Count == 0 && IsTextSearchable && TextFocused && NotFoundContent != null && !Loading;
 
         /// <summary>
         /// True if the component has the pre-requirements to search


### PR DESCRIPTION
Closes #2996

By adding an `Loading` flag, we tell that `NotFoundContent` should only display if the `AutoComplete` isn't in a loading state.
`AutoComplete` will be in a loading state, while `SearchChanged` EventCallback is running.
In the next release, we should make sure that the flag also includes the new `ReadData` feature, #3856

Code used to test:
```
<Autocomplete TItem="string"
              TValue="string"
              Data="@data"
              TextField="@(( item ) => item)"
              ValueField="@((item) => item)"
              Placeholder="Search..."
              Filter="AutocompleteFilter.StartsWith"
              SearchChanged="SearchChanged"
>
    <NotFoundContent> Sorry... @context was not found! :( </NotFoundContent>
</Autocomplete>

@code{
    List<string> data = new();

    public async Task SearchChanged(string value )
    {
        await Task.Delay(2000);
        if (value.StartsWith("a"))
            data = new List<string>()
            {
                "Amalia",
                "Amarante"
            };
        else
            data = new();
    }
}
```