### PR TITLE
DragDrop: optimizations

### DIFF
--- a/Demos/Blazorise.Demo/Pages/Tests/DragDropPage.razor
+++ b/Demos/Blazorise.Demo/Pages/Tests/DragDropPage.razor
@@ -48,8 +48,10 @@
         new DropItem() { Name = "Cabbage", Group = "Basket", Image = "_content/Blazorise.Demo/img/fruit/cabbage.png" },
     };
 
-    private void ItemDropped( DraggableDroppedEventArgs<DropItem> dropItem )
+    private Task ItemDropped( DraggableDroppedEventArgs<DropItem> dropItem )
     {
         dropItem.Item.Group = dropItem.DropZoneName;
+
+        return Task.CompletedTask;
     }
 }

--- a/Documentation/Blazorise.Docs/Models/Snippets.generated.cs
+++ b/Documentation/Blazorise.Docs/Models/Snippets.generated.cs
@@ -1367,9 +1367,10 @@ public class Gender
         new DropItem() { Name = ""Cabbage"", Group = ""Vegetable"", Image = ""img/fruit/cabbage.png"" },
     };
 
-    private void ItemDropped( DraggableDroppedEventArgs<DropItem> dropItem )
+    private Task ItemDropped( DraggableDroppedEventArgs<DropItem> dropItem )
     {
         dropItem.Item.Group = dropItem.DropZoneName;
+        return Task.CompletedTask;
     }
 }";
 
@@ -1432,9 +1433,10 @@ public class Gender
         new DropItem() { Name = ""Item 5"", Group = ""2"" },
     };
 
-    private void ItemDropped( DraggableDroppedEventArgs<DropItem> dropItem )
+    private Task ItemDropped( DraggableDroppedEventArgs<DropItem> dropItem )
     {
         dropItem.Item.Group = dropItem.DropZoneName;
+        return Task.CompletedTask;
     }
 }";
 

--- a/Documentation/Blazorise.Docs/Pages/Docs/Components/DragDrops/Code/BasicDragDropExampleCode.html
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Components/DragDrops/Code/BasicDragDropExampleCode.html
@@ -46,9 +46,10 @@
         <span class="keyword">new</span> DropItem() { Name = <span class="string">&quot;Cabbage&quot;</span>, Group = <span class="string">&quot;Vegetable&quot;</span>, Image = <span class="string">&quot;img/fruit/cabbage.png&quot;</span> },
     };
 
-    <span class="keyword">private</span> <span class="keyword">void</span> ItemDropped( DraggableDroppedEventArgs&lt;DropItem&gt; dropItem )
+    <span class="keyword">private</span> Task ItemDropped( DraggableDroppedEventArgs&lt;DropItem&gt; dropItem )
     {
         dropItem.Item.Group = dropItem.DropZoneName;
+        <span class="keyword">return</span> Task.CompletedTask;
     }
 }
 </pre></div>

--- a/Documentation/Blazorise.Docs/Pages/Docs/Components/DragDrops/Code/DragDropReorderingExampleCode.html
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Components/DragDrops/Code/DragDropReorderingExampleCode.html
@@ -61,9 +61,10 @@
         <span class="keyword">new</span> DropItem() { Name = <span class="string">&quot;Item 5&quot;</span>, Group = <span class="string">&quot;2&quot;</span> },
     };
 
-    <span class="keyword">private</span> <span class="keyword">void</span> ItemDropped( DraggableDroppedEventArgs&lt;DropItem&gt; dropItem )
+    <span class="keyword">private</span> Task ItemDropped( DraggableDroppedEventArgs&lt;DropItem&gt; dropItem )
     {
         dropItem.Item.Group = dropItem.DropZoneName;
+        <span class="keyword">return</span> Task.CompletedTask;
     }
 }
 </pre></div>

