### PR TITLE
Virtualize ManualReadMode : Workaround for Stale parameter 

### DIFF
--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -237,7 +237,7 @@ namespace Blazorise.DataGrid
         {
             Aggregates.Add( aggregate );
         }
-
+        
         public override async Task SetParametersAsync( ParameterView parameters )
         {
             await CheckMultipleSelectionSetEmpty( parameters );
@@ -1055,6 +1055,7 @@ namespace Blazorise.DataGrid
                 : request.Count;
 
             await HandleVirtualizeReadData( request.StartIndex, requestCount, request.CancellationToken );
+            await Task.Yield(); // This line makes sure SetParametersAsync catches up, since we depend upon Data Parameter.
 
             if ( request.CancellationToken.IsCancellationRequested )
                 return new();


### PR DESCRIPTION
Closes [#3516](https://github.com/Megabit/Blazorise/issues/3516)

I couldn't find a better fix. `Virtualize` `ManualReadMode` binds to the `VirtualizeItemsProviderHandler` that expects data to be returned. This data depends upon the `Data` parameter, which in this case, like the user reported, would use stale data, due to `SetParametersAsync` not have been run yet.

I have wondered this before, and `ReadData` does work great. 
But generally, for these apis, and just like in the `Virtualize` component, they tell you to return the data (instead of basically mutating it "externally") and then they do the work internally, do you remember why the choice of `EventCallback` over the "handler" approach? Or was it not considered at the time?