### PR TITLE
Add MouseEventArgs to all Clicked events

### DIFF
--- a/Source/Blazorise.AntDesign/Button.cs
+++ b/Source/Blazorise.AntDesign/Button.cs
@@ -2,6 +2,7 @@
 using Blazorise.Extensions;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.AspNetCore.Components.Web;
 #endregion
 
 namespace Blazorise.AntDesign
@@ -44,7 +45,7 @@ namespace Blazorise.AntDesign
                 }
             }
 
-            builder.OnClick( this, EventCallback.Factory.Create( this, ClickHandler ) );
+            builder.OnClick( this, EventCallback.Factory.Create<MouseEventArgs>( this, ClickHandler ) );
             builder.OnClickPreventDefault( Type == ButtonType.Link && To != null && To.StartsWith( "#" ) );
 
             builder.Attributes( Attributes );

--- a/Source/Blazorise.AntDesign/CloseButton.razor
+++ b/Source/Blazorise.AntDesign/CloseButton.razor
@@ -1,5 +1,5 @@
 ﻿@inherits Blazorise.CloseButton
-<button id="@ElementId" type="button" class="@ClassNames" style="@StyleNames" aria-label="Close" @onclick="@ClickHandler" @attributes="@Attributes">
+<button id="@ElementId" type="button" class="@ClassNames" style="@StyleNames" disabled="@DisabledString" aria-label="Close" @onclick="@ClickHandler" @attributes="@Attributes">
     @if ( ParentAlert != null )
     {
         <span role="img" aria-label="close" class="anticon anticon-close"><svg viewBox="64 64 896 896" focusable="false" class="" data-icon="close" width="1em" height="1em" fill="currentColor" aria-hidden="true"><path d="M563.8 512l262.5-312.9c4.4-5.2.7-13.1-6.1-13.1h-79.8c-4.7 0-9.2 2.1-12.3 5.7L511.6 449.8 295.1 191.7c-3-3.6-7.5-5.7-12.3-5.7H203c-6.8 0-10.5 7.9-6.1 13.1L459.4 512 196.9 824.9A7.95 7.95 0 00203 838h79.8c4.7 0 9.2-2.1 12.3-5.7l216.5-258.1 216.5 258.1c3 3.6 7.5 5.7 12.3 5.7h79.8c6.8 0 10.5-7.9 6.1-13.1L563.8 512z"></path></svg></span>

--- a/Source/Blazorise.Bootstrap/Button.cs
+++ b/Source/Blazorise.Bootstrap/Button.cs
@@ -2,6 +2,7 @@
 using Blazorise.Extensions;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.AspNetCore.Components.Web;
 #endregion
 
 namespace Blazorise.Bootstrap
@@ -37,7 +38,7 @@ namespace Blazorise.Bootstrap
                 }
             }
 
-            builder.OnClick( this, EventCallback.Factory.Create( this, ClickHandler ) );
+            builder.OnClick( this, EventCallback.Factory.Create<MouseEventArgs>( this, ClickHandler ) );
             builder.OnClickPreventDefault( Type == ButtonType.Link && To != null && To.StartsWith( "#" ) );
 
             builder.Attributes( Attributes );

--- a/Source/Blazorise.Bootstrap/CloseButton.razor
+++ b/Source/Blazorise.Bootstrap/CloseButton.razor
@@ -1,5 +1,5 @@
 ﻿@inherits Blazorise.CloseButton
-<button id="@ElementId" type="button" class="@ClassNames" style="@StyleNames" aria-label="Close" @onclick="@ClickHandler" @attributes="@Attributes">
+<button id="@ElementId" type="button" class="@ClassNames" style="@StyleNames" disabled="@DisabledString" aria-label="Close" @onclick="@ClickHandler" @attributes="@Attributes">
     <span aria-hidden="true">&times;</span>
     @ChildContent
 </button>

