### PR TITLE
Support for row overlay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -243,6 +243,9 @@ ModelManifest.xml
 # FAKE - F# Make
 .fake/
 
+# CodeRush personal settings
+.cr/personal
+
 # jekyll
 _site
 Gemfile.lock

--- a/Source/Blazorise/Components/Table/TableRow.razor
+++ b/Source/Blazorise/Components/Table/TableRow.razor
@@ -2,6 +2,8 @@
 @inherits BaseDraggableComponent
 <tr id="@ElementId" class="@ClassNames" style="@StyleNames" @onclick="@OnClickHandler"
     draggable="@DraggableString"
+    @onmouseover="@OnMouseOverHandler"
+    @onmouseleave="@OnMouseLeaveHandler"
     @ondrag="@OnDragHandler"
     @ondrag:preventDefault="@DragPreventDefault"
     @ondragend="@OnDragEndHandler"

--- a/Source/Blazorise/Components/Table/TableRow.razor.cs
+++ b/Source/Blazorise/Components/Table/TableRow.razor.cs
@@ -52,6 +52,26 @@ namespace Blazorise
             return Task.CompletedTask;
         }
 
+        /// <summary>
+        /// Handles the row mouse leave event.
+        /// </summary>
+        /// <param name="eventArgs">Supplies information about a mouse event that is being raised.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        protected Task OnMouseLeaveHandler(MouseEventArgs eventArgs )
+        {
+            return MouseLeave.InvokeAsync( EventArgsMapper.ToMouseEventArgs( eventArgs ) );
+        }
+
+        /// <summary>
+        /// Handles the row mouseover event.
+        /// </summary>
+        /// <param name="eventArgs">Supplies information about a mouse event that is being raised.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        protected Task OnMouseOverHandler(MouseEventArgs eventArgs )
+        {
+            return MouseOver.InvokeAsync( EventArgsMapper.ToMouseEventArgs( eventArgs ) );
+        }
+
         #endregion
 
         #region Properties
@@ -110,6 +130,16 @@ namespace Blazorise
         /// Occurs when the row is double clicked.
         /// </summary>
         [Parameter] public EventCallback<BLMouseEventArgs> DoubleClicked { get; set; }
+
+        /// <summary>
+        /// Occurs when the row is mouse overed.
+        /// </summary>
+        [Parameter] public EventCallback<BLMouseEventArgs> MouseOver { get; set; }
+
+        /// <summary>
+        /// Occurs when the row is mouse leaved.
+        /// </summary>
+        [Parameter] public EventCallback<BLMouseEventArgs> MouseLeave { get; set; }
 
         /// <summary>
         /// Specifies the content to be rendered inside this <see cref="TableRow"/>.

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Blazorise.DataGrid.Enums;
 using Blazorise.DataGrid.Models;
 using Blazorise.DataGrid.Utils;
 using Blazorise.Extensions;
@@ -825,6 +826,15 @@ namespace Blazorise.DataGrid
             }
         }
 
+        internal Task OnRowOverCommand( DataGridRowMouseEventArgs<TItem> eventArgs )
+        {
+            return RowOver.InvokeAsync( eventArgs );
+        }
+        internal Task OnRowLeaveCommand( DataGridRowMouseEventArgs<TItem> eventArgs )
+        {
+            return RowLeave.InvokeAsync( eventArgs );
+        }
+
         internal Task OnRowClickedCommand( DataGridRowMouseEventArgs<TItem> eventArgs )
         {
             return RowClicked.InvokeAsync( eventArgs );
@@ -1313,6 +1323,13 @@ namespace Blazorise.DataGrid
         #endregion
 
         #region Properties
+
+        /// <summary>
+        /// Template for mouse hover overlay display formatting.
+        /// </summary>
+        [Parameter] public RenderFragment<TItem> RowOverlayTemplate { get; set; }
+
+        [Parameter] public RowOverlayPosition RowOverlayPosition { get; set; } = RowOverlayPosition.End;
 
 
         /// <summary>
@@ -1870,6 +1887,16 @@ namespace Blazorise.DataGrid
         /// </summary>
         [Parameter] public EventCallback<TItem> RowRemoved { get; set; }
 
+
+        /// <summary>
+        /// Event called after the mouse leaves the row.
+        /// </summary>
+        [Parameter] public EventCallback<DataGridRowMouseEventArgs<TItem>> RowLeave { get; set; }
+
+        /// <summary>
+        /// Event called after the mouse is over the row.
+        /// </summary>
+        [Parameter] public EventCallback<DataGridRowMouseEventArgs<TItem>> RowOver { get; set; }
         /// <summary>
         /// Event called after the row is clicked.
         /// </summary>

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridRow.razor
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridRow.razor
@@ -14,6 +14,8 @@
     }
 
     <TableRow Clicked="@HandleClick"
