### PR TITLE
NumericPicker: check for large number values

### DIFF
--- a/Source/Blazorise/Components/NumericPicker/NumericPicker.razor.cs
+++ b/Source/Blazorise/Components/NumericPicker/NumericPicker.razor.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq.Expressions;
+using System.Numerics;
 using System.Threading;
 using System.Threading.Tasks;
 using Blazorise.Extensions;
@@ -292,6 +293,10 @@ namespace Blazorise
             if ( Converters.TryChangeType<TValue>( value, out var result, CurrentCultureInfo ) )
             {
                 return Task.FromResult( new ParseValue<TValue>( true, result, null ) );
+            }
+            else if ( Converters.TryParseAndLimitLargeNumber<TValue>( value, out var result2, CurrentCultureInfo ) )
+            {
+                return Task.FromResult( new ParseValue<TValue>( true, result2, null ) );
             }
             else
             {

--- a/Source/Blazorise/Utilities/Converters.cs
+++ b/Source/Blazorise/Utilities/Converters.cs
@@ -177,7 +177,7 @@ namespace Blazorise.Utilities
         }
 
         /// <summary>
-        /// Tries to parse a large string repesenting a number and returns an object of the specified type and whose value is equivalent to the specified object.
+        /// Tries to parse a large string representing a number and returns an object of the specified type and whose value is equivalent to the specified object.
         /// </summary>
         /// <typeparam name="TValue">The type of object to return.</typeparam>
         /// <param name="value">The numeric string representation.</param>

--- a/Source/Blazorise/Utilities/Converters.cs
+++ b/Source/Blazorise/Utilities/Converters.cs
@@ -180,15 +180,15 @@ namespace Blazorise.Utilities
         /// Tries to parse a large string repesenting a number and returns an object of the specified type and whose value is equivalent to the specified object.
         /// </summary>
         /// <typeparam name="TValue">The type of object to return.</typeparam>
-        /// <param name="value">An object that implements the <see cref="IConvertible"/> interface.</param>
+        /// <param name="value">The numeric string representation.</param>
         /// <param name="result">New instance of object whose value is equivalent to the specified object.</param>
         /// <param name="cultureInfo">Culture info to use for conversion.</param>
         /// <returns>True if conversion was successful.</returns>
