### PR TITLE
DataGrid: place command buttons inside of inline div

### DIFF
--- a/Source/Extensions/Blazorise.DataGrid/_DataGridRowCommand.razor
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridRowCommand.razor
@@ -2,100 +2,104 @@
 @inherits _BaseDataGridRowCommand<TItem>
 @if ( EditState == DataGridEditState.Edit )
 {
-    <TableRowCell Class="@(Column.CellClass?.Invoke(Item))" Style="@BuildCellStyle()" TextAlignment="@Column.TextAlignment" VerticalAlignment="@Column.VerticalAlignment" Display="@Column.Display" Flex="@GetCommandFlex()" Gap="@GetCommandGap()">
-        @if ( ParentDataGrid.CommandColumn?.SaveCommandAllowed == true )
-        {
-            var saveButtonString = Localizer.Localize( ParentDataGrid.Localizers?.SaveButtonLocalizer, "Save" );
+    <TableRowCell Class="@(Column.CellClass?.Invoke(Item))" Style="@BuildCellStyle()" TextAlignment="@Column.TextAlignment" VerticalAlignment="@Column.VerticalAlignment" Display="@Column.Display" Flex="@Column.Flex" Gap="@Column.Gap">
+        <Div Flex="@DefaultFlex" Gap="@DefaultGap">
+            @if ( ParentDataGrid.CommandColumn?.SaveCommandAllowed == true )
+            {
+                var saveButtonString = Localizer.Localize( ParentDataGrid.Localizers?.SaveButtonLocalizer, "Save" );
 
-            @if ( ParentDataGrid.CommandColumn?.SaveCommandTemplate != null )
-            {
-                @ParentDataGrid.CommandColumn.SaveCommandTemplate( new()
+                @if ( ParentDataGrid.CommandColumn?.SaveCommandTemplate != null )
                 {
-                    Clicked = Save,
-                    LocalizationString = saveButtonString,
-                    Item = Item,
-                } )
-            }
-            else
-            {
-                @if ( ParentDataGrid.SubmitFormOnEnter )
-                {
-                    <Button Type="ButtonType.Submit" PreventDefaultOnSubmit Color="Color.Link" Clicked="@Save">
-                        @saveButtonString
-                    </Button>
+                    @ParentDataGrid.CommandColumn.SaveCommandTemplate( new()
+                    {
+                        Clicked = Save,
+                        LocalizationString = saveButtonString,
+                        Item = Item,
+                    } )
                 }
                 else
                 {
-                    <Button Color="Color.Link" Clicked="@Save">
-                        @saveButtonString
+                    @if ( ParentDataGrid.SubmitFormOnEnter )
+                    {
+                        <Button Type="ButtonType.Submit" PreventDefaultOnSubmit Color="Color.Link" Clicked="@Save">
+                            @saveButtonString
+                        </Button>
+                    }
+                    else
+                    {
+                        <Button Color="Color.Link" Clicked="@Save">
+                            @saveButtonString
+                        </Button>
+                    }
+                }
+            }
+            @if ( ParentDataGrid.CommandColumn?.CancelCommandAllowed == true )
+            {
+                var cancelButtonString = Localizer.Localize( ParentDataGrid.Localizers?.CancelButtonLocalizer, "Cancel" );
+
+                @if ( ParentDataGrid.CommandColumn?.CancelCommandTemplate != null )
+                {
+                    @ParentDataGrid.CommandColumn.CancelCommandTemplate( new()
+                    {
+                        Clicked = Cancel,
+                        LocalizationString = cancelButtonString,
+                        Item = Item,
+                    } )
+                }
+                else
+                {
+                    <Button Color="Color.Link" Clicked="@Cancel">
+                        @cancelButtonString
                     </Button>
                 }
             }
-        }
-        @if ( ParentDataGrid.CommandColumn?.CancelCommandAllowed == true )
-        {
-            var cancelButtonString = Localizer.Localize( ParentDataGrid.Localizers?.CancelButtonLocalizer, "Cancel" );
-
-            @if ( ParentDataGrid.CommandColumn?.CancelCommandTemplate != null )
-            {
-                @ParentDataGrid.CommandColumn.CancelCommandTemplate( new()
-                {
-                    Clicked = Cancel,
-                    LocalizationString = cancelButtonString,
-                    Item = Item,
-                } )
-            }
-            else
-            {
-                <Button Color="Color.Link" Clicked="@Cancel">
-                    @cancelButtonString
-                </Button>
-            }
-        }
+        </Div>
     </TableRowCell>
 }
 else if ( EditState == DataGridEditState.None && ParentDataGrid.IsCommandVisible )
 {
-    <TableRowCell @onclick:stopPropagation="ParentDataGrid.CommandColumn?.PreventRowClick ?? false" Class="@(Column.CellClass?.Invoke(Item))" Style="@BuildCellStyle()" TextAlignment="@Column.TextAlignment" VerticalAlignment="@Column.VerticalAlignment" Display="@Column.Display" Flex="@GetCommandFlex()" Gap="@GetCommandGap()">
-        @if ( ParentDataGrid.CommandColumn?.EditCommandAllowed == true )
-        {
-            var editButtonString = Localizer.Localize( ParentDataGrid.Localizers?.EditButtonLocalizer, "Edit" );
+    <TableRowCell @onclick:stopPropagation="@(ParentDataGrid.CommandColumn?.PreventRowClick ?? false)" Class="@(Column.CellClass?.Invoke(Item))" Style="@BuildCellStyle()" TextAlignment="@Column.TextAlignment" VerticalAlignment="@Column.VerticalAlignment" Display="@Column.Display" Flex="@Column.Flex" Gap="@Column.Gap">
+        <Div Flex="@DefaultFlex" Gap="@DefaultGap">
+            @if ( ParentDataGrid.CommandColumn?.EditCommandAllowed == true )
+            {
+                var editButtonString = Localizer.Localize( ParentDataGrid.Localizers?.EditButtonLocalizer, "Edit" );
 
-            @if ( ParentDataGrid.CommandColumn?.EditCommandTemplate != null )
-            {
-                @ParentDataGrid.CommandColumn.EditCommandTemplate( new()
+                @if ( ParentDataGrid.CommandColumn?.EditCommandTemplate != null )
                 {
-                    Clicked = Edit,
-                    LocalizationString = editButtonString,
-                    Item = Item,
-                } )
+                    @ParentDataGrid.CommandColumn.EditCommandTemplate( new()
+                    {
+                        Clicked = Edit,
+                        LocalizationString = editButtonString,
+                        Item = Item,
+                    } )
+                }
+                else
+                {
+                    <Button Color="Color.Link" Clicked="@Edit">
+                        @editButtonString
+                    </Button>
+                }
             }
-            else
+            @if ( ParentDataGrid.CommandColumn?.DeleteCommandAllowed == true )
             {
-                <Button Color="Color.Link" Clicked="@Edit">
-                    @editButtonString
-                </Button>
-            }
-        }
-        @if ( ParentDataGrid.CommandColumn?.DeleteCommandAllowed == true )
-        {
-            var deleteButtonString = Localizer.Localize( ParentDataGrid.Localizers?.DeleteButtonLocalizer, "Delete" );
+                var deleteButtonString = Localizer.Localize( ParentDataGrid.Localizers?.DeleteButtonLocalizer, "Delete" );
 
-            @if ( ParentDataGrid.CommandColumn?.DeleteCommandTemplate != null )
-            {
-                @ParentDataGrid.CommandColumn.DeleteCommandTemplate( new()
+                @if ( ParentDataGrid.CommandColumn?.DeleteCommandTemplate != null )
                 {
-                    Clicked = Delete,
-                    LocalizationString = deleteButtonString,
-                    Item = Item,
-                } )
+                    @ParentDataGrid.CommandColumn.DeleteCommandTemplate( new()
+                    {
+                        Clicked = Delete,
+                        LocalizationString = deleteButtonString,
+                        Item = Item,
+                    } )
+                }
+                else
+                {
+                    <Button Color="Color.Link" Clicked="@Delete">
+                        @deleteButtonString
+                    </Button>
+                }
             }
-            else
-            {
-                <Button Color="Color.Link" Clicked="@Delete">
-                    @deleteButtonString
-                </Button>
-            }
-        }
+        </Div>
     </TableRowCell>
 }

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridRowCommand.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridRowCommand.razor.cs
@@ -10,9 +10,9 @@ namespace Blazorise.DataGrid;
 
 public abstract class _BaseDataGridRowCommand<TItem> : ComponentBase, IDisposable
 {
-    private static readonly IFluentFlex DefaultFlex = Flex._;
+    protected static readonly IFluentFlex DefaultFlex = Flex.InlineFlex;
 
-    private static readonly IFluentGap DefaultGap = Gap.Is2;
+    protected static readonly IFluentGap DefaultGap = Gap.Is2;
 
     public override Task SetParametersAsync( ParameterView parameters )
     {
@@ -58,12 +58,6 @@ public abstract class _BaseDataGridRowCommand<TItem> : ComponentBase, IDisposabl
     {
         await InvokeAsync( StateHasChanged );
     }
-
-    protected IFluentFlex GetCommandFlex()
-        => Column.Flex ?? DefaultFlex;
-
-    protected IFluentGap GetCommandGap()
-        => Column.Gap ?? DefaultGap;
 
     protected string BuildCellStyle()
         => Column.BuildCellStyle( Item );

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridRowEdit.razor
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridRowEdit.razor
@@ -31,56 +31,58 @@
                 @if ( ParentDataGrid.CommandColumn is null || ParentDataGrid.CommandColumn.SaveCommandAllowed || ParentDataGrid.CommandColumn.CancelCommandAllowed )
                 {
                     <Row>
-                        <Column Flex="@GetCommandFlex()" Gap="@GetCommandGap()">
-                            @if ( ParentDataGrid.CommandColumn is null || ParentDataGrid.CommandColumn.SaveCommandAllowed )
-                            {
-                                var saveButtonString = Localizer.Localize( ParentDataGrid.Localizers?.SaveButtonLocalizer, "Save" );
+                        <Column Flex="@ParentDataGrid.CommandColumn?.Flex" Gap="@ParentDataGrid.CommandColumn?.Gap">
+                            <Div Flex="@DefaultFlex" Gap="@DefaultGap">
+                                @if ( ParentDataGrid.CommandColumn is null || ParentDataGrid.CommandColumn.SaveCommandAllowed )
+                                {
+                                    var saveButtonString = Localizer.Localize( ParentDataGrid.Localizers?.SaveButtonLocalizer, "Save" );
 
-                                @if ( ParentDataGrid.CommandColumn?.SaveCommandTemplate != null )
-                                {
-                                    @ParentDataGrid.CommandColumn.SaveCommandTemplate( new()
+                                    @if ( ParentDataGrid.CommandColumn?.SaveCommandTemplate != null )
                                     {
-                                        Clicked = callbackFactory.Create( this, SaveWithValidation ),
-                                        LocalizationString = saveButtonString,
-                                        Item = Item,
-                                    });
-                                }
-                                else
-                                {
-                                    @if ( ParentDataGrid.SubmitFormOnEnter )
-                                    {
-                                        <Button Type="ButtonType.Submit" PreventDefaultOnSubmit Color="Color.Link" Clicked="@SaveWithValidation">
-                                            @saveButtonString
-                                        </Button>
+                                        @ParentDataGrid.CommandColumn.SaveCommandTemplate( new()
+                                        {
+                                            Clicked = callbackFactory.Create( this, SaveWithValidation ),
+                                            LocalizationString = saveButtonString,
+                                            Item = Item,
+                                        });
                                     }
                                     else
                                     {
-                                        <Button Color="Color.Link" Clicked="@SaveWithValidation">
-                                            @saveButtonString
+                                        @if ( ParentDataGrid.SubmitFormOnEnter )
+                                        {
+                                            <Button Type="ButtonType.Submit" PreventDefaultOnSubmit Color="Color.Link" Clicked="@SaveWithValidation">
+                                                @saveButtonString
+                                            </Button>
+                                        }
+                                        else
+                                        {
+                                            <Button Color="Color.Link" Clicked="@SaveWithValidation">
+                                                @saveButtonString
+                                            </Button>
+                                        }
+                                    }
+                                }
+                                @if ( ParentDataGrid.CommandColumn is null || ParentDataGrid.CommandColumn.CancelCommandAllowed )
+                                {
+                                    var cancelButtonString = Localizer.Localize( ParentDataGrid.Localizers?.CancelButtonLocalizer, "Cancel" );
+
+                                    @if ( ParentDataGrid.CommandColumn?.CancelCommandTemplate != null )
+                                    {
+                                        @ParentDataGrid.CommandColumn.CancelCommandTemplate( new()
+                                        {
+                                            Clicked = Cancel,
+                                            LocalizationString = cancelButtonString,
+                                            Item = Item,
+                                        });
+                                    }
+                                    else
+                                    {
+                                        <Button Color="Color.Link" Clicked="@Cancel">
+                                            @cancelButtonString
                                         </Button>
                                     }
                                 }
-                            }
-                            @if ( ParentDataGrid.CommandColumn is null || ParentDataGrid.CommandColumn.CancelCommandAllowed )
-                            {
-                                var cancelButtonString = Localizer.Localize( ParentDataGrid.Localizers?.CancelButtonLocalizer, "Cancel" );
-
-                                @if ( ParentDataGrid.CommandColumn?.CancelCommandTemplate != null )
-                                {
-                                    @ParentDataGrid.CommandColumn.CancelCommandTemplate( new()
-                                    {
-                                        Clicked = Cancel,
-                                        LocalizationString = cancelButtonString,
-                                        Item = Item,
-                                    });
-                                }
-                                else
-                                {
-                                    <Button Color="Color.Link" Clicked="@Cancel">
-                                        @cancelButtonString
-                                    </Button>
-                                }
-                            }
+                            </Div>
                         </Column>
                     </Row>
                 }

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridRowEdit.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridRowEdit.razor.cs
@@ -22,9 +22,9 @@ public abstract class _BaseDataGridRowEdit<TItem> : ComponentBase, IDisposable
     protected EventCallback Cancel
         => EventCallback.Factory.Create( this, ParentDataGrid.Cancel );
 
-    private static readonly IFluentFlex DefaultFlex = Flex._;
+    protected static readonly IFluentFlex DefaultFlex = Flex.InlineFlex;
 
-    private static readonly IFluentGap DefaultGap = Gap.Is2;
+    protected static readonly IFluentGap DefaultGap = Gap.Is2;
 
     #endregion
 
@@ -61,12 +61,6 @@ public abstract class _BaseDataGridRowEdit<TItem> : ComponentBase, IDisposable
             await ParentDataGrid.Save();
         }
     }
-
-    protected IFluentFlex GetCommandFlex()
-        => ParentDataGrid.CommandColumn?.Flex ?? DefaultFlex;
-
-    protected IFluentGap GetCommandGap()
-        => ParentDataGrid.CommandColumn?.Gap ?? DefaultGap;
 
     #endregion
 


### PR DESCRIPTION
Closes #4618 

Fixes the spacing of the command cell when the table content is too large. The downside is now that the users cannot override the default spacing of the inlined `div`.