### PR TITLE
Fix theme caching issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -266,3 +266,7 @@ Documentation/Blazorise.Docs.Server/wwwroot/img/blog/.DS_Store
 # Ignore VS Code
 .vscode/*
 .vscode/settings.json
+
+
+# Source Generation directory
+__SOURCEGENERATED__/

--- a/Blazorise.sln
+++ b/Blazorise.sln
@@ -108,6 +108,15 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Blazorise.LoadingIndicator"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Blazorise.FluentValidation", "Source\Extensions\Blazorise.FluentValidation\Blazorise.FluentValidation.csproj", "{55C2652B-18A3-4B28-935A-67D78BFE6E8C}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SourceGenerators", "SourceGenerators", "{0538DB67-B4F3-4D00-B969-D3874A52E405}"
+	ProjectSection(SolutionItems) = preProject
+		Source\SourceGenerators\README.md = Source\SourceGenerators\README.md
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Blazorise.Generator", "Source\SourceGenerators\Blazorise.Generator\Blazorise.Generator.csproj", "{1E8A8C1F-4161-48CA-97EB-D8CA917D1DD4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Blazorise.Generator.Features", "Source\SourceGenerators\Blazorise.Generator.Features\Blazorise.Generator.Features.csproj", "{6C3DD66E-C0F0-471F-A00E-F84BA6F30ACB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -286,6 +295,14 @@ Global
 		{55C2652B-18A3-4B28-935A-67D78BFE6E8C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{55C2652B-18A3-4B28-935A-67D78BFE6E8C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{55C2652B-18A3-4B28-935A-67D78BFE6E8C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1E8A8C1F-4161-48CA-97EB-D8CA917D1DD4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1E8A8C1F-4161-48CA-97EB-D8CA917D1DD4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1E8A8C1F-4161-48CA-97EB-D8CA917D1DD4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1E8A8C1F-4161-48CA-97EB-D8CA917D1DD4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6C3DD66E-C0F0-471F-A00E-F84BA6F30ACB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6C3DD66E-C0F0-471F-A00E-F84BA6F30ACB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6C3DD66E-C0F0-471F-A00E-F84BA6F30ACB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6C3DD66E-C0F0-471F-A00E-F84BA6F30ACB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -336,6 +353,8 @@ Global
 		{F4C121CA-C204-43C4-AF1D-DEE56392526F} = {700B33A3-A855-46C3-BD5A-C6954FC7274B}
 		{570C2383-EE8C-4F02-91E8-E59B879EDCD2} = {9731051E-0AA7-411E-A76A-987854F034DA}
 		{55C2652B-18A3-4B28-935A-67D78BFE6E8C} = {9731051E-0AA7-411E-A76A-987854F034DA}
+		{1E8A8C1F-4161-48CA-97EB-D8CA917D1DD4} = {0538DB67-B4F3-4D00-B969-D3874A52E405}
+		{6C3DD66E-C0F0-471F-A00E-F84BA6F30ACB} = {0538DB67-B4F3-4D00-B969-D3874A52E405}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {205B3EA4-470F-45DA-911E-346AF7D0A9A5}

--- a/Source/Blazorise/Blazorise.csproj
+++ b/Source/Blazorise/Blazorise.csproj
@@ -1,30 +1,42 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
-  <Import Project="..\..\Build\Blazorise.props" />
+	<Import Project="..\..\Build\Blazorise.props" />
 
-  <PropertyGroup>
-    <PackageTags>blazorise blazor components</PackageTags>
-    <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-  </PropertyGroup>
+	<PropertyGroup>
+		<PackageTags>blazorise blazor components</PackageTags>
+		<BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
+	</PropertyGroup>
 
-  <PropertyGroup>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-  </PropertyGroup>
+	<PropertyGroup>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <Content Remove="compilerconfig.json" />
-  </ItemGroup>
+	<ItemGroup>
+		<Content Remove="compilerconfig.json" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <None Include="..\..\LICENSE.md" Pack="true" Visible="false" PackagePath="" />
-    <None Include="..\..\NuGet\Blazorise.png" Pack="true" Visible="false" PackagePath="" />
-  </ItemGroup>
+	<ItemGroup>
+		<None Include="..\..\LICENSE.md" Pack="true" Visible="false" PackagePath="" />
+		<None Include="..\..\NuGet\Blazorise.png" Pack="true" Visible="false" PackagePath="" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <None Remove="Resources\Localization\**\*.json" />
-    <EmbeddedResource Include="Resources\Localization\**\*.json" />
-    <None Remove="Resources\Localization\*.json" />
-    <EmbeddedResource Include="Resources\Localization\*.json" />
-  </ItemGroup>
+	<ItemGroup>
+		<None Remove="Resources\Localization\**\*.json" />
+		<EmbeddedResource Include="Resources\Localization\**\*.json" />
+		<None Remove="Resources\Localization\*.json" />
+		<EmbeddedResource Include="Resources\Localization\*.json" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\SourceGenerators\Blazorise.Generator.Features\Blazorise.Generator.Features.csproj" />
+		<ProjectReference Include="..\SourceGenerators\Blazorise.Generator\Blazorise.Generator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+		<!-- Exclude the output of source generators from the compilation -->
+		<Compile Remove="$(CompilerGeneratedFilesOutputPath)/**/*.cs" />
+	</ItemGroup>
+
+	<PropertyGroup>
+		<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+		<CompilerGeneratedFilesOutputPath>__SOURCEGENERATED__</CompilerGeneratedFilesOutputPath>
+	</PropertyGroup>
 
 </Project>

