### PR TITLE
FileEdit Fix WriteToStreamAsync skipping bytes

### DIFF
--- a/Source/Blazorise/Utilities/IO/RemoteFileEntryStreamReader.cs
+++ b/Source/Blazorise/Utilities/IO/RemoteFileEntryStreamReader.cs
@@ -82,15 +82,17 @@ namespace Blazorise
                     var length = (int)Math.Min( maxMessageSize, FileEntry.Size - position );
 
                     var buffer = new Memory<byte>( new byte[length], 0, length );
-                    await CopyFileDataIntoBuffer( buffer, cancellationToken );
-                    await stream.WriteAsync( buffer, cancellationToken );
+                    var bytesRead = await CopyFileDataIntoBuffer( buffer, cancellationToken );
+
+                    var bufferToWrite = buffer.Slice( 0, bytesRead );
+                    await stream.WriteAsync( bufferToWrite, cancellationToken );
 
                     cancellationToken.ThrowIfCancellationRequested();
 
-                    position += length;
+                    position += bytesRead;
                     await Task.WhenAll(
-                        FileEntryNotifier.UpdateFileWrittenAsync( FileEntry, position, buffer.ToArray() ),
-                        FileEntryNotifier.UpdateFileProgressAsync( FileEntry, buffer.Length ) );
+                        FileEntryNotifier.UpdateFileWrittenAsync( FileEntry, position, bufferToWrite.ToArray() ),
+                        FileEntryNotifier.UpdateFileProgressAsync( FileEntry, bytesRead ) );
 
                     await RefreshUI();
                 }


### PR DESCRIPTION
Closes #4213
So when implementing the new 
**stream-from-javascript-to-net**
https://learn.microsoft.com/en-us/aspnet/core/blazor/javascript-interoperability/call-dotnet-from-javascript?view=aspnetcore-6.0#stream-from-javascript-to-net

in **WriteToStreamAsync**, we made the assumption that the provided buffer would be fully filled from the js stream. This is not true, and occasionally it might send less bytes read back. This PR fixes the wrong assumption. Also you couldn't tell from looking at file sizes since it would create still an equal sized file, just that the content would be corrupt.

Also took the time and tested `OpenReadStream` just to be sure, here it is working correctly.

Bug happens with images with a few hundred of kbs.
Code used to test:

```
<FileEdit @ref="@fileEdit" Placeholder="Programm" AutoReset="false" Changed="@OnFileChanged" MaxFileSize="long.MaxValue" />
<FileEdit @ref="@fileEditCopyTO" Placeholder="ProgrammCopyTo" AutoReset="false" Changed="@OnFileChangedCopyTo" MaxFileSize="long.MaxValue" />
@code {

    FileEdit fileEdit;
    FileEdit fileEditCopyTO;
    async Task OnFileChanged( FileChangedEventArgs e )
    {
        var file = e.Files[0];
        // A stream is going to be the destination stream we're writing to.
        try
        {
            using ( var fileStream = File.Create( "SomePath/test.png" ) )
            {
                await file.WriteToStreamAsync( fileStream );
            }
            Console.WriteLine("Written");
        }
        catch ( Exception exc )
        {
            var message = exc.Message;
            Console.WriteLine(message);
        }
    }

    async Task OnFileChangedCopyTo( FileChangedEventArgs e )
    {
        var file = e.Files[0];
        // A stream is going to be the destination stream we're writing to.
        try
        {
            using var stream = file.OpenReadStream( long.MaxValue );
            using ( var fileStream = File.Create( "SomePath/test.png" ) )
            {

                await stream.CopyToAsync( fileStream );
            }
            Console.WriteLine( "Written" );
        }
        catch ( Exception exc )
        {
            var message = exc.Message;
            Console.WriteLine( message );
        }
    }
}
```