### PR TITLE
Implement delayed execution in BaseAfterRenderComponent

### DIFF
--- a/Build/Blazorise.Demo.props
+++ b/Build/Blazorise.Demo.props
@@ -19,6 +19,7 @@
 		<PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
 		<PackageReference Include="FluentValidation" Version="11.2.0" />
 		<PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.2.0" />
+		<PackageReference Include="Flurl.Http" Version="4.0.0-pre2" />
 	</ItemGroup>
 	
 </Project>

--- a/Demos/Blazorise.Demo.Bootstrap.Server/Controllers/WeatherForecastController.cs
+++ b/Demos/Blazorise.Demo.Bootstrap.Server/Controllers/WeatherForecastController.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Threading.Tasks;
+using Blazorise.Shared.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Blazorise.Demo.Bootstrap.Server.Controllers;
+
+[Route( "weatherforecast" )]
+[ApiController]
+public class WeatherForecastController : ControllerBase
+{
+    private static readonly string[] Summaries = new[]
+    {
+        "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+    };
+
+    private static readonly Random Rand = new Random();
+
+    [HttpGet]
+    [Route( "getforecast" )]
+    public Task<WeatherForecast> GetForecast()
+    {
+        return Task.FromResult( new WeatherForecast
+        {
+            Date = DateTime.Now,
+            TemperatureC = Rand.Next( -20, 55 ),
+            Summary = Summaries[Rand.Next( Summaries.Length )]
+        } );
+    }
+}

--- a/Demos/Blazorise.Demo.Bootstrap.Server/Startup.cs
+++ b/Demos/Blazorise.Demo.Bootstrap.Server/Startup.cs
@@ -59,6 +59,7 @@ namespace Blazorise.Demo.Bootstrap.Server
 
             app.UseEndpoints( endpoints =>
             {
+                endpoints.MapControllers();
                 endpoints.MapBlazorHub();
                 endpoints.MapFallbackToPage( "/_Host" );
             } );

--- a/Shared/Blazorise.Shared/Models/WeatherForecast.cs
+++ b/Shared/Blazorise.Shared/Models/WeatherForecast.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Text.Json.Serialization;
+
+namespace Blazorise.Shared.Models;
+
+public class WeatherForecast
+{
+    [JsonPropertyName( "date" )]
+    public DateTime Date { get; set; }
+
+    [JsonPropertyName( "temperatureC" )]
+    public int TemperatureC { get; set; }
+
+    [JsonPropertyName( "summary" )]
+    public string Summary { get; set; }
+}

--- a/Source/Blazorise/Base/BaseAfterRenderComponent.cs
+++ b/Source/Blazorise/Base/BaseAfterRenderComponent.cs
@@ -34,7 +34,7 @@ namespace Blazorise
         /// <param name="action"></param>
         protected void ExecuteAfterRender( Func<Task> action )
         {
-            if ( ShouldDelayExecution && !Rendered )
+            if ( !Rendered )
             {
                 delayedExecuteAfterRenderQueue ??= new();
                 delayedExecuteAfterRenderQueue.Enqueue( action );
@@ -179,11 +179,6 @@ namespace Blazorise
         /// Indicates if component has been rendered in the browser.
         /// </summary>
         protected bool Rendered { get; private set; }
-
-        /// <summary>
-        /// Indicates if we should wait until the component is fully initialized until we execute methods.
-        /// </summary>
-        protected virtual bool ShouldDelayExecution => false;
 
         /// <summary>
         /// Service that frees the component from the memory.

--- a/Source/Blazorise/Base/BaseAfterRenderComponent.cs
+++ b/Source/Blazorise/Base/BaseAfterRenderComponent.cs
@@ -72,13 +72,13 @@ namespace Blazorise
             {
                 await OnFirstAfterRenderAsync();
 
+                Rendered = true;
+
                 if ( PushDelayedExecuteAfterRender() )
                 {
                     await InvokeAsync( StateHasChanged );
                 }
             }
-
-            Rendered = true;
 
             if ( executeAfterRenderQueue?.Count > 0 )
             {

--- a/Source/Blazorise/Base/BaseComponent.cs
+++ b/Source/Blazorise/Base/BaseComponent.cs
@@ -126,24 +126,6 @@ namespace Blazorise
         }
 
         /// <inheritdoc/>
-        protected override async Task OnAfterRenderAsync( bool firstRender )
-        {
-            if ( firstRender )
-            {
-                await OnFirstAfterRenderAsync();
-            }
-
-            await base.OnAfterRenderAsync( firstRender );
-        }
-
-        /// <summary>
-        /// Method is called only once when component is first rendered.
-        /// </summary>
-        /// <returns>A task that represents the asynchronous operation.</returns>
-        protected virtual Task OnFirstAfterRenderAsync()
-            => Task.CompletedTask;
-
-        /// <inheritdoc/>
         protected override void Dispose( bool disposing )
         {
             if ( disposing )

--- a/Source/Blazorise/Components/NumericPicker/NumericPicker.razor.cs
+++ b/Source/Blazorise/Components/NumericPicker/NumericPicker.razor.cs
@@ -459,9 +459,6 @@ namespace Blazorise
         protected override bool ShouldAutoGenerateId => true;
 
         /// <inheritdoc/>
-        protected override bool ShouldDelayExecution => true;
-
-        /// <inheritdoc/>
         protected override TValue InternalValue { get => Value; set => Value = value; }
 
         /// <summary>

--- a/Source/Blazorise/Components/NumericPicker/NumericPicker.razor.cs
+++ b/Source/Blazorise/Components/NumericPicker/NumericPicker.razor.cs
@@ -58,11 +58,6 @@ namespace Blazorise
         /// </summary>
         private string inputMode;
 
-        /// <summary>
-        /// Indicates if the component is still initializing.
-        /// </summary>
-        private bool initializing = true;
-
         #endregion
 
         #region Constructors
@@ -140,14 +135,11 @@ namespace Blazorise
                 }
             }
 
-            if ( Rendered || initializing )
-            {
-                var valueChanged = parameters.TryGetValue<TValue>( nameof( Value ), out var paramValue ) && !Value.IsEqual( paramValue );
+            var valueChanged = parameters.TryGetValue<TValue>( nameof( Value ), out var paramValue ) && !Value.IsEqual( paramValue );
 
-                if ( valueChanged )
-                {
-                    ExecuteAfterRender( async () => await JSModule.UpdateValue( ElementRef, ElementId, paramValue ) );
-                }
+            if ( valueChanged )
+            {
+                ExecuteAfterRender( async () => await JSModule.UpdateValue( ElementRef, ElementId, paramValue ) );
             }
 
             // This make sure we know that Min or Max parameters are defined and can be checked against the current value.
@@ -210,8 +202,6 @@ namespace Blazorise
                 ModifyValueOnWheel,
                 WheelOn = WheelOn.ToNumericWheelOn(),
             } );
-
-            initializing = false;
 
             await base.OnFirstAfterRenderAsync();
         }