--- a/Source/Blazorise/Blazorise.csproj
+++ b/Source/Blazorise/Blazorise.csproj
@@ -1,42 +1,42 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
-	<Import Project="..\..\Build\Blazorise.props" />
+  <Import Project="..\..\Build\Blazorise.props" />
 
-	<PropertyGroup>
-		<PackageTags>blazorise blazor components</PackageTags>
-		<BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-	</PropertyGroup>
+  <PropertyGroup>
+    <PackageTags>blazorise blazor components</PackageTags>
+    <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
+  </PropertyGroup>
 
-	<PropertyGroup>
-		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-	</PropertyGroup>
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<Content Remove="compilerconfig.json" />
-	</ItemGroup>
+  <ItemGroup>
+    <Content Remove="compilerconfig.json" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<None Include="..\..\LICENSE.md" Pack="true" Visible="false" PackagePath="" />
-		<None Include="..\..\NuGet\Blazorise.png" Pack="true" Visible="false" PackagePath="" />
-	</ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\LICENSE.md" Pack="true" Visible="false" PackagePath="" />
+    <None Include="..\..\NuGet\Blazorise.png" Pack="true" Visible="false" PackagePath="" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<None Remove="Resources\Localization\**\*.json" />
-		<EmbeddedResource Include="Resources\Localization\**\*.json" />
-		<None Remove="Resources\Localization\*.json" />
-		<EmbeddedResource Include="Resources\Localization\*.json" />
-	</ItemGroup>
+  <ItemGroup>
+    <None Remove="Resources\Localization\**\*.json" />
+    <EmbeddedResource Include="Resources\Localization\**\*.json" />
+    <None Remove="Resources\Localization\*.json" />
+    <EmbeddedResource Include="Resources\Localization\*.json" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\SourceGenerators\Blazorise.Generator.Features\Blazorise.Generator.Features.csproj" />
-		<ProjectReference Include="..\SourceGenerators\Blazorise.Generator\Blazorise.Generator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
-		<!-- Exclude the output of source generators from the compilation -->
-		<Compile Remove="$(CompilerGeneratedFilesOutputPath)/**/*.cs" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SourceGenerators\Blazorise.Generator.Features\Blazorise.Generator.Features.csproj" />
+    <ProjectReference Include="..\SourceGenerators\Blazorise.Generator\Blazorise.Generator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <!-- Exclude the output of source generators from the compilation -->
+    <Compile Remove="$(CompilerGeneratedFilesOutputPath)/**/*.cs" />
+  </ItemGroup>
 
-	<PropertyGroup>
-		<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
-		<CompilerGeneratedFilesOutputPath>__SOURCEGENERATED__</CompilerGeneratedFilesOutputPath>
-	</PropertyGroup>
+  <PropertyGroup>
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+    <CompilerGeneratedFilesOutputPath>__SOURCEGENERATED__</CompilerGeneratedFilesOutputPath>
+  </PropertyGroup>
 
 </Project>

--- a/Source/Blazorise/Themes/Theme.cs
+++ b/Source/Blazorise/Themes/Theme.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Blazorise.Extensions;
 using Blazorise.Generator.Features;
 #endregion
 