--- a/Documentation/Blazorise.Docs/Pages/Docs/Components/DragDrops/Examples/BasicDragDropExample.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Components/DragDrops/Examples/BasicDragDropExample.razor
@@ -44,8 +44,9 @@
         new DropItem() { Name = "Cabbage", Group = "Vegetable", Image = "img/fruit/cabbage.png" },
     };
 
-    private void ItemDropped( DraggableDroppedEventArgs<DropItem> dropItem )
+    private Task ItemDropped( DraggableDroppedEventArgs<DropItem> dropItem )
     {
         dropItem.Item.Group = dropItem.DropZoneName;
+        return Task.CompletedTask;
     }
 }

--- a/Documentation/Blazorise.Docs/Pages/Docs/Components/DragDrops/Examples/DragDropReorderingExample.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Components/DragDrops/Examples/DragDropReorderingExample.razor
@@ -59,8 +59,9 @@
         new DropItem() { Name = "Item 5", Group = "2" },
     };
 
-    private void ItemDropped( DraggableDroppedEventArgs<DropItem> dropItem )
+    private Task ItemDropped( DraggableDroppedEventArgs<DropItem> dropItem )
     {
         dropItem.Item.Group = dropItem.DropZoneName;
+        return Task.CompletedTask;
     }
 }

--- a/Source/Blazorise/Components/Droppable/DropContainer.razor.cs
+++ b/Source/Blazorise/Components/Droppable/DropContainer.razor.cs
@@ -81,7 +81,8 @@ namespace Blazorise
                 }
             }
 
-            await ItemDropped.InvokeAsync( new DraggableDroppedEventArgs<TItem>( transaction.Item, dropZoneName, transaction.SourceZoneName, index ) );
+            if ( ItemDropped is not null )
+                await ItemDropped.Invoke( new DraggableDroppedEventArgs<TItem>( transaction.Item, dropZoneName, transaction.SourceZoneName, index ) );
 
             var transactionFinishedEventArgs = new DraggableTransactionEnded<TItem>( dropZoneName, true, transaction );
 
@@ -247,7 +248,7 @@ namespace Blazorise
         /// <summary>
         /// Callback that indicates that an item has been dropped on a drop zone. Should be used to update the "status" of the data item.
         /// </summary>
-        [Parameter] public EventCallback<DraggableDroppedEventArgs<TItem>> ItemDropped { get; set; }
+        [Parameter] public Func<DraggableDroppedEventArgs<TItem>, Task> ItemDropped { get; set; }
 
         /// <summary>
         /// Determines if the item is allowed to be dropped to the specified zone.

--- a/Source/Blazorise/Components/Droppable/DropContainer.razor.cs
+++ b/Source/Blazorise/Components/Droppable/DropContainer.razor.cs
@@ -81,8 +81,7 @@ namespace Blazorise
                 }
             }
 
-            if ( ItemDropped is not null )
-                await ItemDropped.Invoke( new DraggableDroppedEventArgs<TItem>( transaction.Item, dropZoneName, transaction.SourceZoneName, index ) );
+            await ItemDropped.InvokeAsync( new DraggableDroppedEventArgs<TItem>( transaction.Item, dropZoneName, transaction.SourceZoneName, index ) );
 
             var transactionFinishedEventArgs = new DraggableTransactionEnded<TItem>( dropZoneName, true, transaction );
 
@@ -248,7 +247,7 @@ namespace Blazorise
         /// <summary>
         /// Callback that indicates that an item has been dropped on a drop zone. Should be used to update the "status" of the data item.
         /// </summary>
-        [Parameter] public Func<DraggableDroppedEventArgs<TItem>, Task> ItemDropped { get; set; }
+        [Parameter] public EventCallback<DraggableDroppedEventArgs<TItem>> ItemDropped { get; set; }
 
         /// <summary>
         /// Determines if the item is allowed to be dropped to the specified zone.

