### PR TITLE
AutoComplete: On SelectedText parameter change : Propagate Empty String

### DIFF
--- a/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
+++ b/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
@@ -144,7 +144,7 @@ namespace Blazorise.Components
                     }
                 }
 
-                if ( !IsMultiple && CurrentSearch != SelectedText && !string.IsNullOrEmpty( SelectedText ) )
+                if ( !IsMultiple && CurrentSearch != SelectedText )
                 {
                     currentSearch = SelectedText;
 


### PR DESCRIPTION
Closes #4195
User could not set an empty String in a bound SelectedText.  Still had a workaround of using the `Clear` method.

However in the previous release we did have it working like that, and it does make sense. 
![chrome-capture-2022-9-14](https://user-images.githubusercontent.com/22283161/195940431-f040a41f-c8dd-42c4-9d21-d1b22f4b26eb.gif)

Testing code : 
```
<Autocomplete TItem="Test"
              TValue="string" Data="data"
              FreeTyping TextField="@((item) => item.Name)"
              ValueField="@((item) => item.Id)"
              @bind-SelectedText="_test.Name">
    <ItemContent>
        @if ( context.Item.Name != null )
        {
            <Paragraph>@String.Format("{0} ({1})", context.Text, context.Item.Name)</Paragraph>
        }
        else
        {
            <Paragraph>@context.Text</Paragraph>
        }
    </ItemContent>
</Autocomplete>

<Button Clicked="SetValue">Set Value</Button>
@code {
    private List<Test> data = new() { new() { Id = "1", Name = "Test" }, new() { Id = "2", Name = "Test2" } };
    private Test _test = new() { Id = "1", Name = "Test" };
    private class Test
    {
        public string Id { get; set; }
        public string Name { get; set; }

    }

    //private Task OnReadDataAutocompleteTrackArtist( AutocompleteReadDataEventArgs e )
    //{
    //    return Task.CompletedTask;
    //}

    private Task SetValue()
    {
        _test.Name = null;
        return InvokeAsync(StateHasChanged);
    }
}
```