--- a/Source/Blazorise/Themes/Theme.cs
+++ b/Source/Blazorise/Themes/Theme.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Blazorise.Extensions;
 using Blazorise.Generator.Features;
 #endregion
 

--- a/Source/Blazorise/Themes/Theme.cs
+++ b/Source/Blazorise/Themes/Theme.cs
@@ -2,6 +2,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Blazorise.Extensions;
+using Blazorise.Generator.Features;
 #endregion
 
 namespace Blazorise
@@ -9,7 +11,8 @@ namespace Blazorise
     /// <summary>
     /// Holds the options for the theme.
     /// </summary>
-    public record Theme
+    [GenerateEquality]
+    public partial record Theme
     {
         /// <summary>
         /// Globaly enable or disable the theme.
@@ -19,6 +22,7 @@ namespace Blazorise
         /// <summary>
         /// Event raised after the theme options has changed.
         /// </summary>
+        [GenerateIgnoreEquality]
         public event EventHandler<EventArgs> Changed;
 
         /// <summary>

--- a/Source/Blazorise/Themes/ThemeCache.cs
+++ b/Source/Blazorise/Themes/ThemeCache.cs
@@ -1,4 +1,5 @@
 ﻿#region Using directives
+using System;
 using System.Collections.Generic;
 using System.Linq;
 #endregion

--- a/Source/Blazorise/Themes/ThemeCache.cs
+++ b/Source/Blazorise/Themes/ThemeCache.cs
@@ -17,8 +17,7 @@ namespace Blazorise.Themes
 
         private readonly int maxCacheSize;
 
-
-        private readonly Dictionary<Theme, ThemeCachedResource> cachedThemes = new();
+        private readonly Dictionary<int, ThemeCachedResource> cachedThemes = new();
 
 
         private readonly object mutex = new();
@@ -48,9 +47,10 @@ namespace Blazorise.Themes
 
             lock ( mutex )
             {
-                PrepareCache( theme );
+                var cacheHash = theme.GetHashCode();
+                PrepareCache( cacheHash );
 
-                cachedThemes[theme].Variables = variables;
+                cachedThemes[cacheHash].Variables = variables;
             }
         }
 
@@ -62,20 +62,21 @@ namespace Blazorise.Themes
 
             lock ( mutex )
             {
-                PrepareCache( theme );
+                var cacheHash = theme.GetHashCode();
+                PrepareCache( cacheHash );
 
-                cachedThemes[theme].Styles = styles;
+                cachedThemes[cacheHash].Styles = styles;
             }
         }
 
-        private void PrepareCache( Theme theme )
+        private void PrepareCache( int themeCacheKey )
         {
-            if ( !cachedThemes.ContainsKey( theme ) )
+            if ( !cachedThemes.ContainsKey( themeCacheKey ) )
             {
                 if ( cachedThemes.Count + 1 > maxCacheSize )
                     UncacheTheme();
 
-                cachedThemes.Add( theme, new() );
+                cachedThemes.Add( themeCacheKey, new() );
             }
         }
 
@@ -89,7 +90,7 @@ namespace Blazorise.Themes
         {
             lock ( mutex )
             {
-                variables = cachedThemes.GetValueOrDefault( theme )?.Variables;
+                variables = cachedThemes.GetValueOrDefault( theme.GetHashCode() )?.Variables;
                 return variables is not null;
             }
         }
@@ -99,7 +100,7 @@ namespace Blazorise.Themes
         {
             lock ( mutex )
             {
-                styles = cachedThemes.GetValueOrDefault( theme )?.Styles;
+                styles = cachedThemes.GetValueOrDefault( theme.GetHashCode() )?.Styles;
                 return styles is not null;
             }
         }

--- a/Source/Blazorise/Themes/ThemeCache.cs
+++ b/Source/Blazorise/Themes/ThemeCache.cs
@@ -1,5 +1,4 @@
 ﻿#region Using directives
-using System;
 using System.Collections.Generic;
 using System.Linq;
 #endregion
