### PR TITLE
TimeOnly TimePicker fix format string

### DIFF
--- a/Source/Blazorise/Components/TimeEdit/TimeEdit.razor.cs
+++ b/Source/Blazorise/Components/TimeEdit/TimeEdit.razor.cs
@@ -80,7 +80,7 @@ public partial class TimeEdit<TValue> : BaseTextInput<TValue>
         {
             null => null,
             TimeSpan timeSpan => timeSpan.ToString( Parsers.InternalTimeFormat.ToLowerInvariant() ),
-            TimeOnly timeOnly => timeOnly.ToString( Parsers.InternalTimeFormat.ToLowerInvariant() ),
+            TimeOnly timeOnly => timeOnly.ToString( Parsers.InternalTimeFormat ),
             DateTime datetime => datetime.ToString( Parsers.InternalTimeFormat ),
             _ => throw new InvalidOperationException( $"Unsupported type {value.GetType()}" ),
         };


### PR DESCRIPTION
TimeOnly should use HH instead of hh.

fixes #4020