### PR TITLE
Remove Disposed Component References

### DIFF
--- a/Source/Blazorise/Base/BaseAfterRenderComponent.cs
+++ b/Source/Blazorise/Base/BaseAfterRenderComponent.cs
@@ -71,6 +71,8 @@ namespace Blazorise
                 if ( disposing )
                 {
                     executeAfterRenderQueue?.Clear();
+
+                    ComponentDisposer.Dispose( this );
                 }
             }
         }
@@ -98,6 +100,8 @@ namespace Blazorise
                     if ( disposing )
                     {
                         executeAfterRenderQueue?.Clear();
+
+                        ComponentDisposer.Dispose( this );
                     }
                 }
 
@@ -127,6 +131,11 @@ namespace Blazorise
         /// Indicates if component has been rendered in the browser.
         /// </summary>
         protected bool Rendered { get; private set; }
+
+        /// <summary>
+        /// Service that frees the component from the memory.
+        /// </summary>
+        [Inject] protected IComponentDisposer ComponentDisposer { get; private set; }
 
         #endregion
     }

--- a/Source/Blazorise/Base/BaseAfterRenderComponent.cs
+++ b/Source/Blazorise/Base/BaseAfterRenderComponent.cs
@@ -135,7 +135,7 @@ namespace Blazorise
         /// <summary>
         /// Service that frees the component from the memory.
         /// </summary>
-        [Inject] protected IComponentDisposer ComponentDisposer { get; private set; }
+        [Inject] protected internal IComponentDisposer ComponentDisposer { get; set; }
 
         #endregion
     }

--- a/Source/Blazorise/Base/BaseAfterRenderComponent.cs
+++ b/Source/Blazorise/Base/BaseAfterRenderComponent.cs
@@ -116,12 +116,12 @@ namespace Blazorise
         /// <summary>
         /// Indicates if the component is already fully disposed.
         /// </summary>
-        protected bool Disposed { get; private set; }
+        protected internal bool Disposed { get; private set; }
 
         /// <summary>
         /// Indicates if the component is already fully disposed (asynchronously).
         /// </summary>
-        protected bool AsyncDisposed { get; private set; }
+        protected internal bool AsyncDisposed { get; private set; }
 
         /// <summary>
         /// Indicates if component has been rendered in the browser.

--- a/Source/Blazorise/ComponentActivator.cs
+++ b/Source/Blazorise/ComponentActivator.cs
@@ -14,14 +14,6 @@ namespace Blazorise
     /// </summary>
     public class ComponentActivator : IComponentActivator
     {
-        #region Members
-
-        private bool disposePossible;
-
-        private readonly IList<object> disposables;
-
-        #endregion
-
         #region Constructors
 
         /// <summary>
@@ -31,7 +23,6 @@ namespace Blazorise
         public ComponentActivator( IServiceProvider serviceProvider )
         {
             ServiceProvider = serviceProvider;
-            disposables = LoadServiceProviderDisposableList();
         }
 
         #endregion
@@ -45,9 +36,6 @@ namespace Blazorise
         /// <returns>Return the newly created component or raises an exception if the specified typo is invalid.</returns>
         public IComponent CreateInstance( Type componentType )
         {
-            if ( disposePossible )
-                RemoveDisposedComponents();
-
             var instance = ServiceProvider.GetService( componentType );
 
             if ( instance == null )
@@ -61,36 +49,6 @@ namespace Blazorise
             }
 
             return component;
-        }
-
-        /// <summary>
-        /// Loads the ServiceProvider's list of disposables
-        /// </summary>
-        /// <returns>List of object references the ServiceProvider uses to track disposables</returns>
-        private IList<object> LoadServiceProviderDisposableList()
-        {
-            var disposablesPropertyInfo = ServiceProvider.GetType().GetProperty( "Disposables", BindingFlags.Instance | BindingFlags.NonPublic );
-
-            disposePossible = disposablesPropertyInfo is not null;
-
-            return disposablesPropertyInfo?.GetValue( ServiceProvider ) as IList<object> ?? Array.Empty<object>();
-        }
-
-        /// <summary>
-        /// Removes all disposed Blazorise components from the ServiceProvider's disposables list.
-        /// This prevents a memory leak where these references were being held permanently.
-        /// </summary>
-        private void RemoveDisposedComponents()
-        {
-            var disposedComponents = disposables
-                .OfType<BaseAfterRenderComponent>()
-                .Where( x => x.Disposed || x.AsyncDisposed )
-                .ToList();
-
-            foreach ( var component in disposedComponents )
-            {
-                disposables.Remove( component );
-            }
         }
 
         #endregion

