### PR TITLE
DataLabels: fix update from parameters

### DIFF
--- a/Source/Blazorise/Base/BaseComponent.cs
+++ b/Source/Blazorise/Base/BaseComponent.cs
@@ -336,11 +336,6 @@ public abstract class BaseComponent : BaseAfterRenderComponent
     public string StyleNames => StyleBuilder.Styles;
 
     /// <summary>
-    /// Holds the information about the Blazorise global options.
-    /// </summary>
-    [Inject] protected BlazoriseOptions Options { get; set; }
-
-    /// <summary>
     /// Gets or set the javascript runner.
     /// </summary>
     [Inject] protected IIdGenerator IdGenerator { get; set; }

--- a/Source/Extensions/Blazorise.Charts.DataLabels/ChartDataLabels.razor.cs
+++ b/Source/Extensions/Blazorise.Charts.DataLabels/ChartDataLabels.razor.cs
@@ -25,6 +25,26 @@ public partial class ChartDataLabels<TItem> : BaseComponent, IAsyncDisposable
     #region Methods
 
     /// <inheritdoc/>
+    public override Task SetParametersAsync( ParameterView parameters )
+    {
+        if ( Rendered && JSModule is not null )
+        {
+            var datasetsChanged = parameters.TryGetValue<List<ChartDataLabelsDataset>>( nameof( Datasets ), out var paramDataset ) && !Datasets.AreEqual( paramDataset );
+            var optionsChanged = parameters.TryGetValue<ChartDataLabelsOptions>( nameof( Options ), out var paramOptions ) && !Options.IsEqual( paramOptions );
+
+            if ( datasetsChanged || optionsChanged )
+            {
+                ExecuteAfterRender( async () =>
+                {
+                    await JSModule.SetDataLabels( ParentChart.ElementId, Datasets, Options );
+                } );
+            }
+        }
+
+        return base.SetParametersAsync( parameters );
+    }
+
+    /// <inheritdoc/>
     protected override Task OnInitializedAsync()
     {
         if ( ParentChart is not null )


### PR DESCRIPTION
Closes #4585

With this PR, we fix the update of the DataLabels that were being static and only defined once per initialization. We check it the data was changed and then update if needed.