### PR TITLE
Dependabot for js dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,42 @@ updates:
   directory: "/Source/Blazorise.AntDesign"
   schedule:
     interval: daily
-   
+
+- package-ecosystem: npm
+  directory: "/Source/Blazorise.Bootstrap"
+  schedule:
+    interval: daily
+
+- package-ecosystem: npm
+  directory: "/Source/Blazorise.Bootstrap5"
+  schedule:
+    interval: daily
+
+- package-ecosystem: npm
+  directory: "/Source/Blazorise.Bulma"
+  schedule:
+    interval: daily
+
+- package-ecosystem: npm
+  directory: "/Source/Blazorise.Frolic"
+  schedule:
+    interval: daily
+
+- package-ecosystem: npm
+  directory: "/Source/Blazorise.Material"
+  schedule:
+    interval: daily
+
+- package-ecosystem: npm
+  directory: "/Source/Blazorise.Tailwind"
+  schedule:
+    interval: daily
+
+- package-ecosystem: npm
+  directory: "/Source/Extensions/Blazorise.Animations"
+  schedule:
+    interval: daily
+
 - package-ecosystem: npm
   directory: "/Source/Extensions/Blazorise.Charts"
   schedule:
@@ -32,5 +67,95 @@ updates:
     
 - package-ecosystem: npm
   directory: "/Source/Extensions/Blazorise.Charts.Streaming"
+  schedule:
+    interval: daily
+
+- package-ecosystem: npm
+  directory: "/Source/Extensions/Blazorise.Charts.Trendline"
+  schedule:
+    interval: daily
+
+- package-ecosystem: npm
+  directory: "/Source/Extensions/Blazorise.Components"
+  schedule:
+    interval: daily
+
+- package-ecosystem: npm
+  directory: "/Source/Extensions/Blazorise.Cropper"
+  schedule:
+    interval: daily
+
+- package-ecosystem: npm
+  directory: "/Source/Extensions/Blazorise.DataGrid"
+  schedule:
+    interval: daily
+
+- package-ecosystem: npm
+  directory: "/Source/Extensions/Blazorise.FluentValidation"
+  schedule:
+    interval: daily
+
+- package-ecosystem: npm
+  directory: "/Source/Extensions/Blazorise.Icons.Bootstrap"
+  schedule:
+    interval: daily
+
+- package-ecosystem: npm
+  directory: "/Source/Extensions/Blazorise.Icons.FontAwesome"
+  schedule:
+    interval: daily
+
+- package-ecosystem: npm
+  directory: "/Source/Extensions/Blazorise.Icons.Material"
+  schedule:
+    interval: daily
+
+- package-ecosystem: npm
+  directory: "/Source/Extensions/Blazorise.LoadingIndicator"
+  schedule:
+    interval: daily
+
+- package-ecosystem: npm
+  directory: "/Source/Extensions/Blazorise.LottieAnimation"
+  schedule:
+    interval: daily
+
+- package-ecosystem: npm
+  directory: "/Source/Extensions/Blazorise.Markdown"
+  schedule:
+    interval: daily
+
+- package-ecosystem: npm
+  directory: "/Source/Extensions/Blazorise.QRCode"
+  schedule:
+    interval: daily
+
+- package-ecosystem: npm
+  directory: "/Source/Extensions/Blazorise.RichTextEdit"
+  schedule:
+    interval: daily
+
+- package-ecosystem: npm
+  directory: "/Source/Extensions/Blazorise.Sidebar"
+  schedule:
+    interval: daily
+
+- package-ecosystem: npm
+  directory: "/Source/Extensions/Blazorise.Snackbar"
+  schedule:
+    interval: daily
+
+- package-ecosystem: npm
+  directory: "/Source/Extensions/Blazorise.SpinKit"
+  schedule:
+    interval: daily
+
+- package-ecosystem: npm
+  directory: "/Source/Extensions/Blazorise.TreeView"
+  schedule:
+    interval: daily
+
+- package-ecosystem: npm
+  directory: "/Source/Extensions/Blazorise.Video"
   schedule:
     interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,4 +14,23 @@ updates:
   directory: "/Source/Blazorise"
   schedule:
     interval: daily
