### PR TITLE
Dropdown: use fixed strategy

### DIFF
--- a/Source/Blazorise/wwwroot/dropdown.js
+++ b/Source/Blazorise/wwwroot/dropdown.js
@@ -48,7 +48,7 @@ export function initialize(element, elementId, targetElementId, altTargetElement
 
     const instance = createPopper(targetElement, menuElement, {
         placement: getPopperDirection(options.direction, options.rightAligned),
-        strategy: "absolute",
+        strategy: "fixed",
         modifiers: [
             {
                 name: "preventOverflow",


### PR DESCRIPTION
We changed the strategy to `absolute` in #3699. But one of our commercial clients reported an issue. It affects the scrollbars when the menu is shown, even though it has enough room on the screen.

Changing it to `fixed` seems to fix the problem. I have tested all our dropdowns on the demo app, and it seems to be working.