### PR TITLE
Markdown - Able to provide uploadUrl after the actual Upload has happened

### DIFF
--- a/Source/Blazorise/Utilities/IO/FileEntry.cs
+++ b/Source/Blazorise/Utilities/IO/FileEntry.cs
@@ -96,8 +96,10 @@ public class FileEntry : IFileEntry
     /// <inheritdoc/>
     public FileEntryStatus Status { get; set; }
 
-    /// <inheritdoc/>
-    public TaskCompletionSource<string> UploadUrlCallback { get; set; }
+    /// <summary>
+    /// Provides a completion source to delay completion until after the file operation has been fully completed.
+    /// </summary>
+    public TaskCompletionSource FileUploadEndedCallback { get; set; }
 
     #endregion
 }

--- a/Source/Blazorise/Utilities/IO/FileEntry.cs
+++ b/Source/Blazorise/Utilities/IO/FileEntry.cs
@@ -96,5 +96,8 @@ public class FileEntry : IFileEntry
     /// <inheritdoc/>
     public FileEntryStatus Status { get; set; }
 
+    /// <inheritdoc/>
+    public TaskCompletionSource<string> UploadUrlCallback { get; set; }
+
     #endregion
 }

--- a/Source/Blazorise/Utilities/IO/IFileEntry.cs
+++ b/Source/Blazorise/Utilities/IO/IFileEntry.cs
@@ -93,4 +93,10 @@ public interface IFileEntry
     /// Cancels any ongoing FileEntry operation.
     /// </summary>
     public Task Cancel();
+
+    /// <summary>
+    /// Provides a completion source to return an UploadUrl after a file operation has been fully completed.
+    /// If this is set, the underlying component will be using this over <see cref="UploadUrl"/>.
+    /// </summary>
+    public TaskCompletionSource<string> UploadUrlCallback { get; set; }
 }

--- a/Source/Blazorise/Utilities/IO/IFileEntry.cs
+++ b/Source/Blazorise/Utilities/IO/IFileEntry.cs
@@ -95,8 +95,7 @@ public interface IFileEntry
     public Task Cancel();
 
     /// <summary>
-    /// Provides a completion source to return an UploadUrl after a file operation has been fully completed.
-    /// If this is set, the underlying component will be using this over <see cref="UploadUrl"/>.
+    /// Provides a completion source to delay completion until after the file operation has been fully completed.
     /// </summary>
-    public TaskCompletionSource<string> UploadUrlCallback { get; set; }
+    TaskCompletionSource FileUploadEndedCallback { get; set; }
 }

--- a/Source/Extensions/Blazorise.Markdown/Markdown.razor.cs
+++ b/Source/Extensions/Blazorise.Markdown/Markdown.razor.cs
@@ -297,32 +297,28 @@ public partial class Markdown : BaseComponent,
     }
 
     /// <inheritdoc/>
-    public async Task UpdateFileEndedAsync( IFileEntry fileEntry, bool success, FileInvalidReason fileInvalidReason )
+    public Task UpdateFileEndedAsync( IFileEntry fileEntry, bool success, FileInvalidReason fileInvalidReason )
     {
-        if ( ImageUploadEnded is not null )
-            await ImageUploadEnded.Invoke( new( fileEntry, success, fileInvalidReason ) );
-
-        if ( !success )
-        {
-            await JSModule.NotifyImageUploadError( ElementId, fileEntry.ErrorMessage );
-            return;
-        }
-
-
-        if ( fileEntry.FileUploadEndedCallback is null )
-        {
-            await JSModule.NotifyImageUploadSuccess( ElementId, fileEntry.UploadUrl ?? string.Empty );
-        }
-        else
-        {
 #pragma warning disable CS4014 // We want to let execution complete but wait for TaskCompletionSource on the background.
-            Task.Run( async () =>
-            {
+        InvokeAsync( async () =>
+        {
+            if ( fileEntry.FileUploadEndedCallback is not null )
                 await fileEntry.FileUploadEndedCallback.Task;
-                await InvokeAsync( async () => await JSModule.NotifyImageUploadSuccess( ElementId, fileEntry.UploadUrl ?? string.Empty ) );
-            } );
-#pragma warning restore CS4014 
-        }
+
+            if ( ImageUploadEnded is not null )
+                await ImageUploadEnded.Invoke( new( fileEntry, success, fileInvalidReason ) );
+
+            if ( !success )
+            {
+                await JSModule.NotifyImageUploadError( ElementId, fileEntry.ErrorMessage );
+                return;
+            }
+
+            await JSModule.NotifyImageUploadSuccess( ElementId, fileEntry.UploadUrl ?? string.Empty );
+        } );
+#pragma warning restore CS4014
+
+        return Task.CompletedTask;
     }
 
     /// <inheritdoc/>

--- a/Source/Extensions/Blazorise.Markdown/Markdown.razor.cs
+++ b/Source/Extensions/Blazorise.Markdown/Markdown.razor.cs
@@ -281,7 +281,7 @@ public partial class Markdown : BaseComponent,
         file.FileUploadEndedCallback.SetResult();
         await InvokeAsync( StateHasChanged );
     }
-    private TaskCompletionSource taskCompletionSource;
+
     /// <inheritdoc/>
     public Task UpdateFileStartedAsync( IFileEntry fileEntry )
     {


### PR DESCRIPTION
Closes #4335

As a brief reminder, the problem here, is that when uploading images on `Markdown`, you can't set the `File.UploadUrl` before the internal `JSModule.NotifyImageUploadSuccess` (notifies markdown of image success + url) occurs, since it occurs as part of the final process of our file write operations (`FileEndedEvent`).

I don't think there's a good way to do this without introducing any new api. You could probably do some tricks with delays, etc...? But that doesn't seem right. Better have an explicit api in my opinion.
Do you like this one? As long as we properly document it isn't too hard for the user to use. Also, was this where you were going with the `TaskCompletionSource`? I couldn't find another way.

Testing code:
```
<Markdown ImageUploadChanged="Changed" ImageUploadEnded="ImageUploadEnded">

</Markdown>

@code {
    private string result = string.Empty;
    private async Task Changed( FileChangedEventArgs e )
    {
        var file = e.Files[0];
        file.UploadUrlCallback = new TaskCompletionSource<string>();
        result = await Upload( file );
        file.UploadUrlCallback.SetResult(result);
    }

    private async Task<string> Upload( IFileEntry file )
    {
        var stream = new MemoryStream();
        await file.WriteToStreamAsync( stream );
        return "xpto";
    }

    Task ImageUploadEnded( FileEndedEventArgs e )
    {
        Console.WriteLine( "Ended" );
        if ( e.Success )
        {
            e.File.UploadUrl = result;
        }
        else
        {
            e.File.UploadUrl = "FAIL";
        }
        return Task.CompletedTask;
    }
}
```