--- a/Source/Blazorise/ComponentActivator.cs
+++ b/Source/Blazorise/ComponentActivator.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Microsoft.AspNetCore.Components;
-
 #endregion
 
 namespace Blazorise
@@ -16,6 +15,8 @@ namespace Blazorise
     public class ComponentActivator : IComponentActivator
     {
         #region Members
+
+        private bool disposePossible;
 
         private readonly IList<object> disposables;
 
@@ -44,7 +45,8 @@ namespace Blazorise
         /// <returns>Return the newly created component or raises an exception if the specified typo is invalid.</returns>
         public IComponent CreateInstance( Type componentType )
         {
-            RemoveDisposedComponents();
+            if ( disposePossible )
+                RemoveDisposedComponents();
 
             var instance = ServiceProvider.GetService( componentType );
 
@@ -67,8 +69,10 @@ namespace Blazorise
         /// <returns>List of object references the ServiceProvider uses to track disposables</returns>
         private IList<object> LoadServiceProviderDisposableList()
         {
-            var disposablesPropertyInfo = ServiceProvider.GetType()
-                .GetProperty( "Disposables", BindingFlags.Instance | BindingFlags.NonPublic );
+            var disposablesPropertyInfo = ServiceProvider.GetType().GetProperty( "Disposables", BindingFlags.Instance | BindingFlags.NonPublic );
+
+            disposePossible = disposablesPropertyInfo is not null;
+
             return disposablesPropertyInfo?.GetValue( ServiceProvider ) as IList<object> ?? Array.Empty<object>();
         }
 

--- a/Source/Blazorise/ComponentActivator.cs
+++ b/Source/Blazorise/ComponentActivator.cs
@@ -69,7 +69,7 @@ namespace Blazorise
         {
             var disposablesPropertyInfo = ServiceProvider.GetType()
                 .GetProperty( "Disposables", BindingFlags.Instance | BindingFlags.NonPublic );
-            return disposablesPropertyInfo?.GetValue( ServiceProvider ) as IList<object>;
+            return disposablesPropertyInfo?.GetValue( ServiceProvider ) as IList<object> ?? Array.Empty<object>();
         }
 
         /// <summary>

--- a/Source/Blazorise/ComponentActivator.cs
+++ b/Source/Blazorise/ComponentActivator.cs
@@ -1,8 +1,5 @@
 ﻿#region Using directives
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
 using Microsoft.AspNetCore.Components;
 #endregion
 

--- a/Source/Blazorise/ComponentDisposer.cs
+++ b/Source/Blazorise/ComponentDisposer.cs
@@ -53,7 +53,7 @@ namespace Blazorise
 
             if ( component is BaseAfterRenderComponent afterRenderComponent && ( afterRenderComponent.Disposed || afterRenderComponent.AsyncDisposed ) )
             {
-                if (disposables.Contains( component ))
+                if ( disposables.Contains( component ) )
                     disposables.Remove( component );
             }
         }
@@ -68,7 +68,7 @@ namespace Blazorise
 
             disposePossible = disposablesPropertyInfo is not null;
 
-            return disposablesPropertyInfo?.GetValue( ServiceProvider ) as IList<object> ?? Array.Empty<object>();
+            return disposablesPropertyInfo?.GetValue( ServiceProvider ) as IList<object> ?? new List<object>();
         }
 
         #endregion

