### PR TITLE
DatePicker: hack to fix the disabled month rendering

### DIFF
--- a/Source/Blazorise/wwwroot/datePicker.js
+++ b/Source/Blazorise/wwwroot/datePicker.js
@@ -74,6 +74,10 @@ export function initialize(element, elementId, options) {
         picker.altInput.readOnly = options.readOnly || false;
     }
 
+    picker.customOptions = {
+        inputMode: options.inputMode
+    };
+
     _pickers[elementId] = picker;
 }
 
@@ -95,7 +99,8 @@ export function updateValue(element, elementId, value) {
     if (picker) {
         picker.setDate(value);
 
-        if (picker.nextMonthNav) {
+        // workaround for https://github.com/flatpickr/flatpickr/issues/2861
+        if (picker.customOptions && picker.customOptions.inputMode === 2 && picker.nextMonthNav) {
             picker.nextMonthNav.click();
             picker.jumpToDate(value, false);
         }

--- a/Source/Blazorise/wwwroot/datePicker.js
+++ b/Source/Blazorise/wwwroot/datePicker.js
@@ -94,6 +94,11 @@ export function updateValue(element, elementId, value) {
 
     if (picker) {
         picker.setDate(value);
+
+        if (picker.nextMonthNav) {
+            picker.nextMonthNav.click();
+            picker.jumpToDate(value, false);
+        }
     }
 }
 


### PR DESCRIPTION
Closes #4581

A fix for the problem https://github.com/flatpickr/flatpickr/issues/2861

**Test code:**

```razor
<Button Color="Color.Primary" Clicked="@(()=> _selectedDate = DateTime.Today)">
    SET VALUE
</Button>

<DatePicker Date="@_selectedDate"
    @ref="_datePicker"
    DateChanged="@OnDateChangedAsync"
    InputMode="DateInputMode.Month" TValue="DateTime?"
    Min="@DateTimeOffset.MinValue" Max="@DateTimeOffset.Now" />

@code {
    private DatePicker<DateTime?> _datePicker;
    private DateTime? _selectedDate;

    private Task OnDateChangedAsync( DateTime? date )
    {
        _selectedDate = date;

        StateHasChanged();

        return Task.CompletedTask;
    }
}
```