### PR TITLE
Remove focus workaround

### DIFF
--- a/Source/Blazorise/Base/BaseInputComponent.razor.cs
+++ b/Source/Blazorise/Base/BaseInputComponent.razor.cs
@@ -214,12 +214,9 @@ namespace Blazorise
         protected abstract Task OnInternalValueChanged( TValue value );
 
         /// <inheritdoc/>
-        public virtual async Task Focus( bool scrollToElement = true )
+        public virtual Task Focus( bool scrollToElement = true )
         {
-            // workaround from: https://github.com/dotnet/aspnetcore/issues/30070#issuecomment-823938686
-            await Task.Yield();
-
-            await JSUtilitiesModule.Focus( ElementRef, ElementId, scrollToElement );
+            return JSUtilitiesModule.Focus( ElementRef, ElementId, scrollToElement ).AsTask();
         }
 
         /// <summary>


### PR DESCRIPTION
closes #4162

I have left our implementation because we already use the same `utilities.focus` from several places inside of the JS modules. And also, our implementation has the benefit that the element can be retrieved by ElementRef and ElementId, a kinda a fallback in some cases. So all in all it's better to leave it.