--- a/Source/Blazorise/Components/NumericPicker/NumericPicker.razor.cs
+++ b/Source/Blazorise/Components/NumericPicker/NumericPicker.razor.cs
@@ -469,6 +469,9 @@ namespace Blazorise
         protected override bool ShouldAutoGenerateId => true;
 
         /// <inheritdoc/>
+        protected override bool ShouldDelayExecution => true;
+
+        /// <inheritdoc/>
         protected override TValue InternalValue { get => Value; set => Value = value; }
 
         /// <summary>

--- a/Source/Blazorise/Components/NumericPicker/NumericPicker.razor.cs
+++ b/Source/Blazorise/Components/NumericPicker/NumericPicker.razor.cs
@@ -213,8 +213,6 @@ namespace Blazorise
 
             initializing = false;
 
-            //PushDelayedExecuteAfterRender();
-
             await base.OnFirstAfterRenderAsync();
         }
 

--- a/Source/Extensions/Blazorise.Markdown/Markdown.razor.cs
+++ b/Source/Extensions/Blazorise.Markdown/Markdown.razor.cs
@@ -377,6 +377,9 @@ namespace Blazorise.Markdown
         /// <inheritdoc/>
         protected override bool ShouldAutoGenerateId => true;
 
+        /// <inheritdoc/>
+        protected override bool ShouldDelayExecution => true;
+
         /// <summary>
         /// Gets or sets the <see cref="JSMarkdownModule"/> instance.
         /// </summary>