-  
+
+- package-ecosystem: npm
+  directory: "/Source/Blazorise.AntDesign"
+  schedule:
+    interval: daily
+   
+- package-ecosystem: npm
+  directory: "/Source/Extensions/Blazorise.Charts"
+  schedule:
+    interval: daily
+
+- package-ecosystem: npm
+  directory: "/Source/Extensions/Blazorise.Charts.DataLabels"
+  schedule:
+    interval: daily
+    
+- package-ecosystem: npm
+  directory: "/Source/Extensions/Blazorise.Charts.Streaming"
+  schedule:
+    interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+registries:
+  nuget-feed-default:
+    type: nuget-feed
+    url: https://api.nuget.org/v3/index.json
+    
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+
+- package-ecosystem: npm
+  directory: "/Source/Blazorise"
+  schedule:
+    interval: daily
+  

--- a/Build/Blazorise.props
+++ b/Build/Blazorise.props
@@ -27,6 +27,11 @@
 		<SupportedPlatform Include="browser" />		
 	</ItemGroup>
 
+    <ItemGroup>
+        <Content Remove="package.json" />
+        <None Include="package.json" />
+    </ItemGroup>
+
 	<PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
 		<DefineConstants>$(DefineConstants);NET6_0</DefineConstants>
 	</PropertyGroup>

--- a/Build/Blazorise.props
+++ b/Build/Blazorise.props
@@ -27,11 +27,6 @@
 		<SupportedPlatform Include="browser" />		
 	</ItemGroup>
 
-    <ItemGroup>
-        <Content Remove="package.json" />
-        <None Include="package.json" />
-    </ItemGroup>
-
 	<PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
 		<DefineConstants>$(DefineConstants);NET6_0</DefineConstants>
 	</PropertyGroup>

--- a/Source/Blazorise.AntDesign/package.json
+++ b/Source/Blazorise.AntDesign/package.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "name": "Blazorise.AntDesign",
+  "name": "blazorise.antdesign",
   "private": true,
   "devDependencies": {
   },

--- a/Source/Blazorise.AntDesign/package.json
+++ b/Source/Blazorise.AntDesign/package.json
@@ -1,0 +1,10 @@
+{
+  "version": "1.0.0",
+  "name": "Blazorise.AntDesign",
+  "private": true,
+  "devDependencies": {
+  },
+  "dependencies": {
+    "antd": "4.0.0"
+  }
+}

--- a/Source/Blazorise.Bootstrap/package.json
+++ b/Source/Blazorise.Bootstrap/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "devDependencies": {},
   "dependencies": {
-
+    "bootstrap": "4.6.1"
   }
 }

--- a/Source/Blazorise.Bootstrap/package.json
+++ b/Source/Blazorise.Bootstrap/package.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.0.0",
+  "name": "blazorise.bootstrap",
+  "private": true,
+  "devDependencies": {},
+  "dependencies": {
+
+  }
+}

--- a/Source/Blazorise.Bootstrap5/package.json
+++ b/Source/Blazorise.Bootstrap5/package.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.0.0",
+  "name": "blazorise.bootstrap5",
+  "private": true,
+  "devDependencies": {},
+  "dependencies": {
+
+  }
+}

--- a/Source/Blazorise.Bootstrap5/package.json
+++ b/Source/Blazorise.Bootstrap5/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "devDependencies": {},
   "dependencies": {
-
+    "bootstrap": "5.1.1"
   }
 }

--- a/Source/Blazorise.Bulma/package.json
+++ b/Source/Blazorise.Bulma/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "devDependencies": {},
   "dependencies": {
-
+    "bulma": "0.9.1"
   }
 }

--- a/Source/Blazorise.Bulma/package.json
+++ b/Source/Blazorise.Bulma/package.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.0.0",
+  "name": "blazorise.bulma",
+  "private": true,
+  "devDependencies": {},
+  "dependencies": {
+
+  }
+}

