### PR TITLE
Markdown: wait for the first render to execute methods

### DIFF
--- a/Demos/Blazorise.Demo/Pages/Tests/MarkdownPage.razor
+++ b/Demos/Blazorise.Demo/Pages/Tests/MarkdownPage.razor
@@ -6,9 +6,20 @@
                 <CardTitle>Markdown editor</CardTitle>
             </CardHeader>
             <CardBody>
+                <Fields>
+                    <Field ColumnSize="ColumnSize.IsAuto">
+                        <Button Color="Color.Primary" Clicked="@(()=>markdownRef.SetValueAsync("this is a new value from SetValueAsync Method"))">Set SetValueAsync Method</Button>
+                    </Field>
+                    <Field ColumnSize="ColumnSize.IsAuto">
+                        <Button Color="Color.Primary" Clicked="@(()=>markdownValue = "this is a new value from Value Parameter")">Set Value Parameter</Button>
+                    </Field>
+                </Fields>
+            </CardBody>
+            <CardBody>
                 <Row>
                     <Column>
-                        <Markdown Value="@markdownValue" ValueChanged="@OnMarkdownValueChanged"
+                        <Markdown @ref="@markdownRef"
+                                  Value="@markdownValue" ValueChanged="@OnMarkdownValueChanged"
                                   ImageUploadChanged="@OnImageUploadChanged"
                                   ImageUploadStarted="@OnImageUploadStarted"
                                   ImageUploadProgressed="@OnImageUploadProgressed"
@@ -23,22 +34,24 @@
     </Column>
 </Row>
 @code {
+    Markdown markdownRef;
+
     string markdownValue = "# EasyMDE \n Go ahead, play around with the editor! Be sure to check out **bold**, *italic*, [links](https://google.com) and all the other features. You can type the Markdown syntax, use the toolbar, or use shortcuts like `ctrl-b` or `cmd-b`.";
 
     string markdownHtml;
 
     protected override void OnInitialized()
     {
-        markdownHtml = Markdig.Markdown.ToHtml(markdownValue ?? string.Empty);
+        markdownHtml = Markdig.Markdown.ToHtml( markdownValue ?? string.Empty );
 
         base.OnInitialized();
     }
 
-    Task OnMarkdownValueChanged(string value)
+    Task OnMarkdownValueChanged( string value )
     {
         markdownValue = value;
 
-        markdownHtml = Markdig.Markdown.ToHtml(markdownValue ?? string.Empty);
+        markdownHtml = Markdig.Markdown.ToHtml( markdownValue ?? string.Empty );
 
         return Task.CompletedTask;
     }
@@ -46,15 +59,15 @@
     //string fileContent;
     int fileProgress;
 
-    async Task OnImageUploadChanged(FileChangedEventArgs e)
+    async Task OnImageUploadChanged( FileChangedEventArgs e )
     {
         try
         {
-            foreach (var file in e.Files)
+            foreach ( var file in e.Files )
             {
-                using (var stream = new System.IO.MemoryStream())
+                using ( var stream = new System.IO.MemoryStream() )
                 {
-                    await file.WriteToStreamAsync(stream);
+                    await file.WriteToStreamAsync( stream );
 
                     //stream.Seek( 0, SeekOrigin.Begin );
 
@@ -65,9 +78,9 @@
                 }
             }
         }
-        catch (Exception exc)
+        catch ( Exception exc )
         {
-            Console.WriteLine(exc.Message);
+            Console.WriteLine( exc.Message );
         }
         finally
         {
@@ -75,38 +88,38 @@
         }
     }
 
-    Task OnImageUploadStarted(FileStartedEventArgs e)
+    Task OnImageUploadStarted( FileStartedEventArgs e )
     {
         fileProgress = 0;
-        Console.WriteLine($"Started Image: {e.File.Name}");
+        Console.WriteLine( $"Started Image: {e.File.Name}" );
 
         return Task.CompletedTask;
     }
 
-    Task OnImageUploadEnded(FileEndedEventArgs e)
+    Task OnImageUploadEnded( FileEndedEventArgs e )
     {
-        if (e.Success)
+        if ( e.Success )
             // since we're faking the upload in this demo we will just insert some dummy imageUrl
             e.File.UploadUrl = "https://images.pexels.com/photos/4966601/pexels-photo-4966601.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=200";
         else
             e.File.UploadUrl = string.Empty;
 
-        Console.WriteLine($"Finished Image: {e.File.Name}, {nameof(e.Success)}: {e.Success}, {nameof(e.FileInvalidReason)}: {e.FileInvalidReason}");
+        Console.WriteLine( $"Finished Image: {e.File.Name}, {nameof( e.Success )}: {e.Success}, {nameof( e.FileInvalidReason )}: {e.FileInvalidReason}" );
 
         return Task.CompletedTask;
     }
 
-    Task OnImageUploadProgressed(FileProgressedEventArgs e)
+    Task OnImageUploadProgressed( FileProgressedEventArgs e )
     {
         fileProgress = (int)e.Percentage;
-        Console.WriteLine($"Image: {e.File.Name} Progress: {e.Percentage}");
+        Console.WriteLine( $"Image: {e.File.Name} Progress: {e.Percentage}" );
 
         return Task.CompletedTask;
     }
 
-    Task OnImageUploadWritten(FileWrittenEventArgs e)
+    Task OnImageUploadWritten( FileWrittenEventArgs e )
     {
-        Console.WriteLine($"Image: {e.File.Name} Position: {e.Position} Data: {Convert.ToBase64String(e.Data)}");
+        Console.WriteLine( $"Image: {e.File.Name} Position: {e.Position} Data: {Convert.ToBase64String( e.Data )}" );
 
         return Task.CompletedTask;
     }

--- a/Source/Extensions/Blazorise.Markdown/Markdown.razor.cs
+++ b/Source/Extensions/Blazorise.Markdown/Markdown.razor.cs
@@ -33,6 +33,11 @@ namespace Blazorise.Markdown
         /// </summary>
         private bool autofocus;
 
+        /// <summary>
+        /// A stack of functions to execute after the rendering.
+        /// </summary>
+        private Queue<Func<Task>> delayedExecuteAfterRenderQueue;
+
         #endregion
 
         #region Methods
@@ -50,9 +55,9 @@ namespace Blazorise.Markdown
         /// <inheritdoc/>
         public override async Task SetParametersAsync( ParameterView parameters )
         {
-            if ( Initialized && parameters.TryGetValue<string>( nameof( Value ), out var newValue ) && newValue != Value )
+            if ( Rendered && parameters.TryGetValue<string>( nameof( Value ), out var newValue ) && newValue != Value )
             {
-                ExecuteAfterRender( () => SetValueAsync( newValue ) );
+                TryExecuteAfterRender( () => SetValueAsync( newValue ) );
             }
 
             await base.SetParametersAsync( parameters );
@@ -70,7 +75,7 @@ namespace Blazorise.Markdown
                     }
                     else
                     {
-                        ExecuteAfterRender( () => Focus() );
+                        TryExecuteAfterRender( () => Focus() );
                     }
                 }
                 else