--- a/Source/Blazorise.Bootstrap5/Button.cs
+++ b/Source/Blazorise.Bootstrap5/Button.cs
@@ -3,6 +3,7 @@ using Blazorise.Extensions;
 using Blazorise.Utilities;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.AspNetCore.Components.Web;
 #endregion
 
 namespace Blazorise.Bootstrap5
@@ -62,7 +63,7 @@ namespace Blazorise.Bootstrap5
                 builder.AriaExpanded( ParentCollapseHeader.ParentCollapse.Visible.ToString().ToLowerInvariant() );
             }
 
-            builder.OnClick( this, EventCallback.Factory.Create( this, ClickHandler ) );
+            builder.OnClick( this, EventCallback.Factory.Create<MouseEventArgs>( this, ClickHandler ) );
             builder.OnClickPreventDefault( Type == ButtonType.Link && To != null && To.StartsWith( "#" ) );
 
             builder.Attributes( Attributes );

--- a/Source/Blazorise.Bootstrap5/CloseButton.razor
+++ b/Source/Blazorise.Bootstrap5/CloseButton.razor
@@ -1,4 +1,4 @@
 ﻿@inherits Blazorise.CloseButton
-<button id="@ElementId" type="button" class="@ClassNames" style="@StyleNames" aria-label="Close" @onclick="@ClickHandler" @attributes="@Attributes">
+<button id="@ElementId" type="button" class="@ClassNames" style="@StyleNames" disabled="@DisabledString" aria-label="Close" @onclick="@ClickHandler" @attributes="@Attributes">
     @ChildContent
 </button>

--- a/Source/Blazorise.Bulma/Button.cs
+++ b/Source/Blazorise.Bulma/Button.cs
@@ -2,6 +2,7 @@
 using Blazorise.Extensions;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.AspNetCore.Components.Web;
 #endregion
 
 namespace Blazorise.Bulma
@@ -44,7 +45,7 @@ namespace Blazorise.Bulma
                 }
             }
 
-            builder.OnClick( this, EventCallback.Factory.Create( this, ClickHandler ) );
+            builder.OnClick( this, EventCallback.Factory.Create<MouseEventArgs>( this, ClickHandler ) );
             builder.OnClickPreventDefault( Type == ButtonType.Link && To != null && To.StartsWith( "#" ) );
 
             builder.Attributes( Attributes );

--- a/Source/Blazorise/Components/Bar/BarDropdownItem.razor.cs
+++ b/Source/Blazorise/Components/Bar/BarDropdownItem.razor.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Blazorise.States;
 using Blazorise.Utilities;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 #endregion
 
 namespace Blazorise
@@ -34,21 +35,23 @@ namespace Blazorise
         {
             base.BuildStyles( builder );
 
-            builder.Append( FormattableString.Invariant( $"padding-left: { Indentation * ( ParentDropdownState.NestedIndex + 1d ) }rem" ), ParentDropdownState.IsInlineDisplay );
+            builder.Append( FormattableString.Invariant( $"padding-left: {Indentation * ( ParentDropdownState.NestedIndex + 1d )}rem" ), ParentDropdownState.IsInlineDisplay );
         }
 
         /// <summary>
         /// Handles the item onclick event.
         /// </summary>
+        /// <param name="eventArgs">Supplies information about a mouse event that is being raised.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
-        protected async Task ClickHandler()
+        protected async Task ClickHandler( MouseEventArgs eventArgs )
         {
             if ( ParentBarDropdown is not null && ParentDropdownState.Mode == BarMode.Horizontal )
             {
                 if ( !ParentBarDropdown.WasJustToggled )
                     await ParentBarDropdown.Hide( true );
             }
-            await Clicked.InvokeAsync();
+
+            await Clicked.InvokeAsync( eventArgs );
         }
 
         #endregion
@@ -58,7 +61,7 @@ namespace Blazorise
         /// <summary>
         /// Occurs when the item is clicked.
         /// </summary>
