### PR TITLE
Markdown and RichTextEdit: Invoke immediately if Rendered

### DIFF
--- a/Source/Extensions/Blazorise.Markdown/Markdown.razor.cs
+++ b/Source/Extensions/Blazorise.Markdown/Markdown.razor.cs
@@ -200,6 +200,9 @@ namespace Blazorise.Markdown
         /// <returns>Markdown value.</returns>
         public async Task<string> GetValueAsync()
         {
+            if ( Rendered )
+                return await JSModule.GetValue( ElementId );
+
             return await ExecuteAfterRenderAsync( async () => await JSModule.GetValue( ElementId ) );
         }
 
@@ -210,6 +213,13 @@ namespace Blazorise.Markdown
         /// <returns>A task that represents the asynchronous operation.</returns>
         public async Task SetValueAsync( string value )
         {
+            if ( Rendered )
+            {
+                await JSModule.SetValue( ElementId, value );
+
+                return;
+            }
+
             await InvokeAsync( () => ExecuteAfterRender( async () => await JSModule.SetValue( ElementId, value ) ) );
         }
 

--- a/Source/Extensions/Blazorise.RichTextEdit/RichTextEdit.razor.cs
+++ b/Source/Extensions/Blazorise.RichTextEdit/RichTextEdit.razor.cs
@@ -1,6 +1,5 @@
 ﻿#region Using directives
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Blazorise.Extensions;
 using Microsoft.AspNetCore.Components;
@@ -58,6 +57,13 @@ namespace Blazorise.RichTextEdit
         /// </summary>
         public async ValueTask SetHtmlAsync( string html )
         {
+            if ( Rendered )
+            {
+                await JSModule.SetHtmlAsync( EditorRef, html );
+
+                return;
+            }
+
             await InvokeAsync( () => ExecuteAfterRender( async () => await JSModule.SetHtmlAsync( EditorRef, html ) ) );
         }
 
@@ -66,6 +72,11 @@ namespace Blazorise.RichTextEdit
         /// </summary>
         public async ValueTask<string> GetHtmlAsync()
         {
+            if ( Rendered )
+            {
+                return await JSModule.GetHtmlAsync( EditorRef );
+            }
+
             return await ExecuteAfterRender( async () => await JSModule.GetHtmlAsync( EditorRef ) );
         }
 
@@ -75,6 +86,13 @@ namespace Blazorise.RichTextEdit
         /// <seealso href="https://quilljs.com/docs/delta/"/>
         public async ValueTask SetDeltaAsync( string deltaJson )
         {
+            if ( Rendered )
+            {
+                await JSModule.SetDeltaAsync( EditorRef, deltaJson );
+
+                return;
+            }
+
             await InvokeAsync( () => ExecuteAfterRender( async () => await JSModule.SetDeltaAsync( EditorRef, deltaJson ) ) );
         }
 
@@ -84,6 +102,11 @@ namespace Blazorise.RichTextEdit
         /// <seealso href="https://quilljs.com/docs/delta/"/>
         public async ValueTask<string> GetDeltaAsync()
         {
+            if ( Rendered )
+            {
+                return await JSModule.GetDeltaAsync( EditorRef );
+            }
+
             return await ExecuteAfterRender( async () => await JSModule.GetDeltaAsync( EditorRef ) );
         }
 
@@ -92,6 +115,13 @@ namespace Blazorise.RichTextEdit
         /// </summary>
         public async ValueTask SetTextAsync( string text )
         {
+            if ( Rendered )
+            {
+                await JSModule.SetTextAsync( EditorRef, text );
+
+                return;
+            }
+
             await InvokeAsync( () => ExecuteAfterRender( async () => await JSModule.SetTextAsync( EditorRef, text ) ) );
         }
 
@@ -101,6 +131,11 @@ namespace Blazorise.RichTextEdit
         /// <seealso href="https://quilljs.com/docs/delta/"/>
         public async ValueTask<string> GetTextAsync()
         {
+            if ( Rendered )
+            {
+                return await JSModule.GetTextAsync( EditorRef );
+            }
+
             return await ExecuteAfterRender( async () => await JSModule.GetTextAsync( EditorRef ) );
         }
 


### PR DESCRIPTION
Continuation from #4331

I have noticed on our https://support.blazorise.com/ that when I try to post a comment, I can't get the result from the `Markdown` by invoking the `GetValueAsync`. The problem was that I had made it so that #4331 would only return the result if the rendered component. I only noticed it because we wrapped `Markdown` in a separate `MarkdownEditor` component, so the Clicked event didn't get triggered on an IssuesPage.

`return await ExecuteAfterRenderAsync( async () => await JSModule.GetValue( ElementId ) );`

So this PR solves it by returning the result immediately if the component it already being rendered without waiting for the new render to complete.