--- a/Source/Blazorise/ComponentDisposer.cs
+++ b/Source/Blazorise/ComponentDisposer.cs
@@ -1,0 +1,85 @@
+﻿#region Using directives
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Microsoft.AspNetCore.Components;
+#endregion
+
+namespace Blazorise
+{
+    /// <summary>
+    /// Handles the disposable transient components by freeing them from memory.
+    /// </summary>
+    public interface IComponentDisposer
+    {
+        /// <summary>
+        /// Frees the component from <see cref="IServiceProvider"/> disposable collection.
+        /// </summary>
+        /// <typeparam name="TComponent">Type of the component to free.</typeparam>
+        /// <param name="component">Component to free.</param>
+        void Dispose<TComponent>( TComponent component ) where TComponent : IComponent;
+    }
+
+    internal class ComponentDisposer : IComponentDisposer
+    {
+        #region Members
+
+        private bool disposePossible;
+
+        private readonly IList<object> disposables;
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Default constructor.
+        /// </summary>
+        /// <param name="serviceProvider">Service provider used to retrieve registered components.</param>
+        public ComponentDisposer( IServiceProvider serviceProvider )
+        {
+            ServiceProvider = serviceProvider;
+            disposables = LoadServiceProviderDisposableList();
+        }
+
+        #endregion
+
+        #region Methods
+
+        public void Dispose<TComponent>( TComponent component ) where TComponent : IComponent
+        {
+            if ( !disposePossible )
+                return;
+
+            if ( component is BaseAfterRenderComponent afterRenderComponent && ( afterRenderComponent.Disposed || afterRenderComponent.AsyncDisposed ) )
+            {
+                // does it makes sense to check if component exists in the collection?
+                disposables.Remove( component );
+            }
+        }
+
+        /// <summary>
+        /// Loads the ServiceProvider's list of disposables
+        /// </summary>
+        /// <returns>List of object references the ServiceProvider uses to track disposables</returns>
+        private IList<object> LoadServiceProviderDisposableList()
+        {
+            var disposablesPropertyInfo = ServiceProvider.GetType().GetProperty( "Disposables", BindingFlags.Instance | BindingFlags.NonPublic );
+
+            disposePossible = disposablesPropertyInfo is not null;
+
+            return disposablesPropertyInfo?.GetValue( ServiceProvider ) as IList<object> ?? Array.Empty<object>();
+        }
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Gets the reference to the <see cref="IServiceProvider"/>.
+        /// </summary>
+        public IServiceProvider ServiceProvider { get; }
+
+        #endregion
+    }
+}

--- a/Source/Blazorise/ComponentDisposer.cs
+++ b/Source/Blazorise/ComponentDisposer.cs
@@ -53,8 +53,8 @@ namespace Blazorise
 
             if ( component is BaseAfterRenderComponent afterRenderComponent && ( afterRenderComponent.Disposed || afterRenderComponent.AsyncDisposed ) )
             {
-                // does it makes sense to check if component exists in the collection?
-                disposables.Remove( component );
+                if (disposables.Contains( component ))
+                    disposables.Remove( component );
             }
         }
 

--- a/Source/Blazorise/ComponentDisposer.cs
+++ b/Source/Blazorise/ComponentDisposer.cs
@@ -68,7 +68,7 @@ namespace Blazorise
 
             disposePossible = disposablesPropertyInfo is not null;
 
-            return disposablesPropertyInfo?.GetValue( ServiceProvider ) as IList<object> ?? new List<object>();
+            return disposablesPropertyInfo?.GetValue( ServiceProvider ) as IList<object> ?? Array.Empty<object>();
         }
 
         #endregion

--- a/Source/Blazorise/ComponentDisposer.cs
+++ b/Source/Blazorise/ComponentDisposer.cs
@@ -65,10 +65,11 @@ namespace Blazorise
         private IList<object> LoadServiceProviderDisposableList()
         {
             var disposablesPropertyInfo = ServiceProvider.GetType().GetProperty( "Disposables", BindingFlags.Instance | BindingFlags.NonPublic );
+            var disposables = disposablesPropertyInfo?.GetValue( ServiceProvider ) as IList<object> ?? Array.Empty<object>();
 
-            disposePossible = disposablesPropertyInfo is not null;
+            disposePossible = disposables is not null && !disposables.GetType().IsArray;
 
-            return disposablesPropertyInfo?.GetValue( ServiceProvider ) as IList<object> ?? Array.Empty<object>();
+            return disposables;
         }
 
         #endregion