-        [Parameter] public EventCallback Clicked { get; set; }
+        [Parameter] public EventCallback<MouseEventArgs> Clicked { get; set; }
 
         /// <summary>
         /// Specifies the URL of the page the link goes to.

--- a/Source/Blazorise/Components/Bar/BarDropdownToggle.razor.cs
+++ b/Source/Blazorise/Components/Bar/BarDropdownToggle.razor.cs
@@ -5,6 +5,7 @@ using Blazorise.Modules;
 using Blazorise.States;
 using Blazorise.Utilities;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 using Microsoft.JSInterop;
 #endregion
 
@@ -48,7 +49,7 @@ namespace Blazorise
         {
             base.BuildStyles( builder );
 
-            builder.Append( $"padding-left: { Indentation * ParentDropdownState.NestedIndex }rem", ParentDropdownState.IsInlineDisplay );
+            builder.Append( $"padding-left: {Indentation * ParentDropdownState.NestedIndex}rem", ParentDropdownState.IsInlineDisplay );
         }
 
         /// <inheritdoc/>
@@ -85,14 +86,15 @@ namespace Blazorise
         /// <summary>
         /// Handles the button click event.
         /// </summary>
+        /// <param name="eventArgs">Supplies information about a mouse event that is being raised.</param>
         /// <returns>Returns the awaitable task.</returns>
-        protected Task ClickHandler()
+        protected Task ClickHandler( MouseEventArgs eventArgs )
         {
 
             if ( ParentBarDropdown != null )
                 return ParentBarDropdown.Toggle( ElementId );
 
-            return Clicked.InvokeAsync();
+            return Clicked.InvokeAsync( eventArgs );
         }
 
         /// <inheritdoc/>
@@ -159,7 +161,7 @@ namespace Blazorise
         /// <summary>
         /// Occurs when the toggle button is clicked.
         /// </summary>
-        [Parameter] public EventCallback Clicked { get; set; }
+        [Parameter] public EventCallback<MouseEventArgs> Clicked { get; set; }
 
         /// <summary>
         /// Gets or sets the parent dropdown state object.

--- a/Source/Blazorise/Components/Bar/BarLink.razor.cs
+++ b/Source/Blazorise/Components/Bar/BarLink.razor.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Blazorise.States;
 using Blazorise.Utilities;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 #endregion
 
 namespace Blazorise
@@ -32,10 +33,11 @@ namespace Blazorise
         /// <summary>
         /// Handles the link onclick event.
         /// </summary>
+        /// <param name="eventArgs">Supplies information about a mouse event that is being raised.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
-        protected Task ClickHandler()
+        protected Task ClickHandler( MouseEventArgs eventArgs )
         {
-            return Clicked.InvokeAsync();
+            return Clicked.InvokeAsync( eventArgs );
         }
 
         #endregion
@@ -45,7 +47,7 @@ namespace Blazorise
         /// <summary>
         /// Occurs when the item is clicked.
         /// </summary>
-        [Parameter] public EventCallback Clicked { get; set; }
+        [Parameter] public EventCallback<MouseEventArgs> Clicked { get; set; }
 
         /// <summary>
         /// Specifies the URL of the page the link goes to.

--- a/Source/Blazorise/Components/Bar/BarToggler.razor.cs
+++ b/Source/Blazorise/Components/Bar/BarToggler.razor.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Blazorise.States;
 using Blazorise.Utilities;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 #endregion
 
 namespace Blazorise
@@ -47,12 +48,13 @@ namespace Blazorise
         /// <summary>
         /// Handles the toggler onclick event.
         /// </summary>
