### PR TITLE
Modal: dynamically calculate ZIndex

### DIFF
--- a/Source/Blazorise.AntDesign/AntDesignStyleProvider.cs
+++ b/Source/Blazorise.AntDesign/AntDesignStyleProvider.cs
@@ -7,13 +7,25 @@ public class AntDesignStyleProvider : StyleProvider
 {
     #region Modal
 
+    public override int DefaultModalZIndex => 1000;
+
+    public override int DefaultModalBackdropZIndex => 1000;
+
     public override string ModalShow() => "display: block;";
+
+    int ModalZIndexDiff => DefaultModalZIndex - DefaultModalBackdropZIndex;
+
+    public override string ModalZIndex( int modalOpenIndex )
+        => modalOpenIndex > 1 ? $"z-index: {DefaultModalZIndex + ( ModalZIndexDiff * ( modalOpenIndex - 1 ) ) + ModalZIndexDiff}" : null;
+
+    public override string ModalBackdropZIndex( int modalOpenIndex )
+        => modalOpenIndex > 1 ? $"z-index: {DefaultModalZIndex + ( ModalZIndexDiff * ( modalOpenIndex - 1 ) )}" : null;
 
     #endregion
 
     #region ModalBody
 
-    public override string ModalBodyMaxHeight( int maxHeight ) => $"max-height: {maxHeight}vh; overflow-y: auto;";
+    public override string ModalBodyMaxHeight( int maxHeight ) => $"max-height: {maxHeight}vh; overflow-y: auto";
 
     #endregion
 

--- a/Source/Blazorise.Bootstrap/BootstrapStyleProvider.cs
+++ b/Source/Blazorise.Bootstrap/BootstrapStyleProvider.cs
@@ -7,13 +7,25 @@ public class BootstrapStyleProvider : StyleProvider
 {
     #region Modal
 
-    public override string ModalShow() => "display: block;";
+    public override int DefaultModalZIndex => 1050;
+
+    public override int DefaultModalBackdropZIndex => 1040;
+
+    public override string ModalShow() => "display: block";
+
+    int ModalZIndexDiff => DefaultModalZIndex - DefaultModalBackdropZIndex;
+
+    public override string ModalZIndex( int modalOpenIndex )
+        => modalOpenIndex > 1 ? $"z-index: {DefaultModalZIndex + ( ModalZIndexDiff * ( modalOpenIndex - 1 ) ) + ModalZIndexDiff}" : null;
+
+    public override string ModalBackdropZIndex( int modalOpenIndex )
+        => modalOpenIndex > 1 ? $"z-index: {DefaultModalZIndex + ( ModalZIndexDiff * ( modalOpenIndex - 1 ) )}" : null;
 
     #endregion
 
     #region ModalBody
 
-    public override string ModalBodyMaxHeight( int maxHeight ) => $"max-height: {maxHeight}vh; overflow-y: auto;";
+    public override string ModalBodyMaxHeight( int maxHeight ) => $"max-height: {maxHeight}vh; overflow-y: auto";
 
     #endregion
 

--- a/Source/Blazorise.Bootstrap5/Bootstrap5StyleProvider.cs
+++ b/Source/Blazorise.Bootstrap5/Bootstrap5StyleProvider.cs
@@ -8,13 +8,25 @@ public class Bootstrap5StyleProvider
 {
     #region Modal
 
+    public override int DefaultModalZIndex => 1055;
+
+    public override int DefaultModalBackdropZIndex => 1050;
+
     public override string ModalShow() => "display: block;";
+
+    int ModalZIndexDiff => DefaultModalZIndex - DefaultModalBackdropZIndex;
+
+    public override string ModalZIndex( int modalOpenIndex )
+        => modalOpenIndex > 1 ? $"z-index: {DefaultModalZIndex + ( ModalZIndexDiff * ( modalOpenIndex - 1 ) ) + ModalZIndexDiff}" : null;
+
+    public override string ModalBackdropZIndex( int modalOpenIndex )
+        => modalOpenIndex > 1 ? $"z-index: {DefaultModalZIndex + ( ModalZIndexDiff * ( modalOpenIndex - 1 ) )}" : null;
 
     #endregion
 
     #region ModalBody
 
-    public override string ModalBodyMaxHeight( int maxHeight ) => $"max-height: {maxHeight}vh; overflow-y: auto;";
+    public override string ModalBodyMaxHeight( int maxHeight ) => $"max-height: {maxHeight}vh; overflow-y: auto";
 
     #endregion
 

--- a/Source/Blazorise.Bulma/BulmaStyleProvider.cs
+++ b/Source/Blazorise.Bulma/BulmaStyleProvider.cs
@@ -7,19 +7,31 @@ public class BulmaStyleProvider : StyleProvider
 {
     #region Modal
 
+    public override int DefaultModalZIndex => 40;
+
+    public override int DefaultModalBackdropZIndex => 0;
+
     public override string ModalShow() => null;
+
+    int ModalZIndexDiff => DefaultModalZIndex - DefaultModalBackdropZIndex;
+
+    public override string ModalZIndex( int modalOpenIndex )
+        => modalOpenIndex > 1 ? $"z-index: {DefaultModalZIndex + ModalZIndexDiff}" : null;
+
+    public override string ModalBackdropZIndex( int modalOpenIndex )
+        => null;
 
     #endregion
 
     #region ModalBody
 
-    public override string ModalBodyMaxHeight( int maxHeight ) => $"max-height: {maxHeight}vh; overflow-y: auto;";
+    public override string ModalBodyMaxHeight( int maxHeight ) => $"max-height: {maxHeight}vh; overflow-y: auto";
 
     #endregion
 
     #region ProgressBar
 
-    public override string ProgressBarValue( int value ) => $"width: {value}%;";
+    public override string ProgressBarValue( int value ) => $"width: {value}%";
 
     public override string ProgressBarSize( Size size ) => null;
 

--- a/Source/Blazorise.Tailwind/TailwindStyleProvider.cs
+++ b/Source/Blazorise.Tailwind/TailwindStyleProvider.cs
@@ -7,13 +7,25 @@ public class TailwindStyleProvider : StyleProvider
 {
     #region Modal
 
+    public override int DefaultModalZIndex => 50;
+
+    public override int DefaultModalBackdropZIndex => 40;
+
     public override string ModalShow() => null;
+
+    int ModalZIndexDiff => DefaultModalZIndex - DefaultModalBackdropZIndex;
+
+    public override string ModalZIndex( int modalOpenIndex )
+        => modalOpenIndex > 1 ? $"z-index: {DefaultModalZIndex + ( ModalZIndexDiff * ( modalOpenIndex - 1 ) ) + ModalZIndexDiff}" : null;
+
+    public override string ModalBackdropZIndex( int modalOpenIndex )
+        => modalOpenIndex > 1 ? $"z-index: {DefaultModalZIndex + ( ModalZIndexDiff * ( modalOpenIndex - 1 ) )}" : null;
 
     #endregion
 
     #region ModalBody
 
-    public override string ModalBodyMaxHeight( int maxHeight ) => $"max-height: {maxHeight}vh; overflow-y: auto;";
+    public override string ModalBodyMaxHeight( int maxHeight ) => $"max-height: {maxHeight}vh; overflow-y: auto";
 
     #endregion
 

--- a/Source/Blazorise/Components/Modal/Modal.razor.cs
+++ b/Source/Blazorise/Components/Modal/Modal.razor.cs
@@ -123,7 +123,8 @@ public partial class Modal : BaseComponent, ICloseActivator, IAnimatedComponent,
     protected override void BuildStyles( StyleBuilder builder )
     {
         builder.Append( StyleProvider.ModalShow(), IsVisible );
-        builder.Append( $"--modal-animation-duration: {AnimationDuration}ms;" );
+        builder.Append( StyleProvider.ModalZIndex( OpenIndex ) );
+        builder.Append( $"--modal-animation-duration: {AnimationDuration}ms" );
 
         base.BuildStyles( builder );
     }
@@ -298,6 +299,12 @@ public partial class Modal : BaseComponent, ICloseActivator, IAnimatedComponent,
     {
         if ( visible )
         {
+            if ( ModalContext is not null )
+            {
+                // save the state of the modal index
+                state = state with { OpenIndex = ModalContext.RaiseModalOpenIndex() };
+            }
+
             jsRegistered = true;
 
             ExecuteAfterRender( async () =>
@@ -309,6 +316,12 @@ public partial class Modal : BaseComponent, ICloseActivator, IAnimatedComponent,
         }
         else
         {
+            if ( ModalContext is not null )
+            {
+                // save the state of the modal index
+                state = state with { OpenIndex = ModalContext.DecreaseModalOpenIndex() };
+            }
+
             jsRegistered = false;
 
             ExecuteAfterRender( async () =>
@@ -428,6 +441,11 @@ public partial class Modal : BaseComponent, ICloseActivator, IAnimatedComponent,
     protected internal bool IsVisible => State.Visible == true;
 
     /// <summary>
+    /// Returns the opened index of modal.
+    /// </summary>
+    protected internal int OpenIndex => State.OpenIndex;
+
+    /// <summary>
     /// Returns true if the modal backdrop should be visible.
     /// </summary>
     protected internal bool BackdropVisible = false;
@@ -460,6 +478,11 @@ public partial class Modal : BaseComponent, ICloseActivator, IAnimatedComponent,
     /// Gets or sets the <see cref="IJSClosableModule"/> instance.
     /// </summary>
     [Inject] public IJSClosableModule JSClosableModule { get; set; }
+
+    /// <summary>
+    /// Gets or sets the modal shared context.
+    /// </summary>
+    [Inject] private ModalSharedContext ModalContext { get; set; }
 
     /// <summary>
     /// Defines the visibility of modal dialog.

--- a/Source/Blazorise/Components/Modal/ModalSharedContext.cs
+++ b/Source/Blazorise/Components/Modal/ModalSharedContext.cs
@@ -1,0 +1,36 @@
+﻿namespace Blazorise
+{
+    /// <summary>
+    /// Holds the shared context for all the modals in current application state.
+    /// </summary>
+    internal class ModalSharedContext
+    {
+        /// <summary>
+        /// Raises the modals <see cref="OpenIndex"/> and returns the new index.
+        /// </summary>
+        /// <returns>Returns the new open index.</returns>
+        public int RaiseModalOpenIndex()
+        {
+            return ++OpenIndex;
+        }
+
+        /// <summary>
+        /// Decrease the modals <see cref="OpenIndex"/> and returns the new index.
+        /// </summary>
+        /// <returns>Returns the new open index.</returns>
+        public int DecreaseModalOpenIndex()
+        {
+            --OpenIndex;
+
+            if ( OpenIndex < 0 )
+                OpenIndex = 0;
+
+            return OpenIndex;
+        }
+
+        /// <summary>
+        /// Gets or sets the modal open index.
+        /// </summary>
+        public int OpenIndex { get; private set; }
+    }
+}

--- a/Source/Blazorise/Components/Modal/_ModalBackdrop.razor.cs
+++ b/Source/Blazorise/Components/Modal/_ModalBackdrop.razor.cs
@@ -37,6 +37,14 @@ public partial class _ModalBackdrop : BaseComponent
         base.BuildClasses( builder );
     }
 
+    /// <inheritdoc/>
+    protected override void BuildStyles( StyleBuilder builder )
+    {
+        builder.Append( StyleProvider.ModalBackdropZIndex( parentModalState.OpenIndex ) );
+
+        base.BuildStyles( builder );
+    }
+
     #endregion
 
     #region Properties
@@ -64,6 +72,7 @@ public partial class _ModalBackdrop : BaseComponent
             parentModalState = value;
 
             DirtyClasses();
+            DirtyStyles();
         }
     }
 

--- a/Source/Blazorise/Config.cs
+++ b/Source/Blazorise/Config.cs
@@ -30,6 +30,9 @@ public static class Config
         serviceCollection.AddScoped<IComponentActivator, ComponentActivator>();
         serviceCollection.AddScoped<IComponentDisposer, ComponentDisposer>();
 
+        // Shared component context. Must be defined as scoped as we want to make it available for the user session.
+        serviceCollection.AddScoped<ModalSharedContext>();
+
         // If options handler is not defined we will get an exception so
         // we need to initialize an empty action.
         configureOptions ??= _ => { };

--- a/Source/Blazorise/Interfaces/IStyleProvider.cs
+++ b/Source/Blazorise/Interfaces/IStyleProvider.cs
@@ -4,7 +4,15 @@ public interface IStyleProvider
 {
     #region Modal
 
+    int DefaultModalZIndex { get; }
+
+    int DefaultModalBackdropZIndex { get; }
+
     string ModalShow();
+
+    string ModalZIndex( int modalOpenIndex );
+
+    string ModalBackdropZIndex( int modalOpenIndex );
 
     #endregion
 

--- a/Source/Blazorise/Providers/EmptyStyleProvider.cs
+++ b/Source/Blazorise/Providers/EmptyStyleProvider.cs
@@ -7,7 +7,15 @@ class EmptyStyleProvider : IStyleProvider
 {
     #region Modal
 
+    public int DefaultModalZIndex => 0;
+
+    public int DefaultModalBackdropZIndex => 0;
+
     public string ModalShow() => null;
+
+    public string ModalZIndex( int modalOpenIndex ) => null;
+
+    public string ModalBackdropZIndex( int modalOpenIndex ) => null;
 
     #endregion
 

--- a/Source/Blazorise/Providers/StyleProvider.cs
+++ b/Source/Blazorise/Providers/StyleProvider.cs
@@ -8,7 +8,15 @@ public abstract class StyleProvider : IStyleProvider
 {
     #region Modal
 
+    public abstract int DefaultModalZIndex { get; }
+
+    public abstract int DefaultModalBackdropZIndex { get; }
+
     public abstract string ModalShow();
+
+    public abstract string ModalZIndex( int modalOpenIndex );
+
+    public abstract string ModalBackdropZIndex( int modalOpenIndex );
 
     #endregion
 

--- a/Source/Blazorise/States/ModalState.cs
+++ b/Source/Blazorise/States/ModalState.cs
@@ -9,4 +9,9 @@ public record ModalState
     /// Defines the visibility of modal dialog.
     /// </summary>
     public bool Visible { get; init; }
+
+    /// <summary>
+    /// Defines the open state of the modal dialog.
+    /// </summary>
+    public int OpenIndex { get; init; }
 }

--- a/Source/Blazorise/Utilities/StyleBuilder.cs
+++ b/Source/Blazorise/Utilities/StyleBuilder.cs
@@ -46,7 +46,7 @@ public class StyleBuilder
     /// <param name="value">The string to append.</param>
     public void Append( string value )
     {
-        if ( value != null )
+        if ( value is not null )
             builder.Append( value ).Append( Delimiter );
     }
 
@@ -57,7 +57,7 @@ public class StyleBuilder
     /// <param name="condition">Condition that must be true.</param>
     public void Append( string value, bool condition )
     {
-        if ( condition )
+        if ( value is not null && condition )
             builder.Append( value ).Append( Delimiter );
     }
 

--- a/Tests/Blazorise.Tests/Helpers/BlazoriseConfig.cs
+++ b/Tests/Blazorise.Tests/Helpers/BlazoriseConfig.cs
@@ -35,6 +35,9 @@ public static class BlazoriseConfig
         services.AddScoped<ITextLocalizerService, TextLocalizerService>();
         services.AddScoped( typeof( ITextLocalizer<> ), typeof( TextLocalizer<> ) );
 
+        // Shared component context. Must be defined as scoped as we want to make it available for the user session.
+        services.AddScoped<ModalSharedContext>();
+
         Action<BlazoriseOptions> configureOptions = ( options ) =>
         {
         };


### PR DESCRIPTION
Closes #3878

The ZIndex is calculated based on the difference between zindex of the modal and backdrop. The difference is then raised based on the open index to ensure the new index is always higher than the previous one.

Also, I fixed some minor bugs with the styles `;` delimiter.