### PR TITLE
Fix when PaginationItem is disable PaginationLink not call to Clicked

### DIFF
--- a/Source/Blazorise/Components/Pagination/PaginationLink.razor.cs
+++ b/Source/Blazorise/Components/Pagination/PaginationLink.razor.cs
@@ -40,6 +40,9 @@ namespace Blazorise
         /// <returns>A task that represents the asynchronous operation.</returns>
         protected Task ClickHandler( MouseEventArgs eventArgs )
         {
+            if ( parentPaginationItemState.Disabled )
+                return Task.CompletedTask;
+
             return Clicked.InvokeAsync( Page );
         }
 


### PR DESCRIPTION
Added check before invoke Clicked to check if parent Pagination Item is Disabled.
https://github.com/Megabit/Blazorise/issues/4122