--- a/Source/Blazorise.Frolic/package.json
+++ b/Source/Blazorise.Frolic/package.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.0.0",
+  "name": "blazorise.frolic",
+  "private": true,
+  "devDependencies": {},
+  "dependencies": {
+
+  }
+}

--- a/Source/Blazorise.Material/package.json
+++ b/Source/Blazorise.Material/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "devDependencies": {},
   "dependencies": {
-
+    "djibe-material": "4.6.0",
+    "jquery": "3.3.1"
   }
 }

--- a/Source/Blazorise.Material/package.json
+++ b/Source/Blazorise.Material/package.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.0.0",
+  "name": "blazorise.material",
+  "private": true,
+  "devDependencies": {},
+  "dependencies": {
+
+  }
+}

--- a/Source/Blazorise.Tailwind/package.json
+++ b/Source/Blazorise.Tailwind/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "devDependencies": {},
   "dependencies": {
-
+    "tailwindcss": "3.2.4"
   }
 }

--- a/Source/Blazorise.Tailwind/package.json
+++ b/Source/Blazorise.Tailwind/package.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.0.0",
+  "name": "blazorise.tailwind",
+  "private": true,
+  "devDependencies": {},
+  "dependencies": {
+
+  }
+}

--- a/Source/Blazorise/Blazorise.csproj
+++ b/Source/Blazorise/Blazorise.csproj
@@ -41,8 +41,8 @@
 
   <!-- Note: only copy files in debug mode, we don't want automatic actions in release mode / during publishing -->
 
-  <Target Name="PreBuild - Copy javascript dependencies" 
-		  AfterTargets="NpmInstall" 
+  <Target Name="PreBuild - Copy javascript dependencies"
+		  AfterTargets="NpmInstall"
 		  Condition="'$(Configuration)'=='Debug'">
     <!-- In case original, non-modified libraries are used, it's recommended to always overwrite with the correct version -->
     <!--<Exec Command="xcopy /y &quot;$(ProjectDir)node_modules\autonumeric\dist\autoNumeric.min.js&quot; &quot;$(ProjectDir)wwwroot\vendors\autoNumeric.js&quot;" />
@@ -50,10 +50,10 @@
 	<Exec Command="xcopy /y &quot;$(ProjectDir)node_modules\inputmask\dist\inputmask.min.js&quot; &quot;$(ProjectDir)wwwroot\vendors\inputmask.js&quot;" />-->
   </Target>
 
-  <Target Name="NpmInstall" 
-		  Inputs="package.json" 
-		  Outputs="node_modules/.install-stamp" 
-		  BeforeTargets="BeforeBuild" 
+  <Target Name="NpmInstall"
+		  Inputs="package.json"
+		  Outputs="node_modules/.install-stamp"
+		  BeforeTargets="BeforeBuild"
 		  Condition="'$(Configuration)'=='Debug'">
     <!--
       Use npm install or npm ci depending on RestorePackagesWithLockFile value.
@@ -69,5 +69,5 @@
     <!-- Write the stamp file, so incremental builds work -->
     <Touch Files="node_modules/.install-stamp" AlwaysCreate="true" />
   </Target>
-	
+
 </Project>

--- a/Source/Blazorise/Blazorise.csproj
+++ b/Source/Blazorise/Blazorise.csproj
@@ -13,11 +13,13 @@
 
   <ItemGroup>
     <Content Remove="compilerconfig.json" />
+    <Content Remove="package.json" />
   </ItemGroup>
 
   <ItemGroup>
     <None Include="..\..\LICENSE.md" Pack="true" Visible="false" PackagePath="" />
     <None Include="..\..\NuGet\Blazorise.png" Pack="true" Visible="false" PackagePath="" />
+    <None Include="package.json" />
   </ItemGroup>
 
   <ItemGroup>
@@ -39,4 +41,33 @@
     <CompilerGeneratedFilesOutputPath>__SOURCEGENERATED__</CompilerGeneratedFilesOutputPath>
   </PropertyGroup>
 
