### PR TITLE
Bulma fix display none helper // Breakpoint (Responsive helper)

### DIFF
--- a/Source/Blazorise.Bulma/BulmaClassProvider.cs
+++ b/Source/Blazorise.Bulma/BulmaClassProvider.cs
@@ -1369,6 +1369,23 @@ namespace Blazorise.Bulma
             }
         }
 
+        public override string ToDisplayType( DisplayType displayType )
+        {
+            return displayType switch
+            {
+                Blazorise.DisplayType.None => "hidden",
+                Blazorise.DisplayType.Block => "block",
+                Blazorise.DisplayType.Inline => "inline",
+                Blazorise.DisplayType.InlineBlock => "inline-block",
+                Blazorise.DisplayType.Flex => "flex",
+                Blazorise.DisplayType.InlineFlex => "inline-flex",
+                Blazorise.DisplayType.Table => "table",
+                Blazorise.DisplayType.TableRow => "table-row",
+                Blazorise.DisplayType.TableCell => "table-cell",
+                _ => null,
+            };
+        }
+
         public override string ToBackground( Background background )
         {
             var name = background.Name;

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridPagination.razor
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridPagination.razor
@@ -93,7 +93,7 @@
     {
         @if ( !ParentDataGrid.Virtualize )
         {
-            <Field Margin="Blazorise.Margin.IsAuto.OnY.Is2.FromStart" Display="Blazorise.Display.None.InlineBlock.OnDesktop">
+            <Field Margin="Blazorise.Margin.IsAuto.OnY.Is2.FromStart" Display="Blazorise.Display.None.OnMobile.InlineBlock.OnDesktop">
                 @if ( TotalItemsTemplate is not null )
                 {
                     @TotalItemsTemplate( PaginationContext )
@@ -163,7 +163,7 @@
                     var pageNumberString = i.ToString();
                     var pageActive = pageNumber == PaginationContext.CurrentPage;
 
-                    <PaginationItem Display="Blazorise.Display.None.InlineBlock.OnTablet" Disabled="@(pageNumber == PaginationContext.CurrentPage)" Active="@pageActive">
+                    <PaginationItem Display="Blazorise.Display.None.OnMobile.InlineBlock.OnTablet" Disabled="@(pageNumber == PaginationContext.CurrentPage)" Active="@pageActive">
                         <PaginationLink Page="@pageNumberString" Clicked="@OnPaginationItemClick">
                             @if ( PageButtonTemplate is not null )
                             {
@@ -219,7 +219,7 @@
                             }
                         </Select>
                     </PaginationItem>
-                    <Field Margin="Blazorise.Margin.IsAuto.OnY.Is0.FromBottom.Is2.FromStart" Display="Blazorise.Display.None.InlineBlock.OnDesktop">
+                    <Field Margin="Blazorise.Margin.IsAuto.OnY.Is0.FromBottom.Is2.FromStart" Display="Blazorise.Display.None.OnMobile.InlineBlock.OnDesktop">
                         @if ( ItemsPerPageTemplate is not null )
                         {
                             @ItemsPerPageTemplate


### PR DESCRIPTION
Fixes reported issue at https://support.blazorise.com/issues/76/DataGrid-Pagination-Customization
where certain breakpoints would have no effect and would not hide certain datagrid pagination structures.

According to Bulma docs, the correct way to use the breakpoint helper for display `none`, is actually `hidden`.
https://bulma.io/documentation/helpers/visibility-helpers/

Additionally the Pagination Display breakpoint was just slightly changed by adding `OnMobile`, so it does not cause css rule conflict.

Tests were done on every provider.
`AntDesign` has the same problem and we should investigate in the future, but it is a Provider with not as much priority and there's a few other issues with it, so we'll leave it for now and we'll work on improving `AntDesign` issues when we have more time.