### PR TITLE
DataGrid : Adjust IsDisplayable check. 

### DIFF
--- a/Source/Extensions/Blazorise.DataGrid/DataGridColumn.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGridColumn.cs
@@ -240,7 +240,7 @@ namespace Blazorise.DataGrid
         internal Background HeaderCellBackground()
             => ParentDataGrid.IsFixedHeader ? ( ParentDataGrid.HeaderRowStyling?.Background ?? Background.Default ) : Background.Default;
 
-        internal bool IsDisplayable => ColumnType == DataGridColumnType.Command || ColumnType == DataGridColumnType.MultiSelect;
+        internal bool IsDisplayable => ( ColumnType == DataGridColumnType.Command && ParentDataGrid.EditMode == DataGridEditMode.Inline );
 
         internal bool ExcludeFromFilter => ColumnType == DataGridColumnType.Command || ColumnType == DataGridColumnType.MultiSelect;
 

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridRowEdit.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridRowEdit.razor.cs
@@ -87,7 +87,7 @@ namespace Blazorise.DataGrid
             get
             {
                 return Columns
-                    .Where( column => column.IsCommandColumn || column.IsMultiSelectColumn || column.Displayable )
+                    .Where( column => column.IsDisplayable || column.Displayable )
                     .OrderBy( column => column.DisplayOrder );
             }
         }


### PR DESCRIPTION
While investigating issue #4093.

Noticed that the current `DisplayableColumns` check makes it so `DataGridMultiSelectColumn` / `DataGridCommandColumn` would always show even if `Displayable="false"`. 

This does not seem appropriate behaviour. User should still be able to hide them if he wants to. Only real mandatory case, is when the `EditMode` is set to inline, and user needs the `CommandColumn` to display the Save/Cancel buttons. 

This has been tested on our demo DataGridPage with the use of `CommandMode.Default`, which helps having access to the Edit command through the ButtonRow if Command Column is hidden (`Displayable="false"`).