--- a/Source/Blazorise/Components/Droppable/DropZone.razor
+++ b/Source/Blazorise/Components/Droppable/DropZone.razor
@@ -13,43 +13,56 @@
 
             @if ( AllowReorder )
             {
-                @if ( !items.Any() )
-                {
-                    <div @key="@($"{ElementId}_item_preview_placeholder")" class="@PlaceholderClassBuilder.Class"></div>
-                }
-                else
-                {
-                    if ( transactionIndex == -1 )
-                    {
-                        <div @key="@($"{ElementId}_item_preview_placeholder")" class="@PlaceholderClassBuilder.Class"></div>
-                    }
-
-                    <_Draggable @key="@($"{ElementId}_item_preview")" TItem="TItem" Item="default" ZoneName="@Name" Disabled="true" HideContent="false" Class="draggable-preview-start" />
-                }
+                @DraggablePreviewFragment(transactionIndex)
             }
 
             @foreach ( var item in items )
             {
-                var indexCopy = index;
-
-                <_Draggable @key="@($"{ElementId}_item_draggable_{indexCopy}")" TItem="TItem" Item="@item" ZoneName="@Name" DraggingClass="@GetItemDraggingClass()" Disabled="@GetItemDisabled(item)" DisabledClass="@GetItemDisabledClass()" DragStarted="@OnDragStarted" DragEnded="@OnDragEnded" Index="@indexCopy">
-                    @{
-                        var renderer = ItemTemplate ?? ParentContainer?.ItemTemplate;
-                    }
-
-                    @if ( renderer != null )
-                    {
-                        @renderer(item)
-                    }
-                </_Draggable>
-
-                if ( transactionIndex == indexCopy && !IsOrigin( indexCopy ) )
-                {
-                    <div @key="@($"{ElementId}_item_placeholder")" class="@PlaceholderClassBuilder.Class"></div>
-                }
+                @DraggableItemFragment((item,index,transactionIndex))
 
                 index++;
             }
         }
     </div>
 </CascadingValue>
+@code {
+    protected RenderFragment<int> DraggablePreviewFragment => transactionIndex => __builder =>
+    {
+        if ( !items.Any() )
+        {
+            <div @key="@($"{ElementId}_item_preview_placeholder")" class="@PlaceholderClassBuilder.Class"></div>
+        }
+        else
+        {
+            if ( transactionIndex == -1 )
+            {
+                <div @key="@($"{ElementId}_item_preview_placeholder")" class="@PlaceholderClassBuilder.Class"></div>
+            }
+
+            <_Draggable @key="@($"{ElementId}_item_preview")" TItem="TItem" Item="default" ZoneName="@Name" Disabled="true" HideContent="false" Class="draggable-preview-start" />
+        }
+    };
+
+    protected RenderFragment<(TItem item, int index, int transactionIndex)> DraggableItemFragment => tuple => __builder =>
+    {
+        var item = tuple.item;
+        var index = tuple.index;
+        var transactionIndex = tuple.transactionIndex;
+
+        <_Draggable @key="@($"{ElementId}_item_draggable_{index}")" TItem="TItem" Item="@item" ZoneName="@Name" DraggingClass="@GetItemDraggingClass()" Disabled="@GetItemDisabled(item)" DisabledClass="@GetItemDisabledClass()" DragStarted="@OnDragStarted" DragEnded="@OnDragEnded" Index="@index">
+            @{
+                var renderer = ItemTemplate ?? ParentContainer?.ItemTemplate;
+            }
+
+            @if ( renderer != null )
+            {
+                @renderer(item)
+            }
+        </_Draggable>
+
+        if ( transactionIndex == index && !IsOrigin( index ) )
+        {
+            <div @key="@($"{ElementId}_item_placeholder")" class="@PlaceholderClassBuilder.Class"></div>
+        }
+    };
+}

--- a/Source/Blazorise/Components/Droppable/DropZone.razor
+++ b/Source/Blazorise/Components/Droppable/DropZone.razor
@@ -2,7 +2,7 @@
 @typeparam TItem
 @inherits BaseComponent
 <CascadingValue Value="@this" IsFixed>