@@ -14,11 +13,9 @@ namespace Blazorise.Themes
     {
         #region Members
 
-
         private readonly int maxCacheSize;
 
         private readonly Dictionary<int, ThemeCachedResource> cachedThemes = new();
-
 
         private readonly object mutex = new();
 

--- a/Source/Blazorise/Themes/ThemeGenerator.cs
+++ b/Source/Blazorise/Themes/ThemeGenerator.cs
@@ -236,10 +236,10 @@ namespace Blazorise
             //var buttonColor = Contrast( ThemeColorLevel( theme, inColor, options?.VariantButtonColorLevel ?? 8 ) );
             //var buttonHoverColor = ThemeColorLevel( theme, buttonColor, options?.VariantButtonHoverColorLevel ?? 4 );
 
-            Variables[$"{ThemeVariables.SnackbarBackground}-{ variant }"] = ToHex( backgroundColor );
-            Variables[$"{ThemeVariables.SnackbarTextColor}-{ variant }"] = ToHex( textColor );
-            Variables[$"{ThemeVariables.SnackbarButtonColor}-{ variant }"] = ToHex( buttonColor );
-            Variables[$"{ThemeVariables.SnackbarButtonHoverColor}-{ variant }"] = ToHex( buttonHoverColor );
+            Variables[$"{ThemeVariables.SnackbarBackground}-{variant}"] = ToHex( backgroundColor );
+            Variables[$"{ThemeVariables.SnackbarTextColor}-{variant}"] = ToHex( textColor );
+            Variables[$"{ThemeVariables.SnackbarButtonColor}-{variant}"] = ToHex( buttonColor );
+            Variables[$"{ThemeVariables.SnackbarButtonHoverColor}-{variant}"] = ToHex( buttonHoverColor );
         }
 
         /// <summary>

--- a/Source/SourceGenerators/Blazorise.Generator.Features/Blazorise.Generator.Features.csproj
+++ b/Source/SourceGenerators/Blazorise.Generator.Features/Blazorise.Generator.Features.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/Source/SourceGenerators/Blazorise.Generator.Features/GenerateEqualityAttribute.cs
+++ b/Source/SourceGenerators/Blazorise.Generator.Features/GenerateEqualityAttribute.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Blazorise.Generator.Features
+{
+    [AttributeUsage( AttributeTargets.Class )]
+    public class GenerateEqualityAttribute : Attribute
+    {
+
+    }
+}

--- a/Source/SourceGenerators/Blazorise.Generator.Features/GenerateIgnoreEqualityAttribute.cs
+++ b/Source/SourceGenerators/Blazorise.Generator.Features/GenerateIgnoreEqualityAttribute.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Blazorise.Generator.Features
+{
+    [AttributeUsage( AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Event )]
+    public class GenerateIgnoreEqualityAttribute : Attribute
+    {
+
+    }
+}

--- a/Source/SourceGenerators/Blazorise.Generator/Blazorise.Generator.csproj
+++ b/Source/SourceGenerators/Blazorise.Generator/Blazorise.Generator.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<IsRoslynComponent>true</IsRoslynComponent>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\Blazorise.Generator.Features\Blazorise.Generator.Features.csproj" />
+	</ItemGroup>
+</Project>

--- a/Source/SourceGenerators/Blazorise.Generator/Blazorise.Generator.csproj
+++ b/Source/SourceGenerators/Blazorise.Generator/Blazorise.Generator.csproj
@@ -1,19 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
-		<IsRoslynComponent>true</IsRoslynComponent>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <IsRoslynComponent>true</IsRoslynComponent>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
-	<ItemGroup>
-	  <ProjectReference Include="..\Blazorise.Generator.Features\Blazorise.Generator.Features.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Blazorise.Generator.Features\Blazorise.Generator.Features.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/Source/SourceGenerators/Blazorise.Generator/EqualitySourceGenerator.cs
+++ b/Source/SourceGenerators/Blazorise.Generator/EqualitySourceGenerator.cs
@@ -133,7 +133,7 @@ namespace {namespaceName}
             {
 
                 if ( isCollection )
-                { 
+                {
                     sb.AppendLine( $"{STANDARD_SPACING}foreach ( var hashItem in {prop} )" );
                     sb.AppendLine( $"{STANDARD_SPACING}{{" );
                     sb.AppendLine( $"{STANDARD_SPACING}\thash.Add( hashItem );" );
@@ -150,7 +150,6 @@ namespace {namespaceName}
         {
             public List<ClassDeclarationSyntax> Classes { get; } = new List<ClassDeclarationSyntax>();
             public List<RecordDeclarationSyntax> Records { get; } = new List<RecordDeclarationSyntax>();
-
 
             public void OnVisitSyntaxNode( SyntaxNode syntaxNode )
             {
@@ -172,8 +171,6 @@ namespace {namespaceName}
                     Records.Add( recordDeclaration );
                 }
             }
-
-
         }
     }
 }