+  <!-- Note: only copy files in debug mode, we don't want automatic actions in release mode / during publishing -->
+
+  <Target Name="PreBuild - Copy javascript dependencies" 
+		  AfterTargets="NpmInstall" 
+		  Condition="'$(Configuration)'=='Debug'">
+    <Exec Command="xcopy /y &quot;$(ProjectDir)node_modules\autonumeric\dist\autoNumeric.min.js&quot; &quot;$(ProjectDir)wwwroot\vendors\autoNumeric.js&quot;" />
+	<Exec Command="xcopy /y &quot;$(ProjectDir)node_modules\flatpickr\dist\flatpickr.min.js&quot; &quot;$(ProjectDir)wwwroot\vendors\flatpickr.js&quot;" />
+	<Exec Command="xcopy /y &quot;$(ProjectDir)node_modules\inputmask\dist\inputmask.min.js&quot; &quot;$(ProjectDir)wwwroot\vendors\inputmask.js&quot;" />
+  </Target>
+
+  <Target Name="NpmInstall" Inputs="package.json" 
+		  Outputs="node_modules/.install-stamp" 
+		  BeforeTargets="BeforeBuild" 
+		  Condition="'$(Configuration)'=='Debug'">
+    <!--
+      Use npm install or npm ci depending on RestorePackagesWithLockFile value.
+      Uncomment the following lines if you want to use this feature:
+
+      <PropertyGroup>
+          <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+      </PropertyGroup>
+      -->
+    <Exec Command="npm ci" Condition="'$(RestorePackagesWithLockFile)' == 'true'" />
+    <Exec Command="npm install" Condition="'$(RestorePackagesWithLockFile)' != 'true'" />
+
+    <!-- Write the stamp file, so incremental builds work -->
+    <Touch Files="node_modules/.install-stamp" AlwaysCreate="true" />
+  </Target>
+	
 </Project>

--- a/Source/Blazorise/Blazorise.csproj
+++ b/Source/Blazorise/Blazorise.csproj
@@ -13,13 +13,11 @@
 
   <ItemGroup>
     <Content Remove="compilerconfig.json" />
-    <Content Remove="package.json" />
   </ItemGroup>
 
   <ItemGroup>
     <None Include="..\..\LICENSE.md" Pack="true" Visible="false" PackagePath="" />
     <None Include="..\..\NuGet\Blazorise.png" Pack="true" Visible="false" PackagePath="" />
-    <None Include="package.json" />
   </ItemGroup>
 
   <ItemGroup>
@@ -52,7 +50,8 @@
 	<Exec Command="xcopy /y &quot;$(ProjectDir)node_modules\inputmask\dist\inputmask.min.js&quot; &quot;$(ProjectDir)wwwroot\vendors\inputmask.js&quot;" />-->
   </Target>
 
-  <Target Name="NpmInstall" Inputs="package.json" 
+  <Target Name="NpmInstall" 
+		  Inputs="package.json" 
 		  Outputs="node_modules/.install-stamp" 
 		  BeforeTargets="BeforeBuild" 
 		  Condition="'$(Configuration)'=='Debug'">

--- a/Source/Blazorise/Blazorise.csproj
+++ b/Source/Blazorise/Blazorise.csproj
@@ -39,35 +39,4 @@
     <CompilerGeneratedFilesOutputPath>__SOURCEGENERATED__</CompilerGeneratedFilesOutputPath>
   </PropertyGroup>
 