-    <div @ref="@ElementRef" id="@ElementId" class="@ClassNames" style="@StyleNames" @ondragenter="@OnDragEnterHandler" @ondragleave="@OnDragLeaveHandler" @ondrop="@OnDropHandler" @attributes="@Attributes">
+    <div @key="@ElementId" @ref="@ElementRef" id="@ElementId" class="@ClassNames" style="@StyleNames" @ondragenter="@OnDragEnterHandler" @ondragleave="@OnDragLeaveHandler" @ondrop="@OnDropHandler" @attributes="@Attributes">
         @ChildContent
 
         @if ( !OnlyZone )
@@ -15,16 +15,16 @@
             {
                 @if ( !items.Any() )
                 {
-                    <div class="@PlaceholderClassBuilder.Class"></div>
+                    <div @key="@($"{ElementId}_item_preview_placeholder")" class="@PlaceholderClassBuilder.Class"></div>
                 }
                 else
                 {
                     if ( transactionIndex == -1 )
                     {
-                        <div class="@PlaceholderClassBuilder.Class"></div>
+                        <div @key="@($"{ElementId}_item_preview_placeholder")" class="@PlaceholderClassBuilder.Class"></div>
                     }
 
-                    <_Draggable @key="@ElementId" TItem="TItem" Item="default" ZoneName="@Name" Disabled="true" HideContent="false" Class="draggable-preview-start" />
+                    <_Draggable @key="@($"{ElementId}_item_preview")" TItem="TItem" Item="default" ZoneName="@Name" Disabled="true" HideContent="false" Class="draggable-preview-start" />
                 }
             }
 
@@ -32,7 +32,7 @@
             {
                 var indexCopy = index;
 
-                <_Draggable @key="@(item.GetHashCode())" TItem="TItem" Item="@item" ZoneName="@Name" DraggingClass="@GetItemDraggingClass()" Disabled="@GetItemDisabled(item)" DisabledClass="@GetItemDisabledClass()" DragStarted="@OnDragStarted" DragEnded="@OnDragEnded" Index="@indexCopy">
+                <_Draggable @key="@($"{ElementId}_item_draggable_{indexCopy}")" TItem="TItem" Item="@item" ZoneName="@Name" DraggingClass="@GetItemDraggingClass()" Disabled="@GetItemDisabled(item)" DisabledClass="@GetItemDisabledClass()" DragStarted="@OnDragStarted" DragEnded="@OnDragEnded" Index="@indexCopy">
                     @{
                         var renderer = ItemTemplate ?? ParentContainer?.ItemTemplate;
                     }
@@ -45,7 +45,7 @@
 
                 if ( transactionIndex == indexCopy && !IsOrigin( indexCopy ) )
                 {
-                    <div class="@PlaceholderClassBuilder.Class"></div>
+                    <div @key="@($"{ElementId}_item_placeholder")" class="@PlaceholderClassBuilder.Class"></div>
                 }
 
                 index++;

--- a/Source/Blazorise/Components/Droppable/DropZone.razor.cs
+++ b/Source/Blazorise/Components/Droppable/DropZone.razor.cs
@@ -332,9 +332,19 @@ namespace Blazorise
             return (item, canBeDropped);
         }
 
-        private void OnDragStarted() => dragging = true;
+        private Task OnDragStarted()
+        {
+            dragging = true;
 
-        private void OnDragEnded() => dragging = false;
+            return Task.CompletedTask;
+        }
+
+        private Task OnDragEnded( TItem item )
+        {
+            dragging = false;
+
+            return Task.CompletedTask;
+        }
 
         private int count;
         private IEnumerable<TItem> GetItems()

--- a/Source/Blazorise/Components/Droppable/DropZone.razor.cs
+++ b/Source/Blazorise/Components/Droppable/DropZone.razor.cs
@@ -33,6 +33,12 @@ namespace Blazorise
 
         private Dictionary<TItem, int> indices = new();
 