--- a/Source/SourceGenerators/Blazorise.Generator/EqualitySourceGenerator.cs
+++ b/Source/SourceGenerators/Blazorise.Generator/EqualitySourceGenerator.cs
@@ -1,0 +1,179 @@
+﻿using System;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Blazorise.Generator.Features;
+using System.Diagnostics.Contracts;
+
+namespace Blazorise.Generator
+{
+    [Generator]
+    public class EqualitySourceGenerator : ISourceGenerator
+    {
+        private const string STANDARD_SPACING = "\t\t\t";
+
+        public void Initialize( GeneratorInitializationContext context ) => context.RegisterForSyntaxNotifications( () => new GenerateEqualityFinder() );
+
+        public void Execute( GeneratorExecutionContext context )
+        {
+            var records = ( (GenerateEqualityFinder)context.SyntaxReceiver ).Records;
+            if ( records.Count > 0 )
+            {
+                foreach ( RecordDeclarationSyntax record in records )
+                {
+                    AddGenerateEqualitySource( context, record );
+                }
+            }
+        }
+
+        private void AddGenerateEqualitySource( GeneratorExecutionContext context, RecordDeclarationSyntax declarationSyntax )
+        {
+            var namespaceName = ( (Microsoft.CodeAnalysis.CSharp.Syntax.NamespaceDeclarationSyntax)declarationSyntax.Parent ).Name.ToString();
+            var usings = ( (Microsoft.CodeAnalysis.CSharp.Syntax.CompilationUnitSyntax)declarationSyntax.Parent.Parent ).Usings.ToString();
+            var className = declarationSyntax.Identifier.ValueText;
+
+            var propertiesForEquality = new List<(string name, bool isCollection)>();
+
+            foreach ( var item in declarationSyntax.ChildNodes() )
+            {
+                switch ( item )
+                {
+                    case PropertyDeclarationSyntax property:
+                        if ( IsValid( property.AttributeLists ) )
+                        {
+                            if ( property.Type is GenericNameSyntax )
+                            {
+                                var genericTypeName = ( (Microsoft.CodeAnalysis.CSharp.Syntax.GenericNameSyntax)property.Type ).Identifier.Text;
+                                var collectionTypes = new[] { "IEnumerable", "List", "ICollection" };
+
+                                if ( collectionTypes.Contains( genericTypeName ) )
+                                    propertiesForEquality.Add( (property.Identifier.Text, true) );
+                                else
+                                    throw new Exception( $"Unhandled case!! Please check {nameof( EqualitySourceGenerator )}" );
+                            }
+                            else
+                                propertiesForEquality.Add( (property.Identifier.Text, false) );
+                        }
+
+                        break;
+                    case FieldDeclarationSyntax field:
+                        if ( IsValid( field.AttributeLists ) )
+                            propertiesForEquality.Add( (field.Declaration.Variables[0].Identifier.Text, false) );
+                        break;
+                    case EventFieldDeclarationSyntax eventDeclaration:
+                        if ( IsValid( eventDeclaration.AttributeLists ) )
+                            propertiesForEquality.Add( (eventDeclaration.Declaration.Variables[0].Identifier.Text, false) );
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            var returnEquals = GenerateEqualsReturn( propertiesForEquality );
+            var returnGetHashCode = GenerateGetHashCodeReturn( propertiesForEquality );
+
+            context.AddSource( $"{className}.generated.cs", SourceText.From( $@"{usings}
+
+namespace {namespaceName}
+{{
+    public partial record {className} 
+    {{
+
+        /// <inheritdoc/>
+        public virtual bool Equals( {className} obj )
+        {{
+            {returnEquals}
+        }}
+
+        /// <inheritdoc/>
+        public override int GetHashCode()
+        {{
+            {returnGetHashCode}
+        }}
+    }}
+}}", Encoding.UTF8 ) );
+        }
+
+        private bool IsValid( SyntaxList<AttributeListSyntax> attributes )
+        {
+            var attributeName = nameof( GenerateIgnoreEqualityAttribute ).Replace( "Attribute", "" );
+
+            return !attributes
+                    .Any( x => x.Attributes
+                        .Any( y => ( (Microsoft.CodeAnalysis.CSharp.Syntax.IdentifierNameSyntax)y.Name ).Identifier.ValueText == attributeName ) );
+        }
+
+        private static string GenerateEqualsReturn( List<(string name, bool isCollection)> propertiesForEquality )
+        {
+            var sb = new StringBuilder();
+
+            sb.AppendLine( "return obj is not null" );
+            foreach ( (string prop, bool isCollection) in propertiesForEquality )
+            {
+                sb.Append( $"{STANDARD_SPACING}&& " );
+
+                if ( isCollection )
+                    sb.AppendLine( $"{prop}.AreEqual(obj.{prop})" );
+                else
+                    sb.AppendLine( $"{prop} == obj.{prop}" );
+            }
+            sb.Append( ";" );
+            return sb.ToString();
+        }
+
+        private static string GenerateGetHashCodeReturn( List<(string name, bool isCollection)> propertiesForEquality )
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine( $"var hash = new HashCode();" );
+
+            foreach ( (string prop, bool isCollection) in propertiesForEquality )
+            {
+
+                if ( isCollection )
+                { 
+                    sb.AppendLine( $"{STANDARD_SPACING}foreach ( var hashItem in {prop} )" );
+                    sb.AppendLine( $"{STANDARD_SPACING}{{" );
+                    sb.AppendLine( $"{STANDARD_SPACING}\thash.Add( hashItem );" );
+                    sb.AppendLine( $"{STANDARD_SPACING}}}" );
+                }
+                else
+                    sb.AppendLine( $"{STANDARD_SPACING}hash.Add( {prop} );" );
+            }
+            sb.Append( $"{STANDARD_SPACING}return hash.ToHashCode();" );
+            return sb.ToString();
+        }
+
+        private class GenerateEqualityFinder : ISyntaxReceiver
+        {
+            public List<ClassDeclarationSyntax> Classes { get; } = new List<ClassDeclarationSyntax>();
+            public List<RecordDeclarationSyntax> Records { get; } = new List<RecordDeclarationSyntax>();
+
+
+            public void OnVisitSyntaxNode( SyntaxNode syntaxNode )
+            {
+                var attributeName = nameof( GenerateEqualityAttribute ).Replace( "Attribute", "" );
+
+                if ( syntaxNode is ClassDeclarationSyntax classDeclaration
+                    && classDeclaration.AttributeLists
+                    .Any( x => x.Attributes
+                        .Any( y => ( (Microsoft.CodeAnalysis.CSharp.Syntax.IdentifierNameSyntax)y.Name ).Identifier.ValueText == attributeName ) ) )
+                {
+                    Classes.Add( classDeclaration );
+                }
+
+                if ( syntaxNode is RecordDeclarationSyntax recordDeclaration
+                    && recordDeclaration.AttributeLists
+                    .Any( x => x.Attributes
+                        .Any( y => ( (Microsoft.CodeAnalysis.CSharp.Syntax.IdentifierNameSyntax)y.Name ).Identifier.ValueText == attributeName ) ) )
+                {
+                    Records.Add( recordDeclaration );
+                }
+            }
+
+
+        }
+    }
+}

--- a/Source/SourceGenerators/Blazorise.Generator/Properties/launchSettings.json
+++ b/Source/SourceGenerators/Blazorise.Generator/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "Debug.Blazorise": {
+      "commandName": "DebugRoslynComponent",
+      "targetProject": "..\\..\\Blazorise\\Blazorise.csproj"
+    }
+  }
+}

--- a/Source/SourceGenerators/README.md
+++ b/Source/SourceGenerators/README.md
@@ -1,0 +1,22 @@
+﻿# Source Generator
+
+This Source Generator can be applied to projects for source generation.
+
+To do so apply the same as an analyzer to your target project:
+	<ItemGroup>
+		<ProjectReference Include="..\..\..\SourceGenerators\Blazorise.Generator\Blazorise.Generator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+		<!-- Exclude the output of source generators from the compilation -->
+		<Compile Remove="$(CompilerGeneratedFilesOutputPath)/**/*.cs" />
+	</ItemGroup>
+
+To generate the files on a fixed folder on disk:
+	<PropertyGroup>
+		<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+		<CompilerGeneratedFilesOutputPath>__SOURCEGENERATED__</CompilerGeneratedFilesOutputPath>
+	</PropertyGroup>
+
+### Debugging
+For debugging the Source Generator make sure you have installed the .NET Compiler Platform SDK (Visual Studio Installer).
+
+### Just Get It To Work
+These are made on a "Just Get It To Work" basis. However, improve this in the future if maintenance or readability gets more complex.

--- a/Tests/Blazorise.Tests/ThemeCacheTest.cs
+++ b/Tests/Blazorise.Tests/ThemeCacheTest.cs
@@ -129,8 +129,8 @@ namespace Blazorise.Tests
             var secondThemeStillInCache = themeCache.TryGetStylesFromCache( secondCachedTheme, out _ );
 
             // validate
-            Assert.True( firstThemeStillInCache );
-            Assert.False( secondThemeStillInCache );
+            Assert.False( firstThemeStillInCache );
+            Assert.True( secondThemeStillInCache );
         }
 
         [Fact]

