### PR TITLE
Docs: TextEdit page fixes

### DIFF
--- a/Documentation/Blazorise.Docs/Pages/Docs/Components/Texts/TextEditPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Components/Texts/TextEditPage.razor
@@ -228,13 +228,13 @@
     <DocsAttributesItem Name="KeyUp" Type="EventCallback<KeyboardEventArgs>">
         Occurs when a key is released while the control has focus.
     </DocsAttributesItem>
-    <DocsAttributesItem Name="OnFocus" Type="EventCallback<KeyboardEventArgs>">
+    <DocsAttributesItem Name="OnFocus" Type="EventCallback<FocusEventArgs>">
         Occurs when the input box gains focus.
     </DocsAttributesItem>
-    <DocsAttributesItem Name="FocusIn" Type="EventCallback<KeyboardEventArgs>">
+    <DocsAttributesItem Name="FocusIn" Type="EventCallback<FocusEventArgs>">
         Occurs when the input box gains focus.
     </DocsAttributesItem>
-    <DocsAttributesItem Name="FocusOut" Type="EventCallback<KeyboardEventArgs>">
+    <DocsAttributesItem Name="FocusOut" Type="EventCallback<FocusEventArgs>">
         Occurs when the input box loses focus.
     </DocsAttributesItem>
     <DocsAttributesItem Name="Autofocus" Type="bool" Default="false">


### PR DESCRIPTION
Changed KeyboardEventArgs to FocusEventArgs for text edit docs.

Associated Work: #3994 