### PR TITLE
Bug - Removed redundant property

### DIFF
--- a/Documentation/Blazorise.Docs/Pages/Docs/Components/DragDrops/DragDropPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Components/DragDrops/DragDropPage.razor
@@ -115,7 +115,7 @@
     <DocsAttributesItem Name="ItemTemplate" Type="RenderFragment<TItem>">
         The render method that is used to render the items withing the dropzone.
     </DocsAttributesItem>
-    <DocsAttributesItem Name="DropAllowed" Type="Func<TItem, string, bool>" Default="null">
+    <DocsAttributesItem Name="DropAllowed" Type="Func<TItem, bool>" Default="null">
         Determines if the item is allowed to be dropped to the specified zone.
     </DocsAttributesItem>
     <DocsAttributesItem Name="DropAllowedClass" Type="string" Default="null">


### PR DESCRIPTION
Removed string property as type is actually `Func<TItem, bool>`

Associated Issue #3997