+        private bool recalculateItems = true;
+
+        private bool shouldRerender = true;
+
+        private IEnumerable<TItem> items;
+
         #endregion
 
         #region Constructors
@@ -66,7 +72,7 @@ namespace Blazorise
         /// <inheritdoc/>
         protected override async Task OnAfterRenderAsync( bool firstRender )
         {
-            if ( firstRender  )
+            if ( firstRender )
             {
                 await JSModule.Initialize( ElementRef, ElementId );
             }
@@ -167,6 +173,9 @@ namespace Blazorise
                 }
             }
 
+            recalculateItems = true;
+            shouldRerender = true;
+
             DirtyClasses();
 
             InvokeAsync( StateHasChanged );
@@ -175,6 +184,9 @@ namespace Blazorise
         private void OnContainerRefreshRequested( object sender, EventArgs e )
         {
             indices.Clear();
+
+            recalculateItems = true;
+            shouldRerender = true;
 
             DirtyClasses();
 
@@ -185,6 +197,9 @@ namespace Blazorise
         {
             if ( e.ZoneName != Name && e.OldZoneName != Name )
                 return;
+
+            recalculateItems = true;
+            shouldRerender = true;
 
             DirtyClasses();
 
@@ -321,16 +336,24 @@ namespace Blazorise
 
         private void OnDragEnded() => dragging = false;
 
+        private int count;
         private IEnumerable<TItem> GetItems()
         {
-            Func<TItem, bool> predicate = ( item ) => ParentContainer.ItemsFilter( item, Name ?? string.Empty );
-
-            if ( ItemsFilter != null )
+            if ( recalculateItems )
             {
-                predicate = ItemsFilter;
+                recalculateItems = false;
+
+                Func<TItem, bool> predicate = ( item ) => ParentContainer.ItemsFilter( item, Name ?? string.Empty );
+
+                if ( ItemsFilter != null )
+                {
+                    predicate = ItemsFilter;
+                }
+
+                items = ( ParentContainer?.Items ?? Enumerable.Empty<TItem>() ).Where( predicate ).OrderBy( x => GetItemIndex( x ) ).ToArray();
             }
 
-            return ( ParentContainer?.Items ?? Enumerable.Empty<TItem>() ).Where( predicate ).OrderBy( x => GetItemIndex( x ) ).ToArray();
+            return items ?? Enumerable.Empty<TItem>();
         }
 
         private bool GetItemDisabled( TItem item )
@@ -377,6 +400,17 @@ namespace Blazorise
         #endregion
 
         #region Properties
+
+        protected override bool ShouldRender()
+        {
+            if ( shouldRerender )
+            {
+                shouldRerender = false;
+                return true;
+            }
+
+            return shouldRerender;
+        }
 
         /// <inheritdoc/>
         protected override bool ShouldAutoGenerateId => true;

--- a/Source/Blazorise/Components/Droppable/_Draggable.razor.cs
+++ b/Source/Blazorise/Components/Droppable/_Draggable.razor.cs
@@ -43,7 +43,8 @@ namespace Blazorise
 
             ParentContainer.StartTransaction( Item, ZoneName ?? string.Empty, Index, OnDroppedSucceeded, OnDroppedCanceled );
 
-            await DragStarted.InvokeAsync();
+            if ( DragStarted is not null )
+                await DragStarted.Invoke();
         }
 
         private async Task OnDragEndHandler( DragEventArgs e )
@@ -56,7 +57,8 @@ namespace Blazorise
             }
             else
             {
-                await DragEnded.InvokeAsync( Item );
+                if ( DragEnded is not null )
+                    await DragEnded.Invoke( Item );
             }
         }
 
@@ -76,7 +78,8 @@ namespace Blazorise
         {
             dragging = false;
 
-            await DragEnded.InvokeAsync( Item );
+            if ( DragEnded is not null )
+                await DragEnded.Invoke( Item );
 
             await InvokeAsync( StateHasChanged );
         }
