### PR TITLE
#4431 DataGrid's Column extension: Added ability to change on first click sort direction

### DIFF
--- a/Demos/Blazorise.Demo/Pages/Tests/DataGrid/DataInMemoryPage.razor
+++ b/Demos/Blazorise.Demo/Pages/Tests/DataGrid/DataInMemoryPage.razor
@@ -33,7 +33,7 @@
                         <DataGridColumn TItem="Employee" Field="@nameof( Employee.Zip )" Caption="Zip">
                         </DataGridColumn>
                         <DataGridDateColumn TItem="Employee" Field="@nameof( Employee.DateOfBirth )" DisplayFormat="{0:dd.MM.yyyy}" Caption="Date Of Birth" Editable />
-                        <DataGridNumericColumn TItem="Employee" Field="@nameof( Employee.Childrens )" Caption="Childrens" FirstClickSortDirection="SortDirection.Descending" Editable Filterable="false" />
+                        <DataGridNumericColumn TItem="Employee" Field="@nameof( Employee.Childrens )" Caption="Childrens" InverseSorting="true" Editable Filterable="false" />
                         <DataGridSelectColumn TItem="Employee" Field="@nameof( Employee.Gender )" Caption="Gender" Editable>
                             <DisplayTemplate>
                                 @{

--- a/Demos/Blazorise.Demo/Pages/Tests/DataGrid/DataInMemoryPage.razor
+++ b/Demos/Blazorise.Demo/Pages/Tests/DataGrid/DataInMemoryPage.razor
@@ -33,7 +33,7 @@
                         <DataGridColumn TItem="Employee" Field="@nameof( Employee.Zip )" Caption="Zip">
                         </DataGridColumn>
                         <DataGridDateColumn TItem="Employee" Field="@nameof( Employee.DateOfBirth )" DisplayFormat="{0:dd.MM.yyyy}" Caption="Date Of Birth" Editable />
-                        <DataGridNumericColumn TItem="Employee" Field="@nameof( Employee.Childrens )" Caption="Childrens" Editable Filterable="false" />
+                        <DataGridNumericColumn TItem="Employee" Field="@nameof( Employee.Childrens )" Caption="Childrens" FirstClickSortDirection="SortDirection.Descending" Editable Filterable="false" />
                         <DataGridSelectColumn TItem="Employee" Field="@nameof( Employee.Gender )" Caption="Gender" Editable>
                             <DisplayTemplate>
                                 @{

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -1124,7 +1124,9 @@ public partial class DataGrid<TItem> : BaseDataGridComponent
             }
 
             if ( changeSortDirection )
-                column.CurrentSortDirection = sortDirection ?? column.CurrentSortDirection.NextDirection();
+            {
+                column.CurrentSortDirection = sortDirection ?? column.CurrentSortDirection.NextDirection( column.FirstClickSortDirection == SortDirection.Descending );
+            }
 
             if ( !SortByColumns.Any( c => c.GetFieldToSort() == column.GetFieldToSort() ) )
             {

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -1125,7 +1125,7 @@ public partial class DataGrid<TItem> : BaseDataGridComponent
 
             if ( changeSortDirection )
             {
-                column.CurrentSortDirection = sortDirection ?? column.CurrentSortDirection.NextDirection( column.FirstClickSortDirection == SortDirection.Descending );
+                column.CurrentSortDirection = sortDirection ?? column.CurrentSortDirection.NextDirection( column.InverseSorting );
             }
 
             if ( !SortByColumns.Any( c => c.GetFieldToSort() == column.GetFieldToSort() ) )

--- a/Source/Extensions/Blazorise.DataGrid/DataGridColumn.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGridColumn.cs
@@ -313,9 +313,9 @@ public partial class DataGridColumn<TItem> : BaseDataGridColumn<TItem>
     [Parameter] public SortDirection SortDirection { get; set; }
 
     /// <summary>
-    /// Gets or sets the sort direction on the first click.
+    /// Gets or sets whether the sort direction will be Inverted.
     /// </summary>
-    [Parameter] public SortDirection FirstClickSortDirection { get; set; }
+    [Parameter] public bool InverseSorting { get; set; }
 
     /// <summary>
     /// Gets or sets the column's display sort direction template.

--- a/Source/Extensions/Blazorise.DataGrid/DataGridColumn.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGridColumn.cs
@@ -313,6 +313,11 @@ public partial class DataGridColumn<TItem> : BaseDataGridColumn<TItem>
     [Parameter] public SortDirection SortDirection { get; set; }
 
     /// <summary>
+    /// Gets or sets the sort direction on the first click.
+    /// </summary>
+    [Parameter] public SortDirection FirstClickSortDirection { get; set; }
+
+    /// <summary>
     /// Gets or sets the column's display sort direction template.
     /// </summary>
     [Parameter] public RenderFragment<SortDirection> SortDirectionTemplate { get; set; }

--- a/Source/Extensions/Blazorise.DataGrid/ExtensionMethods.cs
+++ b/Source/Extensions/Blazorise.DataGrid/ExtensionMethods.cs
@@ -23,7 +23,7 @@ public static class ExtensionMethods
         switch ( direction )
         {
             case SortDirection.Default:
-                return !isInverse ? SortDirection.Ascending : SortDirection.Descending;
+                return isInverse ? SortDirection.Descending : SortDirection.Ascending;
             case SortDirection.Ascending:
                 return SortDirection.Descending;
             case SortDirection.Descending:

--- a/Source/Extensions/Blazorise.DataGrid/ExtensionMethods.cs
+++ b/Source/Extensions/Blazorise.DataGrid/ExtensionMethods.cs
@@ -16,15 +16,18 @@ public static class ExtensionMethods
     /// Gets the next available direction based on the current one.
     /// </summary>
     /// <param name="direction">Current sort direction.</param>
+    /// <param name="isInverse">Inverse the next sort direction.</param>
     /// <returns>Returns the next available sort direction.</returns>
-    public static SortDirection NextDirection( this SortDirection direction )
+    public static SortDirection NextDirection( this SortDirection direction, bool isInverse = false )
     {
         switch ( direction )
         {
             case SortDirection.Default:
-                return SortDirection.Ascending;
+                return !isInverse ? SortDirection.Ascending : SortDirection.Descending;
             case SortDirection.Ascending:
                 return SortDirection.Descending;
+            case SortDirection.Descending:
+                return SortDirection.Ascending;
             default:
                 return SortDirection.Default;
         }


### PR DESCRIPTION
This is a simple improvement with a small impact on the existing functions.

This improvement adds the property FirstClickSortDirection gives the ability of the developer to select which will be sort direction on the first click, instead of always being ASC and after that, on the second click be DESC.

[Feature #4431](https://github.com/Megabit/Blazorise/issues/4431)