+        /// <param name="eventArgs">Supplies information about a mouse event that is being raised.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
-        protected async Task ClickHandler()
+        protected async Task ClickHandler( MouseEventArgs eventArgs )
         {
             if ( Clicked.HasDelegate )
             {
-                await Clicked.InvokeAsync();
+                await Clicked.InvokeAsync( eventArgs );
             }
 
             if ( Bar != null )
@@ -74,7 +76,7 @@ namespace Blazorise
         /// <summary>
         /// Occurs when the button is clicked.
         /// </summary>
-        [Parameter] public EventCallback Clicked { get; set; }
+        [Parameter] public EventCallback<MouseEventArgs> Clicked { get; set; }
 
         /// <summary>
         /// Provides options for inline or popout styles. Only supported by Vertical Bar. Uses inline by default.

--- a/Source/Blazorise/Components/Breadcrumb/BreadcrumbLink.razor.cs
+++ b/Source/Blazorise/Components/Breadcrumb/BreadcrumbLink.razor.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Blazorise.Utilities;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 #endregion
 
 namespace Blazorise
@@ -38,10 +39,14 @@ namespace Blazorise
         /// <summary>
         /// Handles the link onclick event.
         /// </summary>
+        /// <param name="eventArgs">Supplies information about a mouse event that is being raised.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
-        protected Task ClickHandler()
+        protected Task ClickHandler( MouseEventArgs eventArgs )
         {
-            return Clicked.InvokeAsync();
+            if ( Disabled )
+                return Task.CompletedTask;
+
+            return Clicked.InvokeAsync( eventArgs );
         }
 
         #endregion
@@ -71,7 +76,7 @@ namespace Blazorise
         /// <summary>
         /// Occurs when the item is clicked.
         /// </summary>
-        [Parameter] public EventCallback Clicked { get; set; }
+        [Parameter] public EventCallback<MouseEventArgs> Clicked { get; set; }
 
         /// <summary>
         /// Link to the destination page.

--- a/Source/Blazorise/Components/Button/Button.cs
+++ b/Source/Blazorise/Components/Button/Button.cs
@@ -125,13 +125,13 @@ namespace Blazorise
         /// <summary>
         /// Handles the item onclick event.
         /// </summary>
-        /// <param name="mouseEventArgs">Supplies information about a mouse event that is being raised.</param>
+        /// <param name="eventArgs">Supplies information about a mouse event that is being raised.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
-        protected async Task ClickHandler( MouseEventArgs mouseEventArgs )
+        protected async Task ClickHandler( MouseEventArgs eventArgs )
         {
             if ( !Disabled )
             {
-                await Clicked.InvokeAsync( mouseEventArgs );
+                await Clicked.InvokeAsync( eventArgs );
 
                 // Don't need to check CanExecute again is already part of Disabled check
                 Command?.Execute( CommandParameter );

--- a/Source/Blazorise/Components/Button/Button.cs
+++ b/Source/Blazorise/Components/Button/Button.cs
@@ -8,6 +8,7 @@ using Blazorise.States;
 using Blazorise.Utilities;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.AspNetCore.Components.Web;
 #endregion
 
 namespace Blazorise
@@ -124,12 +125,13 @@ namespace Blazorise
         /// <summary>
         /// Handles the item onclick event.
         /// </summary>
+        /// <param name="mouseEventArgs">Supplies information about a mouse event that is being raised.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
-        protected async Task ClickHandler()
+        protected async Task ClickHandler( MouseEventArgs mouseEventArgs )
         {
             if ( !Disabled )
             {
-                await Clicked.InvokeAsync();
+                await Clicked.InvokeAsync( mouseEventArgs );
 
                 // Don't need to check CanExecute again is already part of Disabled check
                 Command?.Execute( CommandParameter );
@@ -174,7 +176,7 @@ namespace Blazorise
                 }
             }
 
-            builder.OnClick( this, EventCallback.Factory.Create( this, ClickHandler ) );
+            builder.OnClick( this, EventCallback.Factory.Create<MouseEventArgs>( this, ClickHandler ) );
             builder.OnClickPreventDefault( Type == ButtonType.Link && To != null && To.StartsWith( "#" ) );
 
             builder.Attributes( Attributes );
@@ -288,7 +290,7 @@ namespace Blazorise
         /// <summary>
         /// Occurs when the button is clicked.
         /// </summary>
-        [Parameter] public EventCallback Clicked { get; set; }
+        [Parameter] public EventCallback<MouseEventArgs> Clicked { get; set; }
 
         /// <summary>
         /// Defines the button type.

--- a/Source/Blazorise/Components/Button/CloseButton.razor
+++ b/Source/Blazorise/Components/Button/CloseButton.razor
@@ -1,5 +1,5 @@
 ﻿@namespace Blazorise
 @inherits BaseComponent
-<button id="@ElementId" type="button" class="@ClassNames" style="@StyleNames" aria-label="Close" @onclick="@ClickHandler" @attributes="@Attributes">
+<button id="@ElementId" type="button" class="@ClassNames" style="@StyleNames" disabled="@DisabledString" aria-label="Close" @onclick="@ClickHandler" @attributes="@Attributes">
     @ChildContent
 </button>

--- a/Source/Blazorise/Components/Button/CloseButton.razor.cs
+++ b/Source/Blazorise/Components/Button/CloseButton.razor.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Blazorise.Utilities;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 #endregion
 
 namespace Blazorise
@@ -28,8 +29,9 @@ namespace Blazorise
         /// <summary>
         /// Handles the item onclick event.
         /// </summary>
+        /// <param name="eventArgs">Supplies information about a mouse event that is being raised.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
-        protected async Task ClickHandler()
+        protected async Task ClickHandler( MouseEventArgs eventArgs )
         {
             // We must have priority over what get's closed once we click on close button.
             // For example, there can be Alert placed inside of Modal, and Close Button inside of Alert.
@@ -46,7 +48,7 @@ namespace Blazorise
                 }
             }
 
-            await Clicked.InvokeAsync();
+            await Clicked.InvokeAsync( eventArgs );
         }
 
         #endregion
@@ -60,14 +62,25 @@ namespace Blazorise
             => AutoClose.GetValueOrDefault( Options?.AutoCloseParent ?? true );
 
         /// <summary>
+        /// Gets the string representing the disabled state.
+        /// </summary>
+        protected string DisabledString
+            => Disabled.ToString().ToLowerInvariant();
+
+        /// <summary>
         /// Holds the information about the Blazorise global options.
         /// </summary>
         [Inject] protected BlazoriseOptions Options { get; set; }
 
         /// <summary>
+        /// Flag to indicate that the button is not responsive for user interaction.
+        /// </summary>
+        [Parameter] public bool Disabled { get; set; }
+
+        /// <summary>
         /// Occurs when the button is clicked.
         /// </summary>
-        [Parameter] public EventCallback Clicked { get; set; }
+        [Parameter] public EventCallback<MouseEventArgs> Clicked { get; set; }
 
         /// <summary>
         /// If true, the parent <see cref="Alert"/> or <see cref="Modal"/> with be automatically closed

--- a/Source/Blazorise/Components/Collapse/CollapseHeader.razor.cs
+++ b/Source/Blazorise/Components/Collapse/CollapseHeader.razor.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Blazorise.Utilities;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 #endregion
 
 namespace Blazorise
@@ -28,13 +29,14 @@ namespace Blazorise
         /// <summary>
         /// Handles the header onclick event.
         /// </summary>
+        /// <param name="eventArgs">Supplies information about a mouse event that is being raised.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
-        protected async Task ClickHandler()
+        protected async Task ClickHandler( MouseEventArgs eventArgs )
         {
             if ( ParentCollapse != null )
                 await ParentCollapse.Toggle();
 
-            await Clicked.InvokeAsync();
+            await Clicked.InvokeAsync( eventArgs );
         }
 
         #endregion
@@ -44,7 +46,7 @@ namespace Blazorise
         /// <summary>
         /// Occurs when the header is clicked.
         /// </summary>
-        [Parameter] public EventCallback Clicked { get; set; }
+        [Parameter] public EventCallback<MouseEventArgs> Clicked { get; set; }
 
         /// <summary>
         /// Specifies the content to be rendered inside this <see cref="CollapseHeader"/>.

--- a/Source/Blazorise/Components/Dropdown/DropdownToggle.razor.cs
+++ b/Source/Blazorise/Components/Dropdown/DropdownToggle.razor.cs
@@ -5,6 +5,7 @@ using Blazorise.Modules;
 using Blazorise.States;
 using Blazorise.Utilities;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 using Microsoft.JSInterop;
 #endregion
 
@@ -115,8 +116,9 @@ namespace Blazorise
         /// <summary>
         /// Handles the item onclick event.
         /// </summary>
+        /// <param name="eventArgs">Supplies information about a mouse event that is being raised.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
-        protected async Task ClickHandler()
+        protected async Task ClickHandler( MouseEventArgs eventArgs )
         {
             if ( Disabled )
                 return;
@@ -124,7 +126,7 @@ namespace Blazorise
             if ( ParentDropdown != null )
                 await ParentDropdown.Toggle( ElementId );
 
-            await Clicked.InvokeAsync();
+            await Clicked.InvokeAsync( eventArgs );
         }
 
 
@@ -330,7 +332,7 @@ namespace Blazorise
         /// <summary>
         /// Occurs when the toggle button is clicked.
         /// </summary>
-        [Parameter] public EventCallback Clicked { get; set; }
+        [Parameter] public EventCallback<MouseEventArgs> Clicked { get; set; }
 
         /// <summary>
         /// The applied theme.

--- a/Source/Blazorise/Components/Icon/Icon.razor.cs
+++ b/Source/Blazorise/Components/Icon/Icon.razor.cs
@@ -40,10 +40,11 @@ namespace Blazorise
         /// <summary>
         /// Handles the icon onclick event.
         /// </summary>
+        /// <param name="eventArgs">Supplies information about a mouse event that is being raised.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
-        protected Task OnClickHandler()
+        protected Task OnClickHandler( MouseEventArgs eventArgs )
         {
-            return Clicked.InvokeAsync();
+            return Clicked.InvokeAsync( eventArgs );
         }
 
         /// <summary>
@@ -138,7 +139,7 @@ namespace Blazorise
         /// <summary>
         /// Occurs when the icon is clicked.
         /// </summary>
-        [Parameter] public EventCallback Clicked { get; set; }
+        [Parameter] public EventCallback<MouseEventArgs> Clicked { get; set; }
 
         /// <summary>
         /// Occurs when the mouse has entered the icon area.

--- a/Source/Blazorise/Components/Link/Link.razor.cs
+++ b/Source/Blazorise/Components/Link/Link.razor.cs
@@ -6,6 +6,7 @@ using Blazorise.Modules;
 using Blazorise.Utilities;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Routing;
+using Microsoft.AspNetCore.Components.Web;
 #endregion
 
 namespace Blazorise
@@ -109,15 +110,16 @@ namespace Blazorise
         /// <summary>
         /// Handles the link onclick event.
         /// </summary>
+        /// <param name="eventArgs">Supplies information about a mouse event that is being raised.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
-        protected async Task OnClickHandler()
+        protected async Task OnClickHandler( MouseEventArgs eventArgs )
         {
             if ( !string.IsNullOrEmpty( anchorTarget ) )
             {
                 await JSUtilitiesModule.ScrollAnchorIntoView( anchorTarget );
             }
 
-            await Clicked.InvokeAsync();
+            await Clicked.InvokeAsync( eventArgs );
         }
 
         private bool ShouldMatch( string currentUriAbsolute )
@@ -255,7 +257,7 @@ namespace Blazorise
         /// <summary>
         /// Occurs when the link is clicked.
         /// </summary>
-        [Parameter] public EventCallback Clicked { get; set; }
+        [Parameter] public EventCallback<MouseEventArgs> Clicked { get; set; }
 
         /// <summary>
         /// Specifies the content to be rendered inside this <see cref="Link"/>.

--- a/Source/Blazorise/Components/ListGroup/ListGroupItem.razor.cs
+++ b/Source/Blazorise/Components/ListGroup/ListGroupItem.razor.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Blazorise.States;
 using Blazorise.Utilities;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 #endregion
 
 namespace Blazorise
@@ -48,8 +49,9 @@ namespace Blazorise
         /// <summary>
         /// Handles the item onclick event.
         /// </summary>
+        /// <param name="eventArgs">Supplies information about a mouse event that is being raised.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
-        protected async Task ClickHandler()
+        protected async Task ClickHandler( MouseEventArgs eventArgs )
         {
             if ( Disabled )
                 return;
@@ -57,7 +59,7 @@ namespace Blazorise
             if ( ParentListGroup != null )
                 await ParentListGroup.SelectItem( Name );
 
-            await Clicked.InvokeAsync();
+            await Clicked.InvokeAsync( eventArgs );
         }
 
         #endregion
@@ -97,7 +99,7 @@ namespace Blazorise
         /// <summary>
         /// Occurs when the item is clicked.
         /// </summary>
-        [Parameter] public EventCallback Clicked { get; set; }
+        [Parameter] public EventCallback<MouseEventArgs> Clicked { get; set; }
 
         /// <summary>
         /// Cascaded <see cref="ListGroup"/> component state object.

--- a/Source/Blazorise/Components/Steps/Step.razor.cs
+++ b/Source/Blazorise/Components/Steps/Step.razor.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Blazorise.States;
 using Blazorise.Utilities;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 #endregion
 
 namespace Blazorise
@@ -98,10 +99,11 @@ namespace Blazorise
         /// <summary>
         /// Handles the step onclick event.
         /// </summary>
+        /// <param name="eventArgs">Supplies information about a mouse event that is being raised.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
-        protected async Task ClickHandler()
+        protected async Task ClickHandler( MouseEventArgs eventArgs )
         {
-            await Clicked.InvokeAsync();
+            await Clicked.InvokeAsync( eventArgs );
 
             if ( ParentSteps != null )
                 await ParentSteps.SelectStep( Name );
@@ -186,7 +188,7 @@ namespace Blazorise
         /// <summary>
         /// Occurs when the item is clicked.
         /// </summary>
-        [Parameter] public EventCallback Clicked { get; set; }
+        [Parameter] public EventCallback<MouseEventArgs> Clicked { get; set; }
 
         /// <summary>
         /// Custom render template for the marker(circle) part of the step item.

--- a/Source/Blazorise/Components/Tabs/Tab.razor.cs
+++ b/Source/Blazorise/Components/Tabs/Tab.razor.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Blazorise.States;
 using Blazorise.Utilities;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 #endregion
 
 namespace Blazorise
@@ -82,10 +83,14 @@ namespace Blazorise
         /// <summary>
         /// Handles the item onclick event.
         /// </summary>
+        /// <param name="eventArgs">Supplies information about a mouse event that is being raised.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
-        protected async Task ClickHandler()
+        protected async Task ClickHandler( MouseEventArgs eventArgs )
         {
-            await Clicked.InvokeAsync();
+            if ( Disabled )
+                return;
+
+            await Clicked.InvokeAsync( eventArgs );
 
             if ( ParentTabs != null )
                 await ParentTabs.SelectTab( Name );
@@ -133,7 +138,7 @@ namespace Blazorise
         /// <summary>
         /// Occurs when the item is clicked.
         /// </summary>
-        [Parameter] public EventCallback Clicked { get; set; }
+        [Parameter] public EventCallback<MouseEventArgs> Clicked { get; set; }
 
         /// <summary>
         /// Cascaded parent <see cref="Tabs"/> state.

--- a/Source/Blazorise/Extensions/RenderTreeBuilderExtensions.cs
+++ b/Source/Blazorise/Extensions/RenderTreeBuilderExtensions.cs
@@ -182,9 +182,9 @@ namespace Blazorise.Extensions
             return builder;
         }
 
-        public static RenderTreeBuilder OnClick( this RenderTreeBuilder builder, object receiver, EventCallback callback, [CallerLineNumber] int line = 0 )
+        public static RenderTreeBuilder OnClick<T>( this RenderTreeBuilder builder, object receiver, EventCallback<T> callback, [CallerLineNumber] int line = 0 )
         {
-            builder.AddAttribute( GetSequence( line ), "onclick", EventCallback.Factory.Create<Microsoft.AspNetCore.Components.Web.MouseEventArgs>( receiver, callback ) );
+            builder.AddAttribute( GetSequence( line ), "onclick", EventCallback.Factory.Create<T>( receiver, callback ) );
 
             return builder;
         }

--- a/Tests/Blazorise.Tests/ButtonTest.cs
+++ b/Tests/Blazorise.Tests/ButtonTest.cs
@@ -3,6 +3,7 @@ using System;
 using System.Threading.Tasks;
 using Blazorise.Tests.Mocks;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 using Xunit;
 #endregion
 
@@ -116,7 +117,7 @@ namespace Blazorise.Tests
             bool clicked = false;
 
             // test
-            button.Clicked = callbackFactory.Create( this, () => { clicked = true; } );
+            button.Clicked = callbackFactory.Create<MouseEventArgs>( this, ( e ) => { clicked = true; } );
             await button.Click();
 
             // validate

--- a/Tests/Blazorise.Tests/Components/BarLinkComponentTest.cs
+++ b/Tests/Blazorise.Tests/Components/BarLinkComponentTest.cs
@@ -3,6 +3,7 @@ using Blazorise.Tests.Helpers;
 using Blazorise.Tests.TestServices;
 using Bunit;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -22,8 +23,7 @@ namespace Blazorise.Tests.Components
         {
             // setup
             bool wasClicked = false;
-            var testCallback = new EventCallback( null, (Action)( () =>
-                wasClicked = true ) );
+            var testCallback = new EventCallback<MouseEventArgs>( null, ( MouseEventArgs e ) => wasClicked = true );
 
             // test
             var comp = RenderComponent<BarLink>( builder =>
@@ -41,8 +41,7 @@ namespace Blazorise.Tests.Components
         {
             // setup
             bool wasClicked = false;
-            var testCallback = new EventCallback( null, (Action)( () =>
-                wasClicked = true ) );
+            var testCallback = new EventCallback<MouseEventArgs>( null, ( MouseEventArgs e ) => wasClicked = true );
 
             // test
             var comp = RenderComponent<BarLink>( builder =>

--- a/Tests/Blazorise.Tests/Mocks/MockButton.cs
+++ b/Tests/Blazorise.Tests/Mocks/MockButton.cs
@@ -3,6 +3,7 @@ using System;
 using System.Threading.Tasks;
 using Blazorise.Modules;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 using Moq;
 #endregion
 
@@ -44,7 +45,7 @@ namespace Blazorise.Tests.Mocks
 
         public Task Click()
         {
-            return ClickHandler();
+            return ClickHandler( new MouseEventArgs() );
         }
 
         private bool OnFocusCalled( ElementReference elementReference, string elementId, bool scrollToElement )


### PR DESCRIPTION
Closes #3952

Test code

```
<Button Color="Color.Primary" Clicked="@OnClick1">1</Button>
<Button Color="Color.Primary" Clicked="@OnClick2">2</Button>
<Button Color="Color.Primary" Clicked="@(()=>Console.WriteLine("3"))">3</Button>
<Button Color="Color.Primary" Clicked="@(()=>Console.WriteLine("4"))">4</Button>
@code {
    Task OnClick1()
    {
        Console.WriteLine("1");
        return Task.CompletedTask;
    }

    Task OnClick2( MouseEventArgs e )
    {
        Console.WriteLine("2");
        return Task.CompletedTask;
    }
}
```