### PR TITLE
Fix Debounce

### DIFF
--- a/Source/Blazorise/Base/BaseTextInput.razor.cs
+++ b/Source/Blazorise/Base/BaseTextInput.razor.cs
@@ -143,6 +143,7 @@ namespace Blazorise
         private void OnInputValueDebounce( object sender, string value )
         {
             InvokeAsync( () => CurrentValueHandler( value ) );
+            InvokeAsync( StateHasChanged );
         }
 
         /// <inheritdoc/>

--- a/Source/Blazorise/Base/BaseTextInput.razor.cs
+++ b/Source/Blazorise/Base/BaseTextInput.razor.cs
@@ -143,7 +143,6 @@ namespace Blazorise
         private void OnInputValueDebounce( object sender, string value )
         {
             InvokeAsync( () => CurrentValueHandler( value ) );
-            InvokeAsync( StateHasChanged );
         }
 
         /// <inheritdoc/>

--- a/Source/Blazorise/Utilities/ValueDebouncer.cs
+++ b/Source/Blazorise/Utilities/ValueDebouncer.cs
@@ -27,6 +27,8 @@ namespace Blazorise.Utilities
         /// </summary>
         public event EventHandler<string> Debounce;
 
+        private readonly object locker = new();
+
         #endregion
 
         #region Constructors
@@ -53,7 +55,10 @@ namespace Blazorise.Utilities
         /// <param name="eventArgs">Timer event arguments.</param>
         private void OnElapsed( object source, ElapsedEventArgs eventArgs )
         {
-            Debounce?.Invoke( this, value );
+            lock ( locker )
+            {
+                Debounce?.Invoke( this, value );
+            }
         }
 
         #endregion
@@ -68,9 +73,12 @@ namespace Blazorise.Utilities
         {
             timer.Stop();
 
-            this.value = value;
+            lock ( locker )
+            {
+                this.value = value;
 
-            timer.Start();
+                timer.Start();
+            }
         }
 
         /// <summary>
@@ -82,7 +90,10 @@ namespace Blazorise.Utilities
             {
                 timer.Stop();
 
-                Debounce?.Invoke( this, value );
+                lock ( locker )
+                {
+                    Debounce?.Invoke( this, value );
+                }
             }
         }
 


### PR DESCRIPTION
Some simple changes seem to be enough to keep it in sync. I'm happy that hopefully we finally get to fix this feature.

**To test:**
Add to Blazorise global config:
```
options.Debounce = true;
options.DebounceInterval = 300;
```

Test by going to `Autocomplete` and `Datagrid` and see that you can write in increments of 300ms and only then it updates the component internal value triggering the `Datagrid` Filtering or the `Autocomplete` search for example...

If you have any other ideas to test the implementation, say so.


Seems to work just fine even, with 100ms for example, didn't bother to test less then that, would beat the purpose of the feature. :)

Other implementations that I tought off, but apparently we might not need to explore:
- CancellationToken based
- Use `PeriodicTimer` to setup an async awaitable timer and actually wait TaskCompletion before issuing any other update.