-        public static bool TryParseAndLimitLargeNumber<TValue>( object value, out TValue result, CultureInfo cultureInfo = null )
+        public static bool TryParseAndLimitLargeNumber<TValue>( string value, out TValue result, CultureInfo cultureInfo = null )
         {
             try
             {
-                if ( BigInteger.TryParse( value?.ToString(), NumberStyles.AllowLeadingSign | NumberStyles.AllowDecimalPoint, cultureInfo ?? CultureInfo.InvariantCulture, out var bigNumber ) )
+                if ( BigInteger.TryParse( value, NumberStyles.AllowLeadingSign | NumberStyles.AllowDecimalPoint, cultureInfo ?? CultureInfo.InvariantCulture, out var bigNumber ) )
                 {
                     Type conversionType = Nullable.GetUnderlyingType( typeof( TValue ) ) ?? typeof( TValue );
 

--- a/Source/Blazorise/Utilities/Converters.cs
+++ b/Source/Blazorise/Utilities/Converters.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Numerics;
 using System.Runtime.Serialization;
 using Blazorise.Extensions;
 #endregion
@@ -167,6 +168,51 @@ namespace Blazorise.Utilities
                     result = (TValue)Convert.ChangeType( value, conversionType, cultureInfo ?? CultureInfo.InvariantCulture );
 
                 return true;
+            }
+            catch
+            {
+                result = default;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Tries to parse a large string repesenting a numberm and returns an object of the specified type and whose value is equivalent to the specified object.
+        /// </summary>
+        /// <typeparam name="TValue">The type of object to return.</typeparam>
+        /// <param name="value">An object that implements the <see cref="IConvertible"/> interface.</param>
+        /// <param name="result">New instance of object whose value is equivalent to the specified object.</param>
+        /// <param name="cultureInfo">Culture info to use for conversion.</param>
+        /// <returns>True if conversion was successful.</returns>
+        public static bool TryParseAndLimitLargeNumber<TValue>( object value, out TValue result, CultureInfo cultureInfo = null )
+        {
+            try
+            {
+                if ( BigInteger.TryParse( value?.ToString(), NumberStyles.AllowLeadingSign | NumberStyles.AllowDecimalPoint, cultureInfo ?? CultureInfo.InvariantCulture, out var bigNumber ) )
+                {
+                    Type conversionType = Nullable.GetUnderlyingType( typeof( TValue ) ) ?? typeof( TValue );
+
+                    result = conversionType switch
+                    {
+                        Type byteType when byteType == typeof( byte ) || byteType == typeof( byte? ) => bigNumber > byte.MaxValue ? (TValue)(object)byte.MaxValue : bigNumber < byte.MinValue ? (TValue)(object)byte.MinValue : (TValue)(object)bigNumber,
+                        Type shortType when shortType == typeof( short ) || shortType == typeof( short? ) => bigNumber > short.MaxValue ? (TValue)(object)short.MaxValue : bigNumber < short.MinValue ? (TValue)(object)short.MinValue : (TValue)(object)bigNumber,
+                        Type intType when intType == typeof( int ) || intType == typeof( int? ) => bigNumber > int.MaxValue ? (TValue)(object)int.MaxValue : bigNumber < int.MinValue ? (TValue)(object)int.MinValue : (TValue)(object)bigNumber,
+                        Type longType when longType == typeof( long ) || longType == typeof( long? ) => bigNumber > long.MaxValue ? (TValue)(object)long.MaxValue : bigNumber < long.MinValue ? (TValue)(object)long.MinValue : (TValue)(object)bigNumber,
+                        Type floatType when floatType == typeof( float ) || floatType == typeof( float? ) => bigNumber > (BigInteger)float.MaxValue ? (TValue)(object)float.MaxValue : bigNumber < (BigInteger)float.MinValue ? (TValue)(object)float.MinValue : (TValue)(object)bigNumber,
+                        Type doubleType when doubleType == typeof( double ) || doubleType == typeof( double? ) => bigNumber > (BigInteger)double.MaxValue ? (TValue)(object)double.MaxValue : bigNumber < (BigInteger)double.MinValue ? (TValue)(object)double.MinValue : (TValue)(object)bigNumber,
+                        Type decimalType when decimalType == typeof( decimal ) || decimalType == typeof( decimal? ) => bigNumber > (BigInteger)decimal.MaxValue ? (TValue)(object)decimal.MaxValue : bigNumber < (BigInteger)decimal.MinValue ? (TValue)(object)decimal.MinValue : (TValue)(object)bigNumber,
+                        Type sbyteType when sbyteType == typeof( sbyte ) || sbyteType == typeof( sbyte? ) => bigNumber > sbyte.MaxValue ? (TValue)(object)sbyte.MaxValue : bigNumber < sbyte.MinValue ? (TValue)(object)sbyte.MinValue : (TValue)(object)bigNumber,
+                        Type ushortType when ushortType == typeof( ushort ) || ushortType == typeof( ushort? ) => bigNumber > ushort.MaxValue ? (TValue)(object)ushort.MaxValue : bigNumber < ushort.MinValue ? (TValue)(object)ushort.MinValue : (TValue)(object)bigNumber,
+                        Type uintType when uintType == typeof( uint ) || uintType == typeof( uint? ) => bigNumber > uint.MaxValue ? (TValue)(object)uint.MaxValue : bigNumber < uint.MinValue ? (TValue)(object)uint.MinValue : (TValue)(object)bigNumber,
+                        Type ulongType when ulongType == typeof( ulong ) || ulongType == typeof( ulong? ) => bigNumber > ulong.MaxValue ? (TValue)(object)ulong.MaxValue : bigNumber < ulong.MinValue ? (TValue)(object)ulong.MinValue : (TValue)(object)bigNumber,
+                        _ => default,
+                    };
+
+                    return true;
+                }
+
+                result = default;
+                return false;
             }
             catch
             {

--- a/Source/Blazorise/Utilities/Converters.cs
+++ b/Source/Blazorise/Utilities/Converters.cs
@@ -177,7 +177,7 @@ namespace Blazorise.Utilities
         }
 
         /// <summary>
-        /// Tries to parse a large string repesenting a numberm and returns an object of the specified type and whose value is equivalent to the specified object.
+        /// Tries to parse a large string repesenting a number and returns an object of the specified type and whose value is equivalent to the specified object.
         /// </summary>
         /// <typeparam name="TValue">The type of object to return.</typeparam>
         /// <param name="value">An object that implements the <see cref="IConvertible"/> interface.</param>


### PR DESCRIPTION
Closes https://support.blazorise.com/issues/43/NumericPicker-with-too-high-Integer-values

It's not the cleanest solution, but it works. To test the code:

```razor
<Field>
    <FieldLabel ColumnSize="ColumnSize.Is3">Short</FieldLabel>
    <FieldBody>
        <NumericPicker TValue="short" @bind-Value="@pickerValueShort" Decimals=0 Min="1" Max="100" autocomplete=off></NumericPicker>
    </FieldBody>
</Field>
<Field>
    <FieldLabel ColumnSize="ColumnSize.Is3">Int</FieldLabel>
    <FieldBody>
        <NumericPicker TValue="int" @bind-Value="@pickerValueInt" Decimals=0 Min="1" Max="100" autocomplete=off></NumericPicker>
    </FieldBody>
</Field>
<Field>
    <FieldLabel ColumnSize="ColumnSize.Is3">Long</FieldLabel>
    <FieldBody>
        <NumericPicker TValue="long" @bind-Value="@pickerValueLong" Decimals=0 Min="1" Max="100" autocomplete=off></NumericPicker>
    </FieldBody>
</Field>
<Field>
    <FieldLabel ColumnSize="ColumnSize.Is3">Float</FieldLabel>
    <FieldBody>
        <NumericPicker TValue="float" @bind-Value="@pickerValueFloat" Decimals=0 Min="1" Max="100" autocomplete=off></NumericPicker>
    </FieldBody>
</Field>
<Field>
    <FieldLabel ColumnSize="ColumnSize.Is3">Double</FieldLabel>
    <FieldBody>
        <NumericPicker TValue="double" @bind-Value="@pickerValueDouble" Decimals=0 Min="1" Max="100" autocomplete=off></NumericPicker>
    </FieldBody>
</Field>
<Field>
    <FieldLabel ColumnSize="ColumnSize.Is3">Decimal</FieldLabel>
    <FieldBody>
        <NumericPicker TValue="decimal" @bind-Value="@pickerValueDecimal" Decimals=0 Min="1" Max="100" autocomplete=off></NumericPicker>
    </FieldBody>
</Field>
@code {
    private short pickerValueShort;
    private int pickerValueInt;
    private long pickerValueLong;
    private float pickerValueFloat;
    private double pickerValueDouble;
    private decimal pickerValueDecimal;
}
```