+              MouseOver="HandleMouseOver"
+              MouseLeave="HandleMouseLeave"
               DoubleClicked="@HandleDoubleClick"
               ContextMenu="@HandleContextMenu"
               ContextMenuPreventDefault="@ParentDataGrid.RowContextMenuPreventDefault"
@@ -64,6 +66,20 @@
                     }
                 </TableRowCell>
             }
+        }        
+        @if (ParentDataGrid.RowOverlayTemplate != null && mouseIsOver)
+        {
+            IFluentPositionEdgeOffset pos = Position.Absolute.End;
+            if (ParentDataGrid.RowOverlayPosition == Enums.RowOverlayPosition.Start)
+            {
+                pos = Position.Absolute.Start;
+            }
+            <TableRowCell Margin="Margin.Is0" Padding="Padding.Is0" Style="width:0px" Overflow="Overflow.Visible">
+                <Div Position="@pos" Margin="Margin.Is0" Padding="Padding.Is0" >
+                        @ParentDataGrid.RowOverlayTemplate(Item)
+                </Div>
+            </TableRowCell>
         }
+
     </TableRow>
 }

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridRow.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridRow.razor.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Blazorise.DataGrid.Models;
 using Blazorise.Extensions;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 #endregion
 
 namespace Blazorise.DataGrid
@@ -13,7 +14,7 @@ namespace Blazorise.DataGrid
     public abstract class _BaseDataGridRow<TItem> : BaseDataGridComponent
     {
         #region Members
-
+        protected bool mouseIsOver = false;
         /// <summary>
         /// List of columns used to build this row.
         /// </summary>
@@ -106,6 +107,16 @@ namespace Blazorise.DataGrid
             return base.OnAfterRenderAsync( firstRender );
         }
 
+        protected internal async Task HandleMouseLeave( BLMouseEventArgs eventArgs )
+        {
+            mouseIsOver = false;
+            await ParentDataGrid.OnRowLeaveCommand( new( Item, eventArgs ) );
+        }
+        protected internal async Task HandleMouseOver( BLMouseEventArgs eventArgs )
+        {
+            mouseIsOver = true;
+            await ParentDataGrid.OnRowOverCommand( new( Item, eventArgs ) );
+        }
         protected internal async Task HandleClick( BLMouseEventArgs eventArgs )
         {
             if ( !clickFromMultiSelectCheck )


### PR DESCRIPTION
Adds 2 new event callback to datagrid, and a feature to display an overlay when the mouse is over the row.

New Parameter RowOver of type EventCallback<DataGridRowMouseEventArgs<TItem>>
This is called when the mouse is over the row.

New Parameter RowLeave of type EventCallback<DataGridRowMouseEventArgs<TItem>>
This is called when the mouse leaves a row.

These are useful anyway, but used mainly to facilitate the row overlay feature.

New Parameter OverlayTemplate of type RenderFragment<TItem>.

This render fragment can be used to display additional information about the row item when the mouse is over the row. The content of the fragment is displayed over the top of the current row and is right aligned.

```
<DataGrid TItem="sometype">
                       <OverlayTemplate>
                            <Div Flex="Flex.JustifyContent.End.AlignItems.Center" Margin="Margin.Is3.FromBottom" Style="width:400px;background-color:white;">
                                <Div Padding="Padding.Is2">
                                    <Button Size="Size.Small" Color="Color.Secondary" onclick="event.stopPropagation();">Ack</Button>
                                </Div>
                                <Div Padding="Padding.Is2">
                                    <Button Size="Size.Small" Color="Color.Secondary" onclick="event.stopPropagation();">Close</Button>
                                </Div>
                                <Div Padding="Padding.Is2" @onclick:stopPropagation="true" Overflow="Overflow.Visible">
                                    <Dropdown Style="z-index:2000;">
                                        <DropdownToggle Size="Size.Small" Clicked="ToggleClicked">
                                            ...
                                        </DropdownToggle>
                                        <DropdownMenu>
                                            <DropdownItem>Add responder</DropdownItem>
                                            <DropdownItem>Delete</DropdownItem>
                                        </DropdownMenu>
                                    </Dropdown>
                                </Div>
                            </Div>
                        </OverlayTemplate>
</DataGrid>
```

The DataGrid only displays this fragment when an OverlayTemplate is present and the mouse is over a row. 
The fragment is removed when the mouse leaves the row.


