### PR TITLE
Datagrid fix empty template not rendering

### DIFF
--- a/Source/Blazorise/Base/BaseAfterRenderComponent.cs
+++ b/Source/Blazorise/Base/BaseAfterRenderComponent.cs
@@ -80,6 +80,8 @@ namespace Blazorise
                 }
             }
 
+            Rendered = true;
+
             if ( executeAfterRenderQueue?.Count > 0 )
             {
                 while ( executeAfterRenderQueue.Count > 0 )

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -1438,13 +1438,19 @@ namespace Blazorise.DataGrid
         /// Returns true if EmptyTemplate is set and Data is null or empty.
         /// </summary>
         protected bool IsEmptyTemplateVisible
-            => !IsLoading && !IsNewItemInGrid && EmptyTemplate != null && Data.IsNullOrEmpty() && Rendered;
+            => !IsLoading && !IsNewItemInGrid && EmptyTemplate != null && Data.IsNullOrEmpty() && VirtualizeRendered;
 
         /// <summary>
         /// Returns true if EmptyFilterTemplate is set and FilteredData is null or empty.
         /// </summary>
         protected bool IsEmptyFilterTemplateVisible
-            => !IsLoading && !IsNewItemInGrid && EmptyFilterTemplate != null && ( !data.IsNullOrEmpty() && FilteredData.IsNullOrEmpty() ) && Rendered;
+            => !IsLoading && !IsNewItemInGrid && EmptyFilterTemplate != null && ( !data.IsNullOrEmpty() && FilteredData.IsNullOrEmpty() ) && VirtualizeRendered;
+
+        /// <summary>
+        /// Returns true if Virtualize is false or if Virtualize is true && Rendered
+        /// This flag is to make sure Templates don't 'fight' for control over the Virtualize Initial Render.
+        /// </summary>
+        protected bool VirtualizeRendered => !Virtualize || (Virtualize && Rendered);
 
         /// <summary>
         /// Returns true if ShowPager is true and grid is not empty or loading.

--- a/Tests/BasicTestApp.Client/DataGridComponent.razor
+++ b/Tests/BasicTestApp.Client/DataGridComponent.razor
@@ -1,5 +1,5 @@
 ﻿<DataGrid TItem="Employee"
-          Data="InMemoryData"
+          Data="@Data"
           ShowPager
           ShowPageSizes
           Sortable
@@ -39,11 +39,23 @@
                         Caption="Name"
                         Editable />
     </DataGridColumns>
+    <EmptyTemplate>
+        No Records...
+    </EmptyTemplate>
 </DataGrid>
 
 @code {
     [Parameter]
-    public DataGridEditMode DataGridEditMode { get; set; }        
+    public DataGridEditMode DataGridEditMode { get; set; }     
+    
+    [Parameter]
+    public List<Employee> Data { get; set; } = new()
+        {
+            new() { Name = "John", Fraction = "1/2" },
+            new() { Name = "Sarah", Fraction = "1/4" },
+            new() { Name = "Paul", Fraction = "1/8" },
+            new() { Name = "Ana", Fraction = "3/4" }
+        };
 
     public class Employee
     {
@@ -70,12 +82,4 @@
         }
 
     }
-
-    public List<Employee> InMemoryData { get; set; } = new()
-        {
-            new() { Name = "John", Fraction = "1/2" },
-            new() { Name = "Sarah", Fraction = "1/4" },
-            new() { Name = "Paul", Fraction = "1/8" },
-            new() { Name = "Ana", Fraction = "3/4" }
-        };
 }

--- a/Tests/Blazorise.Tests/Components/DataGridComponentTest.cs
+++ b/Tests/Blazorise.Tests/Components/DataGridComponentTest.cs
@@ -30,9 +30,9 @@ namespace Blazorise.Tests.Components
                 parameters.Add( x => x.Data, null ) );
 
             // validate
-            var emptyTemplateValue = comp.Find( "tbody tr td" ).GetAttribute( "textContent" );
+            var emptyTemplateValue = comp.Find( "tbody tr td" ).TextContent;
 
-            Assert.Equal( expectedEmptyTemplate, emptyTemplateValue );
+            Assert.Contains( expectedEmptyTemplate, emptyTemplateValue );
         }
 
         [Fact]

--- a/Tests/Blazorise.Tests/Components/DataGridComponentTest.cs
+++ b/Tests/Blazorise.Tests/Components/DataGridComponentTest.cs
@@ -20,6 +20,22 @@ namespace Blazorise.Tests.Components
         }
 
         [Fact]