--- a/Tests/Blazorise.Tests/ThemeCacheTest.cs
+++ b/Tests/Blazorise.Tests/ThemeCacheTest.cs
@@ -1,4 +1,7 @@
-﻿using Blazorise.Themes;
+﻿using System;
+using System.Collections.Generic;
+using Blazorise.DataGrid.Utils;
+using Blazorise.Themes;
 using Xunit;
 
 namespace Blazorise.Tests
@@ -12,11 +15,15 @@ namespace Blazorise.Tests
             themeCache = new( new( null, options => { } ) );
         }
 
+
+        private Theme InitFullyInstantiatedTheme()
+            => RecursiveObjectActivator.CreateInstance<Theme>();
+
         [Fact]
         public void TryGetVariablesFromCache_ReturnsVariablesCachedBy_CacheVariables()
         {
             // setup
-            var theme = new Theme();
+            var theme =  InitFullyInstantiatedTheme();
 
             // test
             themeCache.CacheVariables( theme, "xyz" );
@@ -28,10 +35,26 @@ namespace Blazorise.Tests
         }
 
         [Fact]
+        public void TryGetVariablesFromCache_ReturnsVariablesCachedBy_AnEqualTheme_CacheVariables()
+        {
+            // setup
+            var theme =  InitFullyInstantiatedTheme();
+            var theme2 = InitFullyInstantiatedTheme();
+
+            // test
+            themeCache.CacheVariables( theme, "xyz" );
+            var success = themeCache.TryGetVariablesFromCache( theme2, out var variables );
+
+            // validate
+            Assert.True( success );
+            Assert.Equal( "xyz", variables );
+        }
+
+        [Fact]
         public void TryGetStylesFromCache_ReturnsStylesCachedBy_CacheStyles()
         {
             // setup
-            var theme = new Theme();
+            var theme = InitFullyInstantiatedTheme();
 
             // test
             themeCache.CacheStyles( theme, "xyz" );
@@ -48,7 +71,7 @@ namespace Blazorise.Tests
             // setup
             var maxCachedStyles = 10;
 
-            var firstCachedTheme = new Theme();
+            var firstCachedTheme = InitFullyInstantiatedTheme();
             themeCache.CacheStyles( firstCachedTheme, "xyz" );
 
             // test
@@ -69,7 +92,7 @@ namespace Blazorise.Tests
             // setup
             var maxCachedStyles = 10;
 
-            var firstCachedTheme = new Theme();
+            var firstCachedTheme = InitFullyInstantiatedTheme();
             themeCache.CacheStyles( firstCachedTheme, "xyz" );
 
             // test
@@ -114,14 +137,34 @@ namespace Blazorise.Tests
         public void EqualThemes_AreEqual()
         {
             // setup
-            var theme1 = new Theme();
-            var theme2 = new Theme();
-
+            var theme1 = InitFullyInstantiatedTheme();
+            theme1.Changed += OnThemeChanged;
+            var theme2 = InitFullyInstantiatedTheme();
+            theme2.Changed += OnThemeChanged;
             // test
             var areEqual = theme1.Equals( theme2 );
 
             // validate
             Assert.True( areEqual );
+        }
+
+        [Fact]
+        public void EqualThemes_DifferentChangedEvent_AreEqual()
+        {
+            // setup
+            var theme1 = InitFullyInstantiatedTheme();
+            var theme2 = InitFullyInstantiatedTheme();
+            theme2.Changed += OnThemeChanged;
+            // test
+            var areEqual = theme1.Equals( theme2 );
+
+            // validate
+            Assert.True( areEqual );
+        }
+
+        private void OnThemeChanged( object sender, EventArgs eventArgs )
+        {
+
         }
 
         [Fact]

--- a/Tests/Blazorise.Tests/ThemeCacheTest.cs
+++ b/Tests/Blazorise.Tests/ThemeCacheTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Blazorise.DataGrid.Utils;
 using Blazorise.Themes;
 using Xunit;
@@ -23,7 +24,7 @@ namespace Blazorise.Tests
         public void TryGetVariablesFromCache_ReturnsVariablesCachedBy_CacheVariables()
         {
             // setup
-            var theme =  InitFullyInstantiatedTheme();
+            var theme = InitFullyInstantiatedTheme();
 
             // test
             themeCache.CacheVariables( theme, "xyz" );
@@ -38,7 +39,7 @@ namespace Blazorise.Tests
         public void TryGetVariablesFromCache_ReturnsVariablesCachedBy_AnEqualTheme_CacheVariables()
         {
             // setup
-            var theme =  InitFullyInstantiatedTheme();
+            var theme = InitFullyInstantiatedTheme();
             var theme2 = InitFullyInstantiatedTheme();
 
             // test
@@ -134,18 +135,46 @@ namespace Blazorise.Tests
         }
 
         [Fact]
-        public void EqualThemes_AreEqual()
+        public void DictionaryCache_RemovesSuccessfully()
+        {
+            // setup
+            Dictionary<Theme, string> cache = new();
+            var theme = InitFullyInstantiatedTheme();
+            cache.Add( theme with { }, "" );
+
+            cache.Remove( cache.First().Key );
+
+            // validate
+            Assert.Empty( cache );
+        }
+
+
+        [Fact]
+        public void EqualThemes_FullyInstiated_AreEqual()
         {
             // setup
             var theme1 = InitFullyInstantiatedTheme();
             theme1.Changed += OnThemeChanged;
             var theme2 = InitFullyInstantiatedTheme();
             theme2.Changed += OnThemeChanged;
-            // test
-            var areEqual = theme1.Equals( theme2 );
 
             // validate
-            Assert.True( areEqual );
+            Assert.Equal( theme1, theme2 );
+            Assert.Equal( theme1.GetHashCode(), theme2.GetHashCode() );
+        }
+
+        [Fact]
+        public void EqualThemes_AreEqual()
+        {
+            // setup
+            var theme1 = new Theme();
+            theme1.Changed += OnThemeChanged;
+            var theme2 = new Theme();
+            theme2.Changed += OnThemeChanged;
+
+            // validate
+            Assert.Equal( theme1, theme2 );
+            Assert.Equal( theme1.GetHashCode(), theme2.GetHashCode() );
         }
 
         [Fact]
@@ -155,11 +184,9 @@ namespace Blazorise.Tests
             var theme1 = InitFullyInstantiatedTheme();
             var theme2 = InitFullyInstantiatedTheme();
             theme2.Changed += OnThemeChanged;
-            // test
-            var areEqual = theme1.Equals( theme2 );
 
             // validate
-            Assert.True( areEqual );
+            Assert.Equal( theme1, theme2 );
         }
 
         private void OnThemeChanged( object sender, EventArgs eventArgs )
@@ -174,11 +201,8 @@ namespace Blazorise.Tests
             var theme1 = new Theme() { TextColorOptions = new() { Danger = "danger" } };
             var theme2 = new Theme() { TextColorOptions = new() { Danger = "warning" } };
 
-            // test
-            var areEqual = theme1.Equals( theme2 );
-
             // validate
-            Assert.False( areEqual );
+            Assert.NotEqual( theme1, theme2 );
         }
     }
 }


### PR DESCRIPTION
Closes #4254

- Introduced Blazorise.SourceGenerator 
- Used a Blazorise.SourceGenerator.Features project to allocate the common Attributes for the generation detection
- Theme is now partial and has Equality / HashCode methods generated. 
  - Like we've talked, the problem here was that the event field was messing up the `GetHashCode` from the `Dictionary`, so on this version at least, it was never caching anything, just wasting memory if multiple themes were used (and not cleaning up either)
  - The tests that we have are good, but unfortunately missed the event field, giving a false sense of being ok.
 - I did not see a reason for the triple variables for caching, and I have reduced the implementation to 1.

I still need to do a bit more testing later today, but all in all seems like it is now working properly.