@@ -85,7 +88,8 @@ namespace Blazorise
         {
             dragging = false;
 
-            await DragEnded.InvokeAsync( Item );
+            if ( DragEnded is not null )
+                await DragEnded.Invoke( Item );
 
             await InvokeAsync( StateHasChanged );
         }
@@ -107,12 +111,12 @@ namespace Blazorise
         /// <summary>
         /// An event that is raised when a drag operation has started.
         /// </summary>
-        [Parameter] public EventCallback<TItem> DragStarted { get; set; }
+        [Parameter] public Func<Task> DragStarted { get; set; }
 
         /// <summary>
         /// An event that is raised when a drag operation has ended.
         /// </summary>
-        [Parameter] public EventCallback<TItem> DragEnded { get; set; }
+        [Parameter] public Func<TItem, Task> DragEnded { get; set; }
 
         /// <summary>
         /// If true, the draggable item canot be dragged.

--- a/Source/Blazorise/Components/Droppable/_Draggable.razor.cs
+++ b/Source/Blazorise/Components/Droppable/_Draggable.razor.cs
@@ -120,7 +120,8 @@ namespace Blazorise
         [Parameter]
         public bool Disabled
         {
-            get => disabled; set
+            get => disabled;
+            set
             {
                 if ( disabled == value )
                     return;

--- a/Tests/BasicTestApp.Client/DropZoneReorderComponent.razor
+++ b/Tests/BasicTestApp.Client/DropZoneReorderComponent.razor
@@ -35,9 +35,10 @@
 
     public List<int> IndexHistory { get; set; } = new();
 
-    private void ItemDropped( DraggableDroppedEventArgs<DropItem> dropItem )
+    private Task ItemDropped( DraggableDroppedEventArgs<DropItem> dropItem )
     {
         dropItem.Item.Group = dropItem.DropZoneName;
         IndexHistory.Add( dropItem.IndexInZone );
+        return Task.CompletedTask;
     }
 }

--- a/Tests/Blazorise.Tests/Components/DropZoneTest.cs
+++ b/Tests/Blazorise.Tests/Components/DropZoneTest.cs
@@ -433,7 +433,7 @@ namespace Blazorise.Tests.Components
 
             DropContainer<object> sut = new DropContainer<object>()
             {
-                ItemDropped = new Func<DraggableDroppedEventArgs<object>, Task>( DropEvent )
+                ItemDropped = new EventCallback<DraggableDroppedEventArgs<object>>( null, DropEvent )
             };
 
             Task DropEvent( DraggableDroppedEventArgs<object> e )

--- a/Tests/Blazorise.Tests/Components/DropZoneTest.cs
+++ b/Tests/Blazorise.Tests/Components/DropZoneTest.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using BasicTestApp.Client;
 using Blazorise.Tests.Helpers;
@@ -432,12 +433,14 @@ namespace Blazorise.Tests.Components
 
             DropContainer<object> sut = new DropContainer<object>()
             {
-                ItemDropped = new EventCallback<DraggableDroppedEventArgs<object>>( null, DropEvent )
+                ItemDropped = new Func<DraggableDroppedEventArgs<object>, Task>( DropEvent )
             };
 
-            void DropEvent( DraggableDroppedEventArgs<object> e )
+            Task DropEvent( DraggableDroppedEventArgs<object> e )
             {
                 returnedArgs = e;
+
+                return Task.CompletedTask;
             }
 
             sut.StartTransaction( new object(), "source_zone_name", 0, () => Task.CompletedTask, () => Task.CompletedTask );


### PR DESCRIPTION
Closes https://support.blazorise.com/issues/80/Reordering-Items-in-DropContainer-Takes-1-minute-to-Complete

Optimizes DropZone so that items are calculated and fetched only when requested. Also added a bunch of `key` attributes to the draggable elements.