### PR TITLE
DataGrid: Virtualize fixes and optimizations

### DIFF
--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor
@@ -59,7 +59,7 @@
                                         {
                                             @column.SortDirectionTemplate( column.CurrentSortDirection )
                                         }
-                                        else 
+                                        else
                                         {
                                             if ( column.CurrentSortDirection == SortDirection.Default && ShowDefaultSortIcon )
                                             {
@@ -144,7 +144,7 @@
                             </ChildContent>
                             <Placeholder>
                                 <_DataGridFullColumnSpanRow TItem="TItem" Columns="@Columns">
-                                    @LoadingTemplate
+                                    &nbsp;@LoadingTemplate
                                 </_DataGridFullColumnSpanRow>
                             </Placeholder>
                         </Virtualize>
@@ -157,7 +157,7 @@
                             </ChildContent>
                             <Placeholder>
                                 <_DataGridFullColumnSpanRow TItem="TItem" Columns="@Columns">
-                                    @LoadingTemplate
+                                    &nbsp;@LoadingTemplate
                                 </_DataGridFullColumnSpanRow>
                             </Placeholder>
                         </Virtualize>

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -252,7 +252,7 @@ namespace Blazorise.DataGrid
                 await JSModule.Initialize( tableRef.ElementRef, ElementId );
                 paginationContext.SubscribeOnPageSizeChanged( OnPageSizeChanged );
                 paginationContext.SubscribeOnPageChanged( OnPageChanged );
-                
+
                 if ( Theme is not null )
                 {
                     Theme.Changed += OnThemeChanged;
@@ -1078,7 +1078,8 @@ namespace Blazorise.DataGrid
             // Debounce the requests. This eliminates a lot of redundant queries at the cost of slight lag after interactions.
             // TODO: Consider making this configurable, or smarter (e.g., doesn't delay on first call in a batch, then the amount
             // of delay increases if you rapidly issue repeated requests, such as when scrolling a long way)
-            await Task.Delay(100);
+            await Task.Delay( 100 );
+
             if ( request.CancellationToken.IsCancellationRequested )
                 return default;
 

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -1074,6 +1074,14 @@ namespace Blazorise.DataGrid
 
         protected async ValueTask<ItemsProviderResult<TItem>> VirtualizeItemsProviderHandler( ItemsProviderRequest request )
         {
+            // Credit to Steve Sanderson's Quickgrid implementation
+            // Debounce the requests. This eliminates a lot of redundant queries at the cost of slight lag after interactions.
+            // TODO: Consider making this configurable, or smarter (e.g., doesn't delay on first call in a batch, then the amount
+            // of delay increases if you rapidly issue repeated requests, such as when scrolling a long way)
+            await Task.Delay(100);
+            if ( request.CancellationToken.IsCancellationRequested )
+                return default;
+
             var requestCount = request.StartIndex > 0
                 ? Math.Min( request.Count, TotalItems.Value - request.StartIndex )
                 : request.Count;
@@ -1082,7 +1090,7 @@ namespace Blazorise.DataGrid
             await Task.Yield(); // This line makes sure SetParametersAsync catches up, since we depend upon Data Parameter.
 
             if ( request.CancellationToken.IsCancellationRequested )
-                return new();
+                return default;
             else
                 return new( Data.ToList(), TotalItems.Value );
         }

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridFullColumnSpanRow.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridFullColumnSpanRow.razor.cs
@@ -10,6 +10,9 @@ namespace Blazorise.DataGrid
     {
         #region Properties
 
+        protected override bool ShouldRender()
+            => false;
+
         protected bool HasCommandColumn
             => Columns.Any( x => x.ColumnType == DataGridColumnType.Command );
 


### PR DESCRIPTION
Closes #4289
Closes #4280

Problem:
- Virtualize + ReadData would get jumpy or just act all weird and doing alot of requests, specially when navigating further down the table.

Solution:
- The placeholder for the rows would be half the size the actual rows, messing up the Virtualize calculations, so we've inserted a blank space so it can calculate the same space, this seems like a fine solution I would say.

Additionally implemented the same delay as in Quickgrid's as it removes redudants calls. Copied same note, as the suggestion seems implementation worthy.
`Virtualize` seems smoother with the changes, specially on Blazor.Server.