### PR TITLE
Fix closable.js find index functions.

### DIFF
--- a/Source/Blazorise/wwwroot/closable.js
+++ b/Source/Blazorise/wwwroot/closable.js
@@ -37,7 +37,7 @@ function findClosableComponentIndex(elementId) {
 
     for (index = 0; index < closableComponents.length; ++index) {
         if (closableComponents[index].elementId === elementId)
-            return closableComponents[index];
+            return index;
     }
 
     return null;
@@ -48,7 +48,7 @@ function findClosableLightComponentIndex(elementId) {
 
     for (index = 0; index < closableLightComponents.length; ++index) {
         if (closableLightComponents[index].elementId === elementId)
-            return closableLightComponents[index];
+            return index;
     }
 
     return null;


### PR DESCRIPTION
Found a bug introduced in https://github.com/Megabit/Blazorise/commit/35849a1794b380f4f947770b41192ac5f8078b2a. Fixes https://github.com/Megabit/Blazorise/issues/4379.

I imagine this may have caused issues elsewhere as well.