--- a/Source/Extensions/Blazorise.Markdown/Markdown.razor.cs
+++ b/Source/Extensions/Blazorise.Markdown/Markdown.razor.cs
@@ -377,9 +377,6 @@ namespace Blazorise.Markdown
         /// <inheritdoc/>
         protected override bool ShouldAutoGenerateId => true;
 
-        /// <inheritdoc/>
-        protected override bool ShouldDelayExecution => true;
-
         /// <summary>
         /// Gets or sets the <see cref="JSMarkdownModule"/> instance.
         /// </summary>

--- a/Source/Extensions/Blazorise.Markdown/Markdown.razor.cs
+++ b/Source/Extensions/Blazorise.Markdown/Markdown.razor.cs
@@ -33,11 +33,6 @@ namespace Blazorise.Markdown
         /// </summary>
         private bool autofocus;
 
-        /// <summary>
-        /// A stack of functions to execute after the rendering.
-        /// </summary>
-        private Queue<Func<Task>> delayedExecuteAfterRenderQueue;
-
         #endregion
 
         #region Methods
@@ -57,7 +52,7 @@ namespace Blazorise.Markdown
         {
             if ( Rendered && parameters.TryGetValue<string>( nameof( Value ), out var newValue ) && newValue != Value )
             {
-                TryExecuteAfterRender( () => SetValueAsync( newValue ) );
+                ExecuteAfterRender( () => SetValueAsync( newValue ) );
             }
 
             await base.SetParametersAsync( parameters );
@@ -75,7 +70,7 @@ namespace Blazorise.Markdown
                     }
                     else
                     {
-                        TryExecuteAfterRender( () => Focus() );
+                        ExecuteAfterRender( () => Focus() );
                     }
                 }
                 else
@@ -150,7 +145,7 @@ namespace Blazorise.Markdown
                 ToolbarButtonClassPrefix
             } );
 
-            TryPushExecuteAfterRender();
+            //PushDelayedExecuteAfterRender();
 
             await base.OnFirstAfterRenderAsync();
         }
@@ -171,35 +166,6 @@ namespace Blazorise.Markdown
             await base.DisposeAsync( disposing );
         }
 
-        protected void TryExecuteAfterRender( Func<Task> action )
-        {
-            // if we have already rendered then just forward the action to the base component
-            if ( Rendered )
-            {
-                ExecuteAfterRender( action );
-
-                return;
-            }
-
-            delayedExecuteAfterRenderQueue ??= new();
-            delayedExecuteAfterRenderQueue.Enqueue( action );
-        }
-
-        protected void TryPushExecuteAfterRender()
-        {
-            if ( delayedExecuteAfterRenderQueue?.Count > 0 )
-            {
-                while ( delayedExecuteAfterRenderQueue.Count > 0 )
-                {
-                    var action = delayedExecuteAfterRenderQueue.Dequeue();
-
-                    ExecuteAfterRender( action );
-                }
-
-                InvokeAsync( StateHasChanged );
-            }
-        }
-
         /// <summary>
         /// Executes given action after the rendering is done.
         /// </summary>
@@ -210,7 +176,7 @@ namespace Blazorise.Markdown
 
             token.Register( () => source.TrySetCanceled() );
 
