### PR TITLE
Autocomplete multiple values sync

### DIFF
--- a/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
+++ b/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
@@ -102,11 +102,11 @@ namespace Blazorise.Components
 
             await base.SetParametersAsync( parameters );
 
-            await SyncronizeSingle( selectedValueParamChanged, selectedTextParamChanged );
+            await SynchronizeSingle( selectedValueParamChanged, selectedTextParamChanged );
             await SynchronizeMultiple( selectedValuesParamChanged, selectedTextsParamChanged );
         }
 
-        private async Task SyncronizeSingle( bool selectedValueParamChanged, bool selectedTextParamChanged )
+        private async Task SynchronizeSingle( bool selectedValueParamChanged, bool selectedTextParamChanged )
         {
             if ( selectedTextParamChanged && !selectedValueParamChanged )
             {

--- a/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
+++ b/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
@@ -100,14 +100,14 @@ namespace Blazorise.Components
             bool selectedValuesParamChanged = false;
             bool selectedTextsParamChanged = false;
 
-            if ( parameters.TryGetValue<IEnumerable<TValue>>( nameof( SelectedValues ), out var paramSelectedValues ) 
+            if ( parameters.TryGetValue<IEnumerable<TValue>>( nameof( SelectedValues ), out var paramSelectedValues )
                 && !selectedValuesParam.AreEqualOrdered( paramSelectedValues ) )
             {
                 selectedValuesParamChanged = true;
                 selectedValues = null;
             }
 
-            if ( parameters.TryGetValue<IEnumerable<string>>( nameof( SelectedTexts ), out var paramSelectedTexts ) 
+            if ( parameters.TryGetValue<IEnumerable<string>>( nameof( SelectedTexts ), out var paramSelectedTexts )
                 && !selectedTextsParam.AreEqualOrdered( paramSelectedTexts ) )
             {
                 selectedTextsParamChanged = true;
@@ -217,6 +217,11 @@ namespace Blazorise.Components
             {
                 selectedTexts = texts;
                 await SelectedTextsChanged.InvokeAsync( texts );
+            }
+
+            if ( ( selectedValuesParamChanged && values is null && SelectedValues is null ) || ( selectedTextsParamChanged && texts is null && SelectedTexts is null ) )
+            {
+                await Task.WhenAll( ResetSelectedValues(), ResetSelectedTexts() );
             }
         }
 
@@ -605,7 +610,7 @@ namespace Blazorise.Components
 
         private async Task AddMultipleValue( TValue value )
         {
-            SelectedValues ??= new( );
+            SelectedValues ??= new();
 
             if ( !SelectedValues.Contains( value ) && value != null )
             {
@@ -632,7 +637,8 @@ namespace Blazorise.Components
 
         private async Task RemoveMultipleText( string text )
         {
-            if ( SelectedTexts is null ) return;
+            if ( SelectedTexts is null )
+                return;
 
             SelectedTexts.Remove( text );
             await SelectedTextsChanged.InvokeAsync( SelectedTexts );
@@ -643,7 +649,8 @@ namespace Blazorise.Components
 
         private async Task RemoveMultipleValue( TValue value )
         {
-            if ( SelectedValues is null ) return;
+            if ( SelectedValues is null )
+                return;
 
             SelectedValues.Remove( value );
             await SelectedValuesChanged.InvokeAsync( SelectedValues );

--- a/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
+++ b/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
@@ -68,10 +68,7 @@ namespace Blazorise.Components
         NullableT<TValue> selectedValue;
         TValue selectedValueParam;
 
-        List<TValue> selectedValues;
         List<TValue> selectedValuesParam;
-
-        List<string> selectedTexts;
         List<string> selectedTextsParam;
 
         #endregion
@@ -96,23 +93,12 @@ namespace Blazorise.Components
 
             var selectedTextParamChanged = parameters.TryGetValue<string>( nameof( SelectedText ), out var paramSelectedText ) && SelectedText != paramSelectedText;
 
+            var selectedValuesParamChanged = parameters.TryGetValue<IEnumerable<TValue>>( nameof( SelectedValues ), out var paramSelectedValues )
+                && !selectedValuesParam.AreEqualOrdered( paramSelectedValues );
 
-            bool selectedValuesParamChanged = false;
-            bool selectedTextsParamChanged = false;
+            var selectedTextsParamChanged = parameters.TryGetValue<IEnumerable<string>>( nameof( SelectedTexts ), out var paramSelectedTexts )
+                && !selectedTextsParam.AreEqualOrdered( paramSelectedTexts );
 
-            if ( parameters.TryGetValue<IEnumerable<TValue>>( nameof( SelectedValues ), out var paramSelectedValues )
-                && !selectedValuesParam.AreEqualOrdered( paramSelectedValues ) )
-            {
-                selectedValuesParamChanged = true;
-                selectedValues = null;
-            }
-
-            if ( parameters.TryGetValue<IEnumerable<string>>( nameof( SelectedTexts ), out var paramSelectedTexts )
-                && !selectedTextsParam.AreEqualOrdered( paramSelectedTexts ) )
-            {
-                selectedTextsParamChanged = true;
-                selectedTexts = null;
-            }
 
             await base.SetParametersAsync( parameters );
 
@@ -209,13 +195,13 @@ namespace Blazorise.Components
 
             if ( values is not null && !SelectedValues.AreEqualOrdered( values ) )
             {
-                selectedValues = values;
+                SelectedValues = values;
                 await SelectedValuesChanged.InvokeAsync( values );
             }
 
             if ( texts is not null && !SelectedTexts.AreEqualOrdered( texts ) )
             {
-                selectedTexts = texts;
+                SelectedTexts = texts;
                 await SelectedTextsChanged.InvokeAsync( texts );
             }
 
@@ -1258,7 +1244,7 @@ namespace Blazorise.Components
         [Parameter]
         public List<TValue> SelectedValues
         {
-            get => selectedValuesParam ?? selectedValues;
+            get => selectedValuesParam;
             set => selectedValuesParam = ( value == null ? null : new( value ) );
         }
 
@@ -1275,7 +1261,7 @@ namespace Blazorise.Components
         [Parameter]
         public List<string> SelectedTexts
         {
-            get => selectedTextsParam ?? selectedTexts;
+            get => selectedTextsParam;
             set => selectedTextsParam = ( value == null ? null : new( value ) );
         }
 

--- a/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
+++ b/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
@@ -193,7 +193,7 @@ namespace Blazorise.Components
             List<TValue> values = null;
             List<string> texts = null;
 
-            if ( selectedTextsParamChanged && !selectedTextsParam.IsNullOrEmpty() && !Data.IsNullOrEmpty() && !selectedValuesParamChanged )
+            if ( selectedTextsParamChanged && selectedTextsParam is not null && !Data.IsNullOrEmpty() && !selectedValuesParamChanged )
             {
                 values = Data.IntersectBy( SelectedTexts, e => GetItemText( e ) ).Select( e => GetItemValue( e ) ).ToList();
                 if ( !FreeTyping )
@@ -202,7 +202,7 @@ namespace Blazorise.Components
                 }
             }
 
-            if ( selectedValuesParamChanged && !selectedValuesParam.IsNullOrEmpty() && !Data.IsNullOrEmpty() )
+            if ( selectedValuesParamChanged && selectedValuesParam is not null && !Data.IsNullOrEmpty() )
             {
                 texts = Data.IntersectBy( SelectedValues, e => GetItemValue( e ) ).Select( e => GetItemText( e ) ).ToList();
             }
@@ -577,8 +577,8 @@ namespace Blazorise.Components
 
         private async Task ResetSelectedValues()
         {
-            selectedValues?.Clear();
-            await SelectedValuesChanged.InvokeAsync( selectedValues );
+            SelectedValues?.Clear();
+            await SelectedValuesChanged.InvokeAsync( SelectedValues );
         }
 
         private async Task ResetSelectedTexts()

--- a/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
+++ b/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
@@ -71,10 +71,10 @@ namespace Blazorise.Components
         NullableT<TValue> selectedValue;
         TValue selectedValueParam;
 
-        List<TValue> selectedValues = new();
+        List<TValue> selectedValues;
         List<TValue> selectedValuesParam;
 
-        List<string> selectedTexts = new();
+        List<string> selectedTexts;
         List<string> selectedTextsParam;
 
         #endregion
@@ -209,13 +209,13 @@ namespace Blazorise.Components
             }
 
             // fire change events
-            if ( !values.IsNullOrEmpty() && !SelectedValues.AreEqualOrdered( values ) )
+            if ( values is not null && !SelectedValues.AreEqualOrdered( values ) )
             {
                 selectedValues = values;
                 await SelectedValuesChanged.InvokeAsync( values );
             }
 
-            if ( !texts.IsNullOrEmpty() && !SelectedTexts.AreEqualOrdered( texts ) )
+            if ( texts is not null && !SelectedTexts.AreEqualOrdered( texts ) )
             {
                 selectedTexts = texts;
                 await SelectedTextsChanged.InvokeAsync( texts );
@@ -607,6 +607,8 @@ namespace Blazorise.Components
 
         private async Task AddMultipleValue( TValue value )
         {
+            SelectedValues ??= new( );
+
             if ( !SelectedValues.Contains( value ) && value != null )
             {
                 SelectedValues.Add( value );
@@ -619,6 +621,8 @@ namespace Blazorise.Components
 
         private Task AddMultipleText( string text )
         {
+            SelectedTexts ??= new();
+
             if ( !string.IsNullOrEmpty( text ) && !SelectedTexts.Contains( text ) )
             {
                 SelectedTexts.Add( text );
@@ -630,6 +634,8 @@ namespace Blazorise.Components
 
         private async Task RemoveMultipleText( string text )
         {
+            if ( SelectedTexts is null ) return;
+
             SelectedTexts.Remove( text );
             await SelectedTextsChanged.InvokeAsync( SelectedTexts );
 
@@ -639,6 +645,8 @@ namespace Blazorise.Components
 
         private async Task RemoveMultipleValue( TValue value )
         {
+            if ( SelectedValues is null ) return;
+
             SelectedValues.Remove( value );
             await SelectedValuesChanged.InvokeAsync( SelectedValues );
         }
@@ -698,7 +706,7 @@ namespace Blazorise.Components
 
             if ( !ManualReadMode )
             {
-                if ( IsMultiple && !IsSuggestSelectedItems )
+                if ( IsMultiple && !IsSuggestSelectedItems && !SelectedValues.IsNullOrEmpty() )
                     query = query.Where( x => !SelectedValues.Contains( ValueField.Invoke( x ) ) );
 
                 if ( CustomFilter != null )
@@ -903,7 +911,7 @@ namespace Blazorise.Components
         {
             return FreeTyping
                     ? IsMultiple
-                        ? string.Join( ';', SelectedTexts )
+                        ? SelectedTexts.IsNullOrEmpty() ? string.Empty : string.Join( ';', SelectedTexts )
                         : CurrentSearch?.ToString()
                     : SelectedValue?.ToString();
         }
@@ -948,7 +956,7 @@ namespace Blazorise.Components
         /// <param name="value"></param>
         /// <returns></returns>
         public TItem GetItemByValue( TValue value )
-            => Data != null
+            => Data is not null
                    ? Data.FirstOrDefault( x => ValueField( x ).IsEqual( value ) )
                    : default;
 
@@ -958,13 +966,19 @@ namespace Blazorise.Components
         /// <param name="text"></param>
         /// <returns></returns>
         public TItem GetItemByText( string text )
-            => Data != null
+            => Data is not null
                    ? Data.FirstOrDefault( x => TextField( x ).IsEqual( text ) )
                    : default;
 
-
+        /// <summary>
+        /// Gets a <typeparamref name="TValue"/> from <see cref="SelectedValues"/> by using the provided <see cref="TextField"/> && <see cref="ValueField"/>.
+        /// </summary>
+        /// <param name="text"></param>
+        /// <returns></returns>
         private TValue GetValueByText( string text )
-            => SelectedValues.FirstOrDefault( x => GetItemText( x ) == text );
+            => SelectedValues is not null
+            ? SelectedValues.FirstOrDefault( x => GetItemText( x ) == text )
+            : default;
 
         #endregion
 
@@ -1243,7 +1257,7 @@ namespace Blazorise.Components
         [Parameter]
         public List<TValue> SelectedValues
         {
-            get => selectedValuesParam ?? ( selectedValues ??= new() );
+            get => selectedValuesParam ?? selectedValues;
             set => selectedValuesParam = ( value == null ? null : new( value ) );
         }
 
@@ -1260,7 +1274,7 @@ namespace Blazorise.Components
         [Parameter]
         public List<string> SelectedTexts
         {
-            get => selectedTextsParam ?? ( selectedTexts ??= new() );
+            get => selectedTextsParam ?? selectedTexts;
             set => selectedTextsParam = ( value == null ? null : new( value ) );
         }
 

--- a/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
+++ b/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
@@ -65,9 +65,6 @@ namespace Blazorise.Components
         string currentSearch;
         string currentSearchParam;
 
-        string selectedText;
-        string selectedTextParam;
-
         NullableT<TValue> selectedValue;
         TValue selectedValueParam;
 
@@ -90,7 +87,6 @@ namespace Blazorise.Components
             }
 
             bool selectedValueParamChanged = false;
-            bool selectedTextParamChanged = false;
 
             if ( parameters.TryGetValue<TValue>( nameof( SelectedValue ), out var paramSelectedValue ) && !selectedValueParam.IsEqual( paramSelectedValue ) )
             {
@@ -98,11 +94,8 @@ namespace Blazorise.Components
                 selectedValueParamChanged = true;
             }
 
-            if ( parameters.TryGetValue<string>( nameof( SelectedText ), out var paramSelectedText ) && selectedTextParam != paramSelectedText )
-            {
-                selectedText = null;
-                selectedTextParamChanged = true;
-            }
+            var selectedTextParamChanged = parameters.TryGetValue<string>( nameof( SelectedText ), out var paramSelectedText ) && SelectedText != paramSelectedText;
+
 
             bool selectedValuesParamChanged = false;
             bool selectedTextsParamChanged = false;
@@ -173,8 +166,8 @@ namespace Blazorise.Components
                     string text = GetItemText( item );
                     if ( text != SelectedText )
                     {
-                        selectedText = text;
-                        await SelectedTextChanged.InvokeAsync( selectedText );
+                        SelectedText = text;
+                        await SelectedTextChanged.InvokeAsync( SelectedText );
 
                         if ( !IsMultiple && CurrentSearch != SelectedText && !string.IsNullOrEmpty( SelectedText ) )
                         {
@@ -234,13 +227,13 @@ namespace Blazorise.Components
             {
                 if ( HasFilteredData )
                 {
-                    currentSearch = selectedText = GetItemText( FilteredData.First() );
+                    currentSearch = SelectedText = GetItemText( FilteredData.First() );
                     selectedValue = new( GetItemValue( FilteredData.First() ) );
 
                     await Task.WhenAll(
                         CurrentSearchChanged.InvokeAsync( currentSearch ),
                         SearchChanged.InvokeAsync( currentSearch ),
-                        SelectedTextChanged.InvokeAsync( selectedText ),
+                        SelectedTextChanged.InvokeAsync( SelectedText ),
                         SelectedValueChanged.InvokeAsync( selectedValue )
                     );
                 }
@@ -278,10 +271,10 @@ namespace Blazorise.Components
                 {
                     ActiveItemIndex = 0;
                     selectedValue = new( GetItemValue( FilteredData.First() ) );
-                    selectedText = GetItemText( FilteredData.First() );
+                    SelectedText = GetItemText( FilteredData.First() );
                     await Task.WhenAll(
                         SelectedValueChanged.InvokeAsync( selectedValue ),
-                        SelectedTextChanged.InvokeAsync( selectedText )
+                        SelectedTextChanged.InvokeAsync( SelectedText )
                         );
                 }
                 else
@@ -295,8 +288,8 @@ namespace Blazorise.Components
 
                     if ( FreeTyping )
                     {
-                        selectedText = CurrentSearch;
-                        await SelectedTextChanged.InvokeAsync( selectedText );
+                        SelectedText = CurrentSearch;
+                        await SelectedTextChanged.InvokeAsync( SelectedText );
                     }
                     else
                     {
@@ -485,14 +478,14 @@ namespace Blazorise.Components
             {
                 selectedValue = new( selectedTValue );
                 var item = GetItemByValue( selectedValue );
-                currentSearch = selectedText = GetItemText( item );
+                currentSearch = SelectedText = GetItemText( item );
                 DirtyFilter();
 
                 await Task.WhenAll(
                     SelectedValueChanged.InvokeAsync( selectedValue ),
                     CurrentSearchChanged.InvokeAsync( currentSearch ),
                     SearchChanged.InvokeAsync( currentSearch ),
-                    SelectedTextChanged.InvokeAsync( selectedText )
+                    SelectedTextChanged.InvokeAsync( SelectedText )
                 );
             }
 
@@ -553,9 +546,9 @@ namespace Blazorise.Components
         {
             var notifyChange = SelectedText is not null;
 
-            selectedText = null;
+            SelectedText = null;
             if ( notifyChange )
-                await SelectedTextChanged.InvokeAsync( selectedText );
+                await SelectedTextChanged.InvokeAsync( SelectedText );
         }
 
         private async Task ResetSelectedValue()
@@ -1207,11 +1200,7 @@ namespace Blazorise.Components
         /// Gets or sets the currently selected item text.
         /// </summary>
         [Parameter]
-        public string SelectedText
-        {
-            get => selectedText ?? selectedTextParam;
-            set => selectedTextParam = value;
-        }
+        public string SelectedText { get; set; }
 
         /// <summary>
         /// Gets or sets the currently selected item text.

--- a/Tests/BasicTestApp.Client/AutocompleteMultipleReadDataComponent.razor
+++ b/Tests/BasicTestApp.Client/AutocompleteMultipleReadDataComponent.razor
@@ -9,6 +9,7 @@
               @bind-SelectedTexts="SelectedTexts"
               Placeholder="Search..."
               FreeTyping
+              MinLength="MinLength"
               SelectionMode="AutocompleteSelectionMode.Multiple">
     <NotFoundContent> Sorry... @context was not found! :( </NotFoundContent>
 </Autocomplete>
@@ -23,11 +24,15 @@
     public Autocomplete<Country, string> AutoCompleteRef { get; set; }
 
 
+
     protected override async Task OnInitializedAsync()
     {
         Countries = await CountryData.GetDataAsync();
         await base.OnInitializedAsync();
     }
+
+    [Parameter]
+    public int MinLength { get; set; } = 1;
 
     [Parameter]
     public List<string> SelectedValues { get; set; }

--- a/Tests/Blazorise.Tests/Components/AutoCompleteMultipleComponentTest.cs
+++ b/Tests/Blazorise.Tests/Components/AutoCompleteMultipleComponentTest.cs
@@ -1,5 +1,6 @@
 ﻿#region Using directives
 using System.Linq;
+using System.Threading.Tasks;
 using AngleSharp.Dom;
 using BasicTestApp.Client;
 using Blazorise.Tests.Helpers;
@@ -29,9 +30,9 @@ namespace Blazorise.Tests.Components
         }
 
         [Fact]
-        public void Clear_ShouldReset()
+        public Task Clear_ShouldReset()
         {
-            TestClear<AutocompleteMultipleComponent>( ( comp ) => comp.Instance.AutoCompleteRef.Clear(), ( comp ) => comp.Instance.SelectedTexts?.ToArray() );
+            return TestClear<AutocompleteMultipleComponent>( async ( comp ) => await comp.Instance.AutoCompleteRef.Clear(), ( comp ) => comp.Instance.SelectedTexts?.ToArray() );
         }
 
         [Fact]

--- a/Tests/Blazorise.Tests/Components/AutocompleteMultipleReadDataComponentTest.cs
+++ b/Tests/Blazorise.Tests/Components/AutocompleteMultipleReadDataComponentTest.cs
@@ -1,4 +1,5 @@
 ﻿#region Using directives
+using System.Threading.Tasks;
 using BasicTestApp.Client;
 using Blazorise.Tests.Helpers;
 using Xunit;
@@ -24,9 +25,9 @@ namespace Blazorise.Tests.Components
         }
 
         [Fact]
-        public void Clear_ShouldReset()
+        public Task Clear_ShouldReset()
         {
-            TestClear<AutocompleteMultipleReadDataComponent>( ( comp ) => comp.Instance.AutoCompleteRef.Clear(), ( comp ) => comp.Instance.SelectedTexts?.ToArray() );
+            return TestClear<AutocompleteMultipleReadDataComponent>( async ( comp ) => await comp.Instance.AutoCompleteRef.Clear(), ( comp ) => comp.Instance.SelectedTexts?.ToArray() );
         }
 
         [Theory]

--- a/Tests/Blazorise.Tests/Components/Base/AutocompleteBaseComponentTest.cs
+++ b/Tests/Blazorise.Tests/Components/Base/AutocompleteBaseComponentTest.cs
@@ -267,14 +267,15 @@ namespace Blazorise.Tests.Components
             comp.WaitForAssertion( () => this.JSInterop.VerifyInvoke( "focus" ), TestExtensions.WaitTime );
         }
 
-        public void TestClear<TComponent>( Func<IRenderedComponent<TComponent>, Task> clear, Func<IRenderedComponent<TComponent>, string[]> getSelectedTexts ) where TComponent : IComponent
+        public async Task TestClear<TComponent>( Func<IRenderedComponent<TComponent>, Task> clear, Func<IRenderedComponent<TComponent>, string[]> getSelectedTexts ) where TComponent : IComponent
         {
             var comp = RenderComponent<TComponent>( parameters =>
-                parameters.TryAdd( "SelectedValues", new List<string> { "PT", "HR" } )
-            );
+            {
+                parameters.TryAdd( "SelectedValues", new List<string> { "PT", "HR" } );
+                parameters.TryAdd( "MinLength", 0 );
+            } );
 
-            comp.InvokeAsync( async () => await clear( comp ) );
-            comp.Render();
+            await comp.InvokeAsync( async () => await clear( comp ) );
 
             var input = comp.Find( ".b-is-autocomplete input" );
             var inputText = input.GetAttribute( "value" );


### PR DESCRIPTION
Closes #4372

I believe the commits should be self descriptive, just let me know if you have any doubts.

------
I believe we should investigate making the `List<>` Parameters we exposed, actually `IEnumerable<>`. This will probably make it easier to handle changes internally, since users won't be able to mutate the collection by calling `.Add` and `.Remove` directly.
But I'm not entirely sure it would cover all cases. 

And I believe we wouldn't need the triplet parameter thing glutio came up with. I only noticed today, that we're actually keeping an additional collection in memory with 
![image](https://user-images.githubusercontent.com/22283161/208254578-70a65519-138f-4b5b-b19a-7bb77df9bdad.png)
precisely because of these mutations which can't be easily detected && compared without creating new references in memory.

**Example:** User does : `SelectedValues.Add("1")`=> When it gets to `SetParametersAsync`, it can't detect a change regularly by doing
```
parameters.TryGetValue<IEnumerable<TValue>>( nameof( SelectedValues ), out var paramSelectedValues )
                && !SelectedValues.AreEqualOrdered( paramSelectedValues ) )
```
as we usually do, because it's basically the same reference and already mutated.


As for users being able to Add/Remove items programatically they would instead go trough the actual provided Autocomplete APIs or assign a new `IEnumerable<>` which, again I'm believing would make it easy to detect the change with the `ParameterView.TryGetValue` api.
Open a new issue with this if you believe it's worth exploring, otherwise I believe we've been closed most loopholes bit by bit with each issue we've had on this **v1.1** release.