### PR TITLE
DatePicker: disable input on mobile

### DIFF
--- a/Documentation/Blazorise.Docs/Pages/Docs/Components/Dates/DatePickerPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Components/Dates/DatePickerPage.razor
@@ -287,7 +287,7 @@
     <DocsAttributesItem Name="Inline" Type="bool" Default="false">
         Display the calendar in an always-open state with the inline option.
     </DocsAttributesItem>
-    <DocsAttributesItem Name="DisableMobile" Type="bool" Default="true">
+    <DocsAttributesItem Name="DisableMobile" Type="bool" Default="false">
         If enabled, it disables the native input on mobile devices.
     </DocsAttributesItem>
 </DocsAttributes>

--- a/Source/Blazorise/Components/DatePicker/DatePicker.razor.cs
+++ b/Source/Blazorise/Components/DatePicker/DatePicker.razor.cs
@@ -533,7 +533,7 @@ public partial class DatePicker<TValue> : BaseTextInput<IReadOnlyList<TValue>>, 
     /// <summary>
     /// If enabled, it disables the native input on mobile devices.
     /// </summary>
-    [Parameter] public bool DisableMobile { get; set; } = true;
+    [Parameter] public bool DisableMobile { get; set; }
 
     #endregion
 }

--- a/Source/Blazorise/wwwroot/datePicker.js
+++ b/Source/Blazorise/wwwroot/datePicker.js
@@ -39,8 +39,8 @@ export function initialize(element, elementId, options) {
     const defaultOptions = {
         enableTime: options.inputMode === 1,
         dateFormat: options.inputMode === 1 ? 'Y-m-d H:i' : 'Y-m-d',
-        allowInput: true,
-        altInput: true,
+        allowInput: !(options.disableMobile || false),
+        altInput: !(options.disableMobile || false),
         altFormat: options.displayFormat ? options.displayFormat : (options.inputMode === 1 ? 'Y-m-d H:i' : 'Y-m-d'),
         defaultDate: options.defaultDate,
         minDate: options.min,
@@ -52,7 +52,7 @@ export function initialize(element, elementId, options) {
         clickOpens: !(options.readOnly || false),
         disable: options.disabledDates || [],
         inline: options.inline || false,
-        disableMobile: options.disableMobile || true,
+        disableMobile: options.disableMobile || false,
         static: true
     };
 

--- a/Source/Blazorise/wwwroot/datePicker.js
+++ b/Source/Blazorise/wwwroot/datePicker.js
@@ -69,7 +69,7 @@ export function initialize(element, elementId, options) {
 
     const picker = flatpickr(element, Object.assign({}, defaultOptions, pluginOptions));
 
-    if (options) {
+    if (options && picker.altInput) {
         picker.altInput.disabled = options.disabled || false;
         picker.altInput.readOnly = options.readOnly || false;
     }

--- a/Source/Blazorise/wwwroot/datePicker.js
+++ b/Source/Blazorise/wwwroot/datePicker.js
@@ -39,8 +39,8 @@ export function initialize(element, elementId, options) {
     const defaultOptions = {
         enableTime: options.inputMode === 1,
         dateFormat: options.inputMode === 1 ? 'Y-m-d H:i' : 'Y-m-d',
-        allowInput: !(options.disableMobile || false),
-        altInput: !(options.disableMobile || false),
+        allowInput: !(isMobile() && (options.disableMobile || false)),
+        altInput: !(isMobile() && (options.disableMobile || false)),
         altFormat: options.displayFormat ? options.displayFormat : (options.inputMode === 1 ? 'Y-m-d H:i' : 'Y-m-d'),
         defaultDate: options.defaultDate,
         minDate: options.min,
@@ -218,4 +218,10 @@ export function select(element, elementId, focus) {
     if (picker && picker.altInput) {
         utilities.select(picker.altInput, null, focus);
     }
+}
+
+function isMobile() {
+    return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+        navigator.userAgent
+    );
 }


### PR DESCRIPTION
Closes #4577

This PR disables the input it DisableMobile is enabled. I have also set DisableMobile with default `false`, par flatpickr documentation.

The only problem is that the input is shown as grayed like it has a disabled state. I don't know if that is the right behavior for the [flatpickr](https://github.com/flatpickr/flatpickr).

**Example**

![image](https://user-images.githubusercontent.com/900302/218277870-7d7df59b-3359-4877-83dc-fc6092e375d9.png)

@Mr-Pearce do you think this is OK?