@@ -81,76 +86,73 @@ namespace Blazorise.Markdown
         }
 
         /// <inheritdoc/>
-        protected override async Task OnAfterRenderAsync( bool firstRender )
+        protected override async Task OnFirstAfterRenderAsync()
         {
-            await base.OnAfterRenderAsync( firstRender );
+            dotNetObjectRef ??= DotNetObjectReference.Create( this );
 
-            if ( firstRender )
+            await JSModule.Initialize( dotNetObjectRef, ElementRef, ElementId, new
             {
-                dotNetObjectRef ??= DotNetObjectReference.Create( this );
-
-                await JSModule.Initialize( dotNetObjectRef, ElementRef, ElementId, new
+                Value,
+                AutoDownloadFontAwesome,
+                HideIcons,
+                ShowIcons,
+                LineNumbers,
+                LineWrapping,
+                MinHeight,
+                MaxHeight,
+                Placeholder,
+                TabSize,
+                Theme,
+                Direction,
+                Toolbar = Toolbar != null && toolbarButtons?.Count > 0
+                    ? MarkdownActionProvider.Serialize( toolbarButtons )
+                    : null,
+                ToolbarTips,
+                UploadImage,
+                ImageMaxSize,
+                ImageAccept,
+                ImageUploadEndpoint,
+                ImagePathAbsolute,
+                ImageCSRFToken,
+                ImageTexts = ImageTexts == null ? null : new
                 {
-                    Value,
-                    AutoDownloadFontAwesome,
-                    HideIcons,
-                    ShowIcons,
-                    LineNumbers,
-                    LineWrapping,
-                    MinHeight,
-                    MaxHeight,
-                    Placeholder,
-                    TabSize,
-                    Theme,
-                    Direction,
-                    Toolbar = Toolbar != null && toolbarButtons?.Count > 0
-                        ? MarkdownActionProvider.Serialize( toolbarButtons )
-                        : null,
-                    ToolbarTips,
-                    UploadImage,
-                    ImageMaxSize,
-                    ImageAccept,
-                    ImageUploadEndpoint,
-                    ImagePathAbsolute,
-                    ImageCSRFToken,
-                    ImageTexts = ImageTexts == null ? null : new
-                    {
-                        SbInit = ImageTexts.Init,
-                        SbOnDragEnter = ImageTexts.OnDragEnter,
-                        SbOnDrop = ImageTexts.OnDrop,
-                        SbProgress = ImageTexts.Progress,
-                        SbOnUploaded = ImageTexts.OnUploaded,
-                        ImageTexts.SizeUnits,
-                    },
-                    ErrorMessages,
-                    Autofocus,
-                    AutoRefresh,
-                    Autosave,
-                    BlockStyles,
-                    ForceSync,
-                    IndentWithTabs,
-                    InputStyle,
-                    InsertTexts,
-                    NativeSpellcheck,
-                    ParsingConfig,
-                    PreviewClass,
-                    PreviewImagesInEditor,
-                    PromptTexts,
-                    PromptURLs,
-                    RenderingConfig,
-                    ScrollbarStyle,
-                    Shortcuts,
-                    SideBySideFullscreen,
-                    SpellChecker,
-                    Status,
-                    StyleSelectedText,
-                    SyncSideBySidePreviewScroll,
-                    UnorderedListStyle,
-                    ToolbarButtonClassPrefix
-                } );
+                    SbInit = ImageTexts.Init,
+                    SbOnDragEnter = ImageTexts.OnDragEnter,
+                    SbOnDrop = ImageTexts.OnDrop,
+                    SbProgress = ImageTexts.Progress,
+                    SbOnUploaded = ImageTexts.OnUploaded,
+                    ImageTexts.SizeUnits,
+                },
+                ErrorMessages,
+                Autofocus,
+                AutoRefresh,
+                Autosave,
+                BlockStyles,
+                ForceSync,
+                IndentWithTabs,
+                InputStyle,
+                InsertTexts,
+                NativeSpellcheck,
+                ParsingConfig,
+                PreviewClass,
+                PreviewImagesInEditor,
+                PromptTexts,
+                PromptURLs,
+                RenderingConfig,
+                ScrollbarStyle,
+                Shortcuts,
+                SideBySideFullscreen,
+                SpellChecker,
+                Status,
+                StyleSelectedText,
+                SyncSideBySidePreviewScroll,
+                UnorderedListStyle,
+                ToolbarButtonClassPrefix
+            } );
 