-  <!-- Note: only copy files in debug mode, we don't want automatic actions in release mode / during publishing -->
-
-  <Target Name="PreBuild - Copy javascript dependencies"
-		  AfterTargets="NpmInstall"
-		  Condition="'$(Configuration)'=='Debug'">
-    <!-- In case original, non-modified libraries are used, it's recommended to always overwrite with the correct version -->
-    <!--<Exec Command="xcopy /y &quot;$(ProjectDir)node_modules\autonumeric\dist\autoNumeric.min.js&quot; &quot;$(ProjectDir)wwwroot\vendors\autoNumeric.js&quot;" />
-	<Exec Command="xcopy /y &quot;$(ProjectDir)node_modules\flatpickr\dist\flatpickr.min.js&quot; &quot;$(ProjectDir)wwwroot\vendors\flatpickr.js&quot;" />
-	<Exec Command="xcopy /y &quot;$(ProjectDir)node_modules\inputmask\dist\inputmask.min.js&quot; &quot;$(ProjectDir)wwwroot\vendors\inputmask.js&quot;" />-->
-  </Target>
-
-  <Target Name="NpmInstall"
-		  Inputs="package.json"
-		  Outputs="node_modules/.install-stamp"
-		  BeforeTargets="BeforeBuild"
-		  Condition="'$(Configuration)'=='Debug'">
-    <!--
-      Use npm install or npm ci depending on RestorePackagesWithLockFile value.
-      Uncomment the following lines if you want to use this feature:
-
-      <PropertyGroup>
-          <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
-      </PropertyGroup>
-      -->
-    <Exec Command="npm ci" Condition="'$(RestorePackagesWithLockFile)' == 'true'" />
-    <Exec Command="npm install" Condition="'$(RestorePackagesWithLockFile)' != 'true'" />
-
-    <!-- Write the stamp file, so incremental builds work -->
-    <Touch Files="node_modules/.install-stamp" AlwaysCreate="true" />
-  </Target>
-
 </Project>

--- a/Source/Blazorise/Blazorise.csproj
+++ b/Source/Blazorise/Blazorise.csproj
@@ -46,9 +46,10 @@
   <Target Name="PreBuild - Copy javascript dependencies" 
 		  AfterTargets="NpmInstall" 
 		  Condition="'$(Configuration)'=='Debug'">
-    <Exec Command="xcopy /y &quot;$(ProjectDir)node_modules\autonumeric\dist\autoNumeric.min.js&quot; &quot;$(ProjectDir)wwwroot\vendors\autoNumeric.js&quot;" />
+    <!-- In case original, non-modified libraries are used, it's recommended to always overwrite with the correct version -->
+    <!--<Exec Command="xcopy /y &quot;$(ProjectDir)node_modules\autonumeric\dist\autoNumeric.min.js&quot; &quot;$(ProjectDir)wwwroot\vendors\autoNumeric.js&quot;" />
 	<Exec Command="xcopy /y &quot;$(ProjectDir)node_modules\flatpickr\dist\flatpickr.min.js&quot; &quot;$(ProjectDir)wwwroot\vendors\flatpickr.js&quot;" />
-	<Exec Command="xcopy /y &quot;$(ProjectDir)node_modules\inputmask\dist\inputmask.min.js&quot; &quot;$(ProjectDir)wwwroot\vendors\inputmask.js&quot;" />
+	<Exec Command="xcopy /y &quot;$(ProjectDir)node_modules\inputmask\dist\inputmask.min.js&quot; &quot;$(ProjectDir)wwwroot\vendors\inputmask.js&quot;" />-->
   </Target>
 
   <Target Name="NpmInstall" Inputs="package.json" 

--- a/Source/Blazorise/package-lock.json
+++ b/Source/Blazorise/package-lock.json
@@ -1,0 +1,28 @@
+{
+  "name": "Blazorise",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@popperjs/core": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.0.tgz",
+      "integrity": "sha512-zrsUxjLOKAzdewIDRWy9nsV1GQsKBCWaGwsZQlCgr6/q+vjyZhFgqedLfFBuI9anTPEUT4APq9Mu0SZBTzIcGQ=="
+    },
+    "autonumeric": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/autonumeric/-/autonumeric-4.6.0.tgz",
+      "integrity": "sha512-bYnD2oD9UMZBTxSWcvXH1MTcp0w+CUBfXe4HI1QJLGzJu+O27Ny5gqzRcFuDsZB9jrZ5SJjqAG0PieJsaUdTcg=="
+    },
+    "flatpickr": {
+      "version": "4.6.9",
+      "resolved": "https://registry.npmjs.org/flatpickr/-/flatpickr-4.6.9.tgz",
+      "integrity": "sha512-F0azNNi8foVWKSF+8X+ZJzz8r9sE1G4hl06RyceIaLvyltKvDl6vqk9Lm/6AUUCi5HWaIjiUbk7UpeE/fOXOpw=="
+    },
+    "inputmask": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/inputmask/-/inputmask-5.0.7.tgz",
+      "integrity": "sha512-rUxbRDS25KEib+c/Ow+K01oprU/+EK9t9SOPC8ov94/ftULGDqj1zOgRU/Hko6uzoKRMdwCfuhAafJ/Wk2wffQ=="
+    }
+  }
+}