--- a/Source/Blazorise/Config.cs
+++ b/Source/Blazorise/Config.cs
@@ -27,8 +27,8 @@ namespace Blazorise
         /// <returns></returns>
         public static IServiceCollection AddBlazorise( this IServiceCollection serviceCollection, Action<BlazoriseOptions> configureOptions = null )
         {
-            serviceCollection.Replace( ServiceDescriptor.Transient<IComponentActivator, ComponentActivator>() );
-            serviceCollection.Replace( ServiceDescriptor.Transient<IComponentDisposer, ComponentDisposer>() );
+            serviceCollection.Replace( ServiceDescriptor.Scoped<IComponentActivator, ComponentActivator>() );
+            serviceCollection.Replace( ServiceDescriptor.Scoped<IComponentDisposer, ComponentDisposer>() );
 
             // If options handler is not defined we will get an exception so
             // we need to initialize an empty action.

--- a/Source/Blazorise/Config.cs
+++ b/Source/Blazorise/Config.cs
@@ -28,6 +28,7 @@ namespace Blazorise
         public static IServiceCollection AddBlazorise( this IServiceCollection serviceCollection, Action<BlazoriseOptions> configureOptions = null )
         {
             serviceCollection.Replace( ServiceDescriptor.Transient<IComponentActivator, ComponentActivator>() );
+            serviceCollection.Replace( ServiceDescriptor.Transient<IComponentDisposer, ComponentDisposer>() );
 
             // If options handler is not defined we will get an exception so
             // we need to initialize an empty action.

--- a/Source/Blazorise/Properties/AssemblyInfo.cs
+++ b/Source/Blazorise/Properties/AssemblyInfo.cs
@@ -6,3 +6,4 @@
 [assembly: InternalsVisibleTo( "Blazorise.Bulma" )]
 [assembly: InternalsVisibleTo( "Blazorise.Material" )]
 [assembly: InternalsVisibleTo( "Blazorise.Markdown" )]
+[assembly: InternalsVisibleTo( "Blazorise.Tests" )]

--- a/Source/Blazorise/Utilities/ExpressionCompiler.cs
+++ b/Source/Blazorise/Utilities/ExpressionCompiler.cs
@@ -1,0 +1,43 @@
+﻿#region Using directives
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Microsoft.AspNetCore.Components.Forms;
+#endregion
+
+namespace Blazorise
+{
+    /// <summary>
+    /// Helper for various expression based methods.
+    /// </summary>
+    public static class ExpressionCompiler
+    {
+        /// <summary>
+        /// Gets a property in an unknown instance.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="instance"></param>
+        /// <param name="propertyName"></param>
+        /// <returns></returns>
+        public static T GetProperty<T>( object instance, string propertyName )
+            => CreatePropertyGetter<T>( instance, propertyName )(instance);
+
+        /// <summary>
+        /// Generates a function getter for a property in an unknown instance.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="instance"></param>
+        /// <param name="propertyName"></param>
+        /// <returns></returns>
+        public static Func<object, T> CreatePropertyGetter<T>( object instance, string propertyName )
+        {
+            var parameterExp = Expression.Parameter( typeof( object ), "instance" );
+            var castExp = Expression.TypeAs( parameterExp, instance.GetType() );
+            var property = Expression.Property( castExp, propertyName );
+
+            return Expression.Lambda<Func<object, T>>( Expression.Convert( property, typeof( T ) ), parameterExp ).Compile();
+        }
+    }
+}

--- a/Tests/Blazorise.Benchmark/Program.cs
+++ b/Tests/Blazorise.Benchmark/Program.cs
@@ -2,10 +2,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Running;
 using Blazorise.Benchmark.Blazorise;
 using Blazorise.Benchmark.DataGrid;
+using Blazorise.DataGrid.Utils;
 using Blazorise.Extensions;
 #endregion
 
@@ -17,7 +19,8 @@ namespace Blazorise.Benchmark
         {
             //_ = BenchmarkRunner.Run<SequenceEquals>();
             //_ = BenchmarkRunner.Run<ReflectionBenchmark>();
-            _ = BenchmarkRunner.Run<ThemeBenchmark>();
+            //_ = BenchmarkRunner.Run<ThemeBenchmark>();
+            _ = BenchmarkRunner.Run<PropertyGetter>();
         }
 
         public class SequenceEquals
@@ -30,6 +33,58 @@ namespace Blazorise.Benchmark
 
             [Benchmark]
             public bool ArraySequenceEqual() => simpleList1.AreEqual( simpleList2 );
+        }
+
+        public class PropertyGetter
+        {
+            private class TestClass
+            {
+                private string testProperty { get; set; }
+            }
+
+            private const string PROPERTY_NAME = "testProperty";
+            private static Func<object, string> cachedPropertyExpressionGetter;
+            private static PropertyInfo cachedPropertyInfo;
+
+            private TestClass Instantiate()
+                => new();
+
+
+            [Benchmark]
+            public string StandardReflection()
+            {
+                var instance = Instantiate();
+                var disposablesPropertyInfo = instance.GetType().GetProperty( PROPERTY_NAME, BindingFlags.Instance | BindingFlags.NonPublic );
+                return disposablesPropertyInfo?.GetValue( instance ) as string;
+            }
+
+            [Benchmark]
+            public string StandardReflectionCached()
+            {
+                var instance = Instantiate();
+                if ( cachedPropertyInfo is null )
+                    cachedPropertyInfo = instance.GetType().GetProperty( PROPERTY_NAME, BindingFlags.Instance | BindingFlags.NonPublic );
+
+                return cachedPropertyInfo?.GetValue( instance ) as string;
+            }
+
+            [Benchmark]
+            public string ExpressionGetter()
+            {
+                var instance = Instantiate();
+                return ExpressionCompiler.GetProperty<string>( instance, PROPERTY_NAME );
+            }
+
+            [Benchmark]
+            public string ExpressionGetterCached()
+            {
+                var instance = Instantiate();
+                if ( cachedPropertyExpressionGetter is null )
+                    cachedPropertyExpressionGetter = ExpressionCompiler.CreatePropertyGetter<string>( instance, PROPERTY_NAME );
+
+                return cachedPropertyExpressionGetter( instance );
+            }
+
         }
     }
 }

