### PR TITLE
Removed shadow from disabled buttons

### DIFF
--- a/Source/Blazorise.Bootstrap/BootstrapThemeGenerator.cs
+++ b/Source/Blazorise.Bootstrap/BootstrapThemeGenerator.cs
@@ -128,7 +128,6 @@ namespace Blazorise.Bootstrap
                     .Append( $"color: {yiqBackground};" )
                     .Append( $"background-color: {background};" )
                     .Append( $"border-color: {border};" )
-                    .Append( $"box-shadow: 0 0 0 {options?.BoxShadowSize ?? ".2rem"} {boxShadow};" )
                     .AppendLine( "}" );
 
                 sb

--- a/Source/Blazorise.Bootstrap5/Bootstrap5ThemeGenerator.cs
+++ b/Source/Blazorise.Bootstrap5/Bootstrap5ThemeGenerator.cs
@@ -128,7 +128,6 @@ namespace Blazorise.Bootstrap5
                     .Append( $"color: {yiqBackground};" )
                     .Append( $"background-color: {background};" )
                     .Append( $"border-color: {border};" )
-                    .Append( $"box-shadow: 0 0 0 {options?.BoxShadowSize ?? ".2rem"} {boxShadow};" )
                     .AppendLine( "}" );
 
                 sb


### PR DESCRIPTION
Fixes: https://github.com/Megabit/Blazorise/issues/4125

Removed `box-shadow` from disabled buttons on `BootstrapThemeGenerator` and `Bootstrap5ThemeGenerator`. This issue does not appear on the other providers.