### PR TITLE
Autocomplete fixes // MinLength = 0

### DIFF
--- a/Demos/Blazorise.Demo/Pages/Tests/ComponentsPage.razor
+++ b/Demos/Blazorise.Demo/Pages/Tests/ComponentsPage.razor
@@ -117,7 +117,7 @@
                 </Field>
                 <Field Horizontal JustifyContent="JustifyContent.End">
                     <FieldBody ColumnSize="ColumnSize.Is10.Is2.WithOffset">
-                        Selected search value: @selectedAutoCompleteSearchValue
+                        Selected value: @selectedAutoCompleteSearchValue
                     </FieldBody>
                     <FieldBody ColumnSize="ColumnSize.Is10.Is2.WithOffset">
                         Selected text value: @selectedAutoCompleteText
@@ -208,7 +208,7 @@
                 </Field>
                 <Field Horizontal JustifyContent="JustifyContent.End">
                     <FieldBody ColumnSize="ColumnSize.Is10.Is2.WithOffset">
-                        Selected search value: @selectedAutoCompleteReadDataSearchValue
+                        Selected value: @selectedAutoCompleteReadDataSearchValue
                     </FieldBody>
                     <FieldBody ColumnSize="ColumnSize.Is10.Is2.WithOffset">
                         Selected text value: @selectedAutoCompleteReadDataText

--- a/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
+++ b/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
@@ -369,6 +369,7 @@ namespace Blazorise.Components
                         if ( item != null && ValueField != null )
                         {
                             await OnDropdownItemSelected( ValueField.Invoke( item ) );
+                            ActiveItemIndex = Math.Max( 0, Math.Min( FilteredData.Count - 1, ActiveItemIndex ) );
                         }
                     }
                 }

--- a/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
+++ b/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
@@ -665,6 +665,7 @@ namespace Blazorise.Components
         {
             await RemoveMultipleText( text );
             await RemoveMultipleValue( GetValueByText( text ) );
+            DirtyFilter();
         }
 
         /// <summary>
@@ -676,6 +677,7 @@ namespace Blazorise.Components
         {
             await RemoveMultipleText( GetItemText( value ) );
             await RemoveMultipleValue( value );
+            DirtyFilter();
         }
 
         private void FilterData()

--- a/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
+++ b/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
@@ -369,7 +369,6 @@ namespace Blazorise.Components
                         if ( item != null && ValueField != null )
                         {
                             await OnDropdownItemSelected( ValueField.Invoke( item ) );
-                            ActiveItemIndex = Math.Max( 0, Math.Min( FilteredData.Count - 1, ActiveItemIndex ) );
                         }
                     }
                 }

--- a/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
+++ b/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
@@ -436,7 +436,8 @@ namespace Blazorise.Components
 
         private async Task OnDropdownItemSelected( object value )
         {
-            if ( SelectionMode == AutocompleteSelectionMode.Default )
+            //TODO : Once Multiple is deprecated we may remove the && !IsMultiple condition
+            if ( SelectionMode == AutocompleteSelectionMode.Default && !IsMultiple )
             {
                 await Close();
             }
@@ -448,18 +449,7 @@ namespace Blazorise.Components
                     await Close();
                     await ResetCurrentSearch();
                 }
-                else if ( !IsSuggestSelectedItems )
-                {
-                    if ( AutoPreSelect )
-                    {
-                        ActiveItemIndex = Math.Max( 0, Math.Min( FilteredData.Count, ActiveItemIndex ) );
-                    }
-                    else
-                    {
-                        await ResetActiveItemIndex();
-                    }
-                }
-                else
+                else if ( IsSuggestSelectedItems )
                 {
                     ActiveItemIndex = FilteredData.Index( x => ValueField( x ).IsEqual( value ) );
                 }
@@ -506,6 +496,7 @@ namespace Blazorise.Components
                 );
             }
 
+            ActiveItemIndex = Math.Max( 0, Math.Min( FilteredData.Count - 1, ActiveItemIndex ) );
             await Revalidate();
         }
 

--- a/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
+++ b/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
@@ -363,10 +363,13 @@ namespace Blazorise.Components
 
                 if ( ActiveItemIndex >= 0 )
                 {
-                    var item = FilteredData[ActiveItemIndex];
-                    if ( item != null && ValueField != null )
+                    if ( FilteredData?.Count > 0 )
                     {
-                        await OnDropdownItemSelected( ValueField.Invoke( item ) );
+                        var item = FilteredData[ActiveItemIndex];
+                        if ( item != null && ValueField != null )
+                        {
+                            await OnDropdownItemSelected( ValueField.Invoke( item ) );
+                        }
                     }
                 }
 

--- a/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
+++ b/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
@@ -363,7 +363,7 @@ namespace Blazorise.Components
 
                 if ( ActiveItemIndex >= 0 )
                 {
-                    if ( FilteredData?.Count > 0 )
+                    if ( FilteredData?.Count > 0 && DropdownVisible )
                     {
                         var item = FilteredData[ActiveItemIndex];
                         if ( item != null && ValueField != null )
@@ -436,7 +436,7 @@ namespace Blazorise.Components
 
         private async Task OnDropdownItemSelected( object value )
         {
-            if ( SelectionMode == AutocompleteSelectionMode.Default )
+            if ( SelectionMode == AutocompleteSelectionMode.Default && MinLength > 0 )
             {
                 await Close();
             }

--- a/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
+++ b/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
@@ -363,7 +363,7 @@ namespace Blazorise.Components
 
                 if ( ActiveItemIndex >= 0 )
                 {
-                    if ( FilteredData?.Count > 0 && DropdownVisible )
+                    if ( FilteredData?.Count > 0 )
                     {
                         var item = FilteredData[ActiveItemIndex];
                         if ( item != null && ValueField != null )
@@ -436,7 +436,7 @@ namespace Blazorise.Components
 
         private async Task OnDropdownItemSelected( object value )
         {
-            if ( SelectionMode == AutocompleteSelectionMode.Default && MinLength > 0 )
+            if ( SelectionMode == AutocompleteSelectionMode.Default )
             {
                 await Close();
             }


### PR DESCRIPTION
Fixes 
https://support.blazorise.com/issues/84/Autocomplete-Selection-with-Enter-Error

- Fixed trying to get an item when there's no data.
- Fixed MinLength = 0 + Multiple, would hide Dropdown on selection. 
- Fixed ActiveItemIndex being higher then the actual Data if the last item was selected
- Fixed Removing a multiple value by pressing backspace for example and not refreshing the data, this would be very apparent when MinLength = 0

Test Code:

```
<Blazorise.Components.Autocomplete TItem="Author" TValue="Author"
                                   Data="@AuthorList"
                                   TextField="@(item => item.Name)"
                                   ValueField="@(item => item)"
                                   Multiple
                                   MinLength="0"
                                   CloseOnSelection="false" />

@code {
    private List<Author> AuthorList = new() { new() { Name = "A" }, new() { Name = "AB" }, new() { Name = "AC" }, new() { Name = "AD" } };
    private class Author
    {
        public string Name { get; set; }
    }
}
```