--- a/Source/Blazorise/package.json
+++ b/Source/Blazorise/package.json
@@ -1,9 +1,8 @@
 {
   "version": "1.0.0",
-  "name": "Blazorise",
+  "name": "blazorise",
   "private": true,
-  "devDependencies": {
-  },
+  "devDependencies": {},
   "dependencies": {
     "autonumeric": "4.6.0",
     "flatpickr": "4.6.9",

--- a/Source/Blazorise/package.json
+++ b/Source/Blazorise/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "autonumeric": "4.6.0",
     "flatpickr": "4.6.9",
-    "inputmask": "5.0.7"
+    "inputmask": "5.0.7",
+    "@popperjs/core": "2.11.0"
   }
 }

--- a/Source/Blazorise/package.json
+++ b/Source/Blazorise/package.json
@@ -1,0 +1,12 @@
+{
+  "version": "1.0.0",
+  "name": "Blazorise",
+  "private": true,
+  "devDependencies": {
+  },
+  "dependencies": {
+    "autonumeric": "4.6.0",
+    "flatpickr": "4.6.9",
+    "inputmask": "5.0.7"
+  }
+}

--- a/Source/Extensions/Blazorise.Animate/package.json
+++ b/Source/Extensions/Blazorise.Animate/package.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.0.0",
+  "name": "blazorise.animate",
+  "private": true,
+  "devDependencies": {},
+  "dependencies": {
+
+  }
+}

--- a/Source/Extensions/Blazorise.Charts.DataLabels/package.json
+++ b/Source/Extensions/Blazorise.Charts.DataLabels/package.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "name": "Blazorise.Charts.DataLabels",
+  "name": "blazorise.charts.datalabels",
   "private": true,
   "devDependencies": {
   },

--- a/Source/Extensions/Blazorise.Charts.DataLabels/package.json
+++ b/Source/Extensions/Blazorise.Charts.DataLabels/package.json
@@ -1,0 +1,10 @@
+{
+  "version": "1.0.0",
+  "name": "Blazorise.Charts.DataLabels",
+  "private": true,
+  "devDependencies": {
+  },
+  "dependencies": {
+    "chartjs-plugin-datalabels": "2.0.0"
+  }
+}

--- a/Source/Extensions/Blazorise.Charts.Streaming/package.json
+++ b/Source/Extensions/Blazorise.Charts.Streaming/package.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "name": "Blazorise.Charts.Streaming",
+  "name": "blazorise.charts.streaming",
   "private": true,
   "devDependencies": {
   },

--- a/Source/Extensions/Blazorise.Charts.Streaming/package.json
+++ b/Source/Extensions/Blazorise.Charts.Streaming/package.json
@@ -1,0 +1,10 @@
+{
+  "version": "1.0.0",
+  "name": "Blazorise.Charts.Streaming",
+  "private": true,
+  "devDependencies": {
+  },
+  "dependencies": {
+    "chartjs-plugin-streaming": "2.0.0"
+  }
+}

--- a/Source/Extensions/Blazorise.Charts.Trendline/package.json
+++ b/Source/Extensions/Blazorise.Charts.Trendline/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "devDependencies": {},
   "dependencies": {
-
+    "chartjs-plugin-trendline": "2.0.0"
   }
 }

--- a/Source/Extensions/Blazorise.Charts.Trendline/package.json
+++ b/Source/Extensions/Blazorise.Charts.Trendline/package.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.0.0",
+  "name": "blazorise.trendline",
+  "private": true,
+  "devDependencies": {},
+  "dependencies": {
+
+  }
+}