+        public void NoData_Should_Render_EmptyTemplate()
+        {
+            // setup
+            var expectedEmptyTemplate = "No Records...";
+
+            // test
+            var comp = RenderComponent<DataGridComponent>( parameters =>
+                parameters.Add( x => x.Data, null ) );
+
+            // validate
+            var emptyTemplateValue = comp.Find( "tbody tr td" ).GetAttribute( "textContent" );
+
+            Assert.Equal( expectedEmptyTemplate, emptyTemplateValue );
+        }
+
+        [Fact]
         public void SortByField_Should_CorrectlySortRows()
         {
             // setup
@@ -47,16 +63,16 @@ namespace Blazorise.Tests.Components
             // setup
             var comp = RenderComponent<DataGridComponent>( parameters =>
                 parameters.Add( x => x.DataGridEditMode, editMode ) );
-            var startingDataCount = comp.Instance.InMemoryData.Count;
+            var startingDataCount = comp.Instance.Data.Count;
 
             // test
             comp.Click( "#btnNew" );
             comp.Click( "#btnSave" );
-            var currentDataCount = comp.Instance.InMemoryData.Count;
+            var currentDataCount = comp.Instance.Data.Count;
 
             // validate
             var expectedResult = startingDataCount + 1;
-            comp.WaitForAssertion( () => Assert.Equal( expectedResult, comp.Instance.InMemoryData.Count ), System.TimeSpan.FromSeconds( 3 ) );
+            comp.WaitForAssertion( () => Assert.Equal( expectedResult, comp.Instance.Data.Count ), System.TimeSpan.FromSeconds( 3 ) );
         }
 
         [Theory]
@@ -73,15 +89,15 @@ namespace Blazorise.Tests.Components
             // test
             comp.Find( "#btnEdit" ).Click();
 
-            comp.Input( "input", updatedName, 
-                ( firstInput ) => firstInput.SetAttribute( "value", updatedName ));
-            
+            comp.Input( "input", updatedName,
+                ( firstInput ) => firstInput.SetAttribute( "value", updatedName ) );
+
             comp.Click( "#btnSave" );
 
-            var currentName = comp.Instance.InMemoryData[0].Name;
+            var currentName = comp.Instance.Data[0].Name;
 
             // validate
-            comp.WaitForAssertion( () => Assert.Contains( comp.Instance.InMemoryData, x => x.Name == updatedName ), System.TimeSpan.FromSeconds( 3 ) );
+            comp.WaitForAssertion( () => Assert.Contains( comp.Instance.Data, x => x.Name == updatedName ), System.TimeSpan.FromSeconds( 3 ) );
         }
 
         [Theory]
@@ -93,12 +109,12 @@ namespace Blazorise.Tests.Components
             // setup
             var comp = RenderComponent<DataGridComponent>( parameters =>
                 parameters.Add( x => x.DataGridEditMode, editMode ) );
-            var startingDataCount = comp.Instance.InMemoryData.Count;
+            var startingDataCount = comp.Instance.Data.Count;
 
             // test
             comp.Click( "#btnDelete" );
 
-            var currentDataCount = comp.Instance.InMemoryData.Count;
+            var currentDataCount = comp.Instance.Data.Count;
 
             // validate
             var expectedResult = startingDataCount - 1;


### PR DESCRIPTION
Closes #4390

It was actually a combination of 8a605f5af766c0eaacdc83b3fdda04cf7bb8d470 messing with the `Rendered` flag since Datagrid does not call `await base.OnAfterRenderAsync( firstRender );` when it is first rendered.
There was two possible fixes here,
- We could make sure to call the `await base.OnAfterRenderAsync( firstRender ); `
- Make sure the Rendered flag is set on our `BaseAfterRenderComponent` even if firstRender was never true;

We decided to take the second route, as it is how it was working before from a more general pespective. From a `Datagrid` perspective we decide to not call `await base.OnAfterRenderAsync( firstRender );` just like it was previously, as to avoid any unintended/unexpected side effects.

And the 4ae8aa8909a9893a67a0a13d75968c3cc8531b87 (#3800)
Where the new added `Rendered` check to the `IsEmptyTemplateVisible` flag works for most cases, but on a first Render where the Datagrid has no `Data`, without `Virtualize` set, the flag for `IsEmptyTemplateVisible` is actually not recalculated after the component is `Rendered` and therefore would not display the `EmptyTemplate` also.