--- a/Tests/Blazorise.Tests/Components/DropZoneTest.cs
+++ b/Tests/Blazorise.Tests/Components/DropZoneTest.cs
@@ -8,6 +8,7 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.DependencyInjection;
+using Moq;
 using Xunit;
 
 namespace Blazorise.Tests.Components
@@ -73,6 +74,10 @@ namespace Blazorise.Tests.Components
         public void DropZone_DisposeWork()
         {
             var container = new DropZone<object>();
+
+            var mockComponentDisposer = new Mock<IComponentDisposer>();
+            container.ComponentDisposer = mockComponentDisposer.Object;
+
             container.Dispose();
         }
 

--- a/Tests/Blazorise.Tests/Helpers/BlazoriseConfig.cs
+++ b/Tests/Blazorise.Tests/Helpers/BlazoriseConfig.cs
@@ -18,6 +18,7 @@ namespace Blazorise.Tests.Helpers
     {
         public static void AddBootstrapProviders( TestServiceProvider services )
         {
+            services.AddSingleton<IComponentDisposer, ComponentDisposer>();
             services.AddSingleton<IIdGenerator>( new IdGenerator() );
             services.AddSingleton<IEditContextValidator>( sp => new EditContextValidator( new ValidationMessageLocalizerAttributeFinder(), sp ) );
             services.AddSingleton<IClassProvider>( new BootstrapClassProvider() );

--- a/Tests/Blazorise.Tests/Mocks/MockButton.cs
+++ b/Tests/Blazorise.Tests/Mocks/MockButton.cs
@@ -13,6 +13,12 @@ namespace Blazorise.Tests.Mocks
     {
         public MockButton( Dropdown parentDropdown = null, Addons parentAddons = null, Buttons parentButtons = null )
         {
+            var mockComponentDisposer = new Mock<IComponentDisposer>();
+            this.ComponentDisposer = mockComponentDisposer.Object;
+
+            mockComponentDisposer
+                .Setup( r => r.Dispose( It.IsAny<BaseAfterRenderComponent>() ) );
+
             var mockRunner = new Mock<IJSUtilitiesModule>();
 
             mockRunner


### PR DESCRIPTION
References to disposed components were being held by the service provider forever, causing a memory leak. This will clean up already disposed components from the service provider, allowing the GC to clean up all unreferenced controls

Closes #4100 