-            TryExecuteAfterRender( async () =>
+            ExecuteAfterRender( async () =>
             {
                 try
                 {
@@ -246,7 +212,7 @@ namespace Blazorise.Markdown
         /// <returns>A task that represents the asynchronous operation.</returns>
         public async Task SetValueAsync( string value )
         {
-            await InvokeAsync( () => TryExecuteAfterRender( async () => await JSModule.SetValue( ElementId, value ) ) );
+            await InvokeAsync( () => ExecuteAfterRender( async () => await JSModule.SetValue( ElementId, value ) ) );
         }
 
         /// <summary>

--- a/Source/Extensions/Blazorise.Markdown/Markdown.razor.cs
+++ b/Source/Extensions/Blazorise.Markdown/Markdown.razor.cs
@@ -145,8 +145,6 @@ namespace Blazorise.Markdown
                 ToolbarButtonClassPrefix
             } );
 
-            //PushDelayedExecuteAfterRender();
-
             await base.OnFirstAfterRenderAsync();
         }
 

--- a/Source/Extensions/Blazorise.RichTextEdit/BaseRichTextEditComponent.cs
+++ b/Source/Extensions/Blazorise.RichTextEdit/BaseRichTextEditComponent.cs
@@ -12,15 +12,6 @@ namespace Blazorise.RichTextEdit
     /// </summary>
     public class BaseRichTextEditComponent : BaseComponent
     {
-        #region Members
-
-        /// <summary>
-        /// A stack of functions to execute after the rendering.
-        /// </summary>
-        private Queue<Func<Task>> delayedExecuteAfterRenderQueue;
-
-        #endregion
-
         #region Constructors
 
         /// <summary>
@@ -32,35 +23,6 @@ namespace Blazorise.RichTextEdit
 
         #region Methods
 
-        protected void TryExecuteAfterRender( Func<Task> action )
-        {
-            // if we have already rendered then just forward the action to the base component
-            if ( Rendered )
-            {
-                ExecuteAfterRender( action );
-
-                return;
-            }
-
-            delayedExecuteAfterRenderQueue ??= new();
-            delayedExecuteAfterRenderQueue.Enqueue( action );
-        }
-
-        protected void TryPushExecuteAfterRender()
-        {
-            if ( delayedExecuteAfterRenderQueue?.Count > 0 )
-            {
-                while ( delayedExecuteAfterRenderQueue.Count > 0 )
-                {
-                    var action = delayedExecuteAfterRenderQueue.Dequeue();
-
-                    ExecuteAfterRender( action );
-                }
-
-                InvokeAsync( StateHasChanged );
-            }
-        }
-
         /// <summary>
         /// Executes given action after the rendering is done.
         /// </summary>
@@ -71,7 +33,7 @@ namespace Blazorise.RichTextEdit
 
             token.Register( () => source.TrySetCanceled() );
 
-            TryExecuteAfterRender( async () =>
+            ExecuteAfterRender( async () =>
             {
                 try
                 {

--- a/Source/Extensions/Blazorise.RichTextEdit/RichTextEdit.razor.cs
+++ b/Source/Extensions/Blazorise.RichTextEdit/RichTextEdit.razor.cs
@@ -50,7 +50,9 @@ namespace Blazorise.RichTextEdit
                 await OnContentChanged();
             }
 
-            TryPushExecuteAfterRender();
+            //PushDelayedExecuteAfterRender();
+
+            await base.OnFirstAfterRenderAsync();
         }
 
         /// <summary>
@@ -58,7 +60,7 @@ namespace Blazorise.RichTextEdit
         /// </summary>
         public async ValueTask SetHtmlAsync( string html )
         {
-            await InvokeAsync( () => TryExecuteAfterRender( async () => await JSModule.SetHtmlAsync( EditorRef, html ) ) );
+            await InvokeAsync( () => ExecuteAfterRender( async () => await JSModule.SetHtmlAsync( EditorRef, html ) ) );
         }
 
         /// <summary>
@@ -75,7 +77,7 @@ namespace Blazorise.RichTextEdit
         /// <seealso href="https://quilljs.com/docs/delta/"/>
         public async ValueTask SetDeltaAsync( string deltaJson )
         {
-            await InvokeAsync( () => TryExecuteAfterRender( async () => await JSModule.SetDeltaAsync( EditorRef, deltaJson ) ) );
+            await InvokeAsync( () => ExecuteAfterRender( async () => await JSModule.SetDeltaAsync( EditorRef, deltaJson ) ) );
         }
 
         /// <summary>
@@ -92,7 +94,7 @@ namespace Blazorise.RichTextEdit
         /// </summary>
         public async ValueTask SetTextAsync( string text )
         {
-            await InvokeAsync( () => TryExecuteAfterRender( async () => await JSModule.SetTextAsync( EditorRef, text ) ) );
+            await InvokeAsync( () => ExecuteAfterRender( async () => await JSModule.SetTextAsync( EditorRef, text ) ) );
         }
 
         /// <summary>
@@ -109,7 +111,7 @@ namespace Blazorise.RichTextEdit
         /// </summary>
         public async ValueTask ClearAsync()
         {
-            await InvokeAsync( () => TryExecuteAfterRender( async () =>
+            await InvokeAsync( () => ExecuteAfterRender( async () =>
             {
                 await JSModule.ClearAsync( EditorRef );
                 await OnContentChanged();
@@ -145,12 +147,15 @@ namespace Blazorise.RichTextEdit
         /// </summary>
         private async Task SetReadOnly( bool value )
         {
-            await InvokeAsync( () => TryExecuteAfterRender( async () => await JSModule.SetReadOnly( EditorRef, value ) ) );
+            await InvokeAsync( () => ExecuteAfterRender( async () => await JSModule.SetReadOnly( EditorRef, value ) ) );
         }
 
         #endregion
 
         #region Properties
+
+        /// <inheritdoc/>
+        protected override bool ShouldDelayExecution => true;
 
         /// <summary>
         /// Gets or sets the <see cref="JSRichTextEditModule"/> instance.

--- a/Source/Extensions/Blazorise.RichTextEdit/RichTextEdit.razor.cs
+++ b/Source/Extensions/Blazorise.RichTextEdit/RichTextEdit.razor.cs
@@ -152,9 +152,6 @@ namespace Blazorise.RichTextEdit
 
         #region Properties
 
-        /// <inheritdoc/>
-        protected override bool ShouldDelayExecution => true;
-
         /// <summary>
         /// Gets or sets the <see cref="JSRichTextEditModule"/> instance.
         /// </summary>

--- a/Source/Extensions/Blazorise.RichTextEdit/RichTextEdit.razor.cs
+++ b/Source/Extensions/Blazorise.RichTextEdit/RichTextEdit.razor.cs
@@ -50,8 +50,6 @@ namespace Blazorise.RichTextEdit
                 await OnContentChanged();
             }
 
-            //PushDelayedExecuteAfterRender();
-
             await base.OnFirstAfterRenderAsync();
         }
 


### PR DESCRIPTION
**Test for #4075** 

This test can be run only on Blazorise.Demo.Bootstrap.Server because it only has the controller with the endpoint `weatherforecast/getforecast"`.

```razor
@using Flurl;
@using Flurl.Http;
@using System.Text.Json.Serialization;

<Row>
    <Column>
        <Field>
            <NumericPicker Decimals="0" SelectAllOnFocus="true" @bind-Value="@Forecast.TemperatureC" />
        </Field>
    </Column>
</Row>


@code {
    [Inject] NavigationManager NavMgr { get; set; }

    private WeatherForecast Forecast = new();

    protected override async Task OnAfterRenderAsync( bool firstRender )
    {
        await base.OnAfterRenderAsync( firstRender );

        if ( firstRender )
        {
            Forecast = await NavMgr.BaseUri.AppendPathSegment( "weatherforecast/getforecast" ).GetJsonAsync<WeatherForecast>();
            await InvokeAsync( StateHasChanged );
        }
    }
}
```

---

**Test for #4114**

```razor
<Row>
    <Column>
        <RichTextEdit @ref="editor" Theme="RichTextEditTheme.Snow" />
    </Column>
</Row>

@code {
    private RichTextEdit editor;

    private string html = "Hello world.";
    private bool isSet;

    protected override async Task OnAfterRenderAsync( bool firstRender )
    {
        if ( !isSet && editor != null )
        {
            isSet = true;

            await editor.SetHtmlAsync( html );
            StateHasChanged();
        }

        await base.OnAfterRenderAsync( firstRender );
    }
}
```