--- a/Source/Extensions/Blazorise.Charts/package.json
+++ b/Source/Extensions/Blazorise.Charts/package.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "name": "Blazorise.Charts",
+  "name": "blazorise.charts",
   "private": true,
   "devDependencies": {
   },

--- a/Source/Extensions/Blazorise.Charts/package.json
+++ b/Source/Extensions/Blazorise.Charts/package.json
@@ -1,0 +1,12 @@
+{
+  "version": "1.0.0",
+  "name": "Blazorise.Charts",
+  "private": true,
+  "devDependencies": {
+  },
+  "dependencies": {
+    "chart.js": "3.7.1",
+    "chartjs-adapter-luxon": "1.0.0",
+    "luxon": "1.27.0"
+  }
+}

--- a/Source/Extensions/Blazorise.Components/package.json
+++ b/Source/Extensions/Blazorise.Components/package.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.0.0",
+  "name": "blazorise.components",
+  "private": true,
+  "devDependencies": {},
+  "dependencies": {
+
+  }
+}

--- a/Source/Extensions/Blazorise.Cropper/package.json
+++ b/Source/Extensions/Blazorise.Cropper/package.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.0.0",
+  "name": "blazorise.cropper",
+  "private": true,
+  "devDependencies": {},
+  "dependencies": {
+
+  }
+}

--- a/Source/Extensions/Blazorise.Cropper/package.json
+++ b/Source/Extensions/Blazorise.Cropper/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "devDependencies": {},
   "dependencies": {
-
+    "cropperjs": "2.0.0-beta.1"
   }
 }

--- a/Source/Extensions/Blazorise.DataGrid/package.json
+++ b/Source/Extensions/Blazorise.DataGrid/package.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.0.0",
+  "name": "blazorise.datagrid",
+  "private": true,
+  "devDependencies": {},
+  "dependencies": {
+
+  }
+}

--- a/Source/Extensions/Blazorise.FluentValidation/package.json
+++ b/Source/Extensions/Blazorise.FluentValidation/package.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.0.0",
+  "name": "blazorise.fluentvalidation",
+  "private": true,
+  "devDependencies": {},
+  "dependencies": {
+
+  }
+}

--- a/Source/Extensions/Blazorise.Icons.Bootstrap/package.json
+++ b/Source/Extensions/Blazorise.Icons.Bootstrap/package.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.0.0",
+  "name": "blazorise.icons.bootstrap",
+  "private": true,
+  "devDependencies": {},
+  "dependencies": {
+
+  }
+}

--- a/Source/Extensions/Blazorise.Icons.FontAwesome/package.json
+++ b/Source/Extensions/Blazorise.Icons.FontAwesome/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "devDependencies": {},
   "dependencies": {
-
+    "@fortawesome/fontawesome-free": "5.15.4"
   }
 }

--- a/Source/Extensions/Blazorise.Icons.FontAwesome/package.json
+++ b/Source/Extensions/Blazorise.Icons.FontAwesome/package.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.0.0",
+  "name": "blazorise.icons.fontawesome",
+  "private": true,
+  "devDependencies": {},
+  "dependencies": {
+
+  }
+}

--- a/Source/Extensions/Blazorise.Icons.Material/package.json
+++ b/Source/Extensions/Blazorise.Icons.Material/package.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.0.0",
+  "name": "blazorise.icons.material",
+  "private": true,
+  "devDependencies": {},
+  "dependencies": {
+
+  }
+}

--- a/Source/Extensions/Blazorise.LoadingIndicator/package.json
+++ b/Source/Extensions/Blazorise.LoadingIndicator/package.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.0.0",
+  "name": "blazorise.loadingindicator",
+  "private": true,
+  "devDependencies": {},
+  "dependencies": {
+
+  }
+}

--- a/Source/Extensions/Blazorise.LottieAnimation/package.json
+++ b/Source/Extensions/Blazorise.LottieAnimation/package.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.0.0",
+  "name": "blazorise.lottieanimation",
+  "private": true,
+  "devDependencies": {},
+  "dependencies": {
+
+  }
+}