-                Initialized = true;
-            }
+            TryPushExecuteAfterRender();
+
+            await base.OnFirstAfterRenderAsync();
         }
 
         /// <inheritdoc/>
@@ -169,16 +171,72 @@ namespace Blazorise.Markdown
             await base.DisposeAsync( disposing );
         }
 
+        protected void TryExecuteAfterRender( Func<Task> action )
+        {
+            // if we have already rendered then just forward the action to the base component
+            if ( Rendered )
+            {
+                ExecuteAfterRender( action );
+
+                return;
+            }
+
+            delayedExecuteAfterRenderQueue ??= new();
+            delayedExecuteAfterRenderQueue.Enqueue( action );
+        }
+
+        protected void TryPushExecuteAfterRender()
+        {
+            if ( delayedExecuteAfterRenderQueue?.Count > 0 )
+            {
+                while ( delayedExecuteAfterRenderQueue.Count > 0 )
+                {
+                    var action = delayedExecuteAfterRenderQueue.Dequeue();
+
+                    ExecuteAfterRender( action );
+                }
+
+                InvokeAsync( StateHasChanged );
+            }
+        }
+
+        /// <summary>
+        /// Executes given action after the rendering is done.
+        /// </summary>
+        /// <remarks>Don't await this on the UI thread, because that will cause a deadlock.</remarks>
+        protected async Task<T> ExecuteAfterRenderAsync<T>( Func<Task<T>> action, CancellationToken token = default )
+        {
+            var source = new TaskCompletionSource<T>();
+
+            token.Register( () => source.TrySetCanceled() );
+
+            TryExecuteAfterRender( async () =>
+            {
+                try
+                {
+                    var result = await action();
+                    source.TrySetResult( result );
+                }
+                catch ( TaskCanceledException )
+                {
+                    source.TrySetCanceled();
+                }
+                catch ( Exception e )
+                {
+                    source.TrySetException( e );
+                }
+            } );
+
+            return await source.Task.ConfigureAwait( false );
+        }
+
         /// <summary>
         /// Gets the markdown value.
         /// </summary>
         /// <returns>Markdown value.</returns>
         public async Task<string> GetValueAsync()
         {
-            if ( !Initialized )
-                return null;
-
-            return await JSModule.GetValue( ElementId );
+            return await ExecuteAfterRenderAsync( async () => await JSModule.GetValue( ElementId ) );
         }
 
         /// <summary>
@@ -188,10 +246,7 @@ namespace Blazorise.Markdown
         /// <returns>A task that represents the asynchronous operation.</returns>
         public async Task SetValueAsync( string value )
         {
-            if ( !Initialized )
-                return;
-
-            await JSModule.SetValue( ElementId, value );
+            await InvokeAsync( () => TryExecuteAfterRender( async () => await JSModule.SetValue( ElementId, value ) ) );
         }
 
         /// <summary>
@@ -367,11 +422,6 @@ namespace Blazorise.Markdown
         /// Gets or sets the <see cref="IJSFileModule"/> instance.
         /// </summary>
         [Inject] public IJSFileModule JSFileModule { get; set; }
-
-        /// <summary>
-        /// Indicates if markdown editor is properly initialized.
-        /// </summary>
-        protected bool Initialized { get; set; }
 
         /// <summary>
         /// Gets or set the javascript runtime.


### PR DESCRIPTION
Closes #4084

Added the same lifecycle logic as in #4315. We're postponing `ExecuteAfterRender` after the component is fully rendered and initialized and then forwarding it all to execution.

PS. we can consider implementing the same logic in a centralized way so that it can be reused by other components. We need to do this in `master.`