--- a/Source/Extensions/Blazorise.LottieAnimation/package.json
+++ b/Source/Extensions/Blazorise.LottieAnimation/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "devDependencies": {},
   "dependencies": {
-
+    "lottie-web": "5.10.0"
   }
 }

--- a/Source/Extensions/Blazorise.Markdown/package.json
+++ b/Source/Extensions/Blazorise.Markdown/package.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.0.0",
+  "name": "blazorise.markdown",
+  "private": true,
+  "devDependencies": {},
+  "dependencies": {
+
+  }
+}

--- a/Source/Extensions/Blazorise.Markdown/package.json
+++ b/Source/Extensions/Blazorise.Markdown/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "devDependencies": {},
   "dependencies": {
-
+    "easymde": "2.18.0",
+    "highlight.js": "9.11.0"
   }
 }

--- a/Source/Extensions/Blazorise.QRCode/package.json
+++ b/Source/Extensions/Blazorise.QRCode/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "devDependencies": {},
   "dependencies": {
-
+    "qr-code-styling-v2": "1.5.1"
   }
 }

--- a/Source/Extensions/Blazorise.QRCode/package.json
+++ b/Source/Extensions/Blazorise.QRCode/package.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.0.0",
+  "name": "blazorise.qrcode",
+  "private": true,
+  "devDependencies": {},
+  "dependencies": {
+
+  }
+}

--- a/Source/Extensions/Blazorise.RichTextEdit/package.json
+++ b/Source/Extensions/Blazorise.RichTextEdit/package.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.0.0",
+  "name": "blazorise.richtextedit",
+  "private": true,
+  "devDependencies": {},
+  "dependencies": {
+
+  }
+}

--- a/Source/Extensions/Blazorise.Sidebar/package.json
+++ b/Source/Extensions/Blazorise.Sidebar/package.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.0.0",
+  "name": "blazorise.sidebar",
+  "private": true,
+  "devDependencies": {},
+  "dependencies": {
+
+  }
+}

--- a/Source/Extensions/Blazorise.Snackbar/package.json
+++ b/Source/Extensions/Blazorise.Snackbar/package.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.0.0",
+  "name": "blazorise.snackbar",
+  "private": true,
+  "devDependencies": {},
+  "dependencies": {
+
+  }
+}

--- a/Source/Extensions/Blazorise.SpinKit/package.json
+++ b/Source/Extensions/Blazorise.SpinKit/package.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.0.0",
+  "name": "blazorise.spinkit",
+  "private": true,
+  "devDependencies": {},
+  "dependencies": {
+
+  }
+}

--- a/Source/Extensions/Blazorise.TreeView/package.json
+++ b/Source/Extensions/Blazorise.TreeView/package.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.0.0",
+  "name": "blazorise.treeview",
+  "private": true,
+  "devDependencies": {},
+  "dependencies": {
+
+  }
+}

--- a/Source/Extensions/Blazorise.Video/package.json
+++ b/Source/Extensions/Blazorise.Video/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "devDependencies": {},
   "dependencies": {
-
+    "dash": "3.22.8",
+    "hls.js": "1.2.6",
+    "plyr": "3.7.2"
   }
 }

--- a/Source/Extensions/Blazorise.Video/package.json
+++ b/Source/Extensions/Blazorise.Video/package.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.0.0",
+  "name": "blazorise.video",
+  "private": true,
+  "devDependencies": {},
+  "dependencies": {
+
+  }
+}


### PR DESCRIPTION
As discussed in #4440 , this is a PoC to add dependabot for the js dependencies.

_Note that this is a PoC to show how it can be used and is not a full solution._

- [x] Add dependabot configuration file so it is aware of the npm projects to check
- [x] Add npm package.config for the _Blazorise_ project. I tried finding the correct packages, but **please verify that these are the correct packages / versions**
- [x] Add "copy js dependencies" in debug mode step so the software is always shipped with the intended packages