### PR TITLE
DataGrid : Add StateHasChanged after IsLoading is set to true

### DIFF
--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor
@@ -207,7 +207,7 @@
                 }
                 @if ( IsLoadingTemplateVisible )
                 {
-                    <_DataGridFullColumnSpanRow TItem="TItem" Columns="@Columns">
+                    <_DataGridFullColumnSpanRow TItem="TItem" Columns="@Columns" RenderUpdates>
                         @LoadingTemplate
                     </_DataGridFullColumnSpanRow>
                 }

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -1256,6 +1256,7 @@ public partial class DataGrid<TItem> : BaseDataGridComponent
         try
         {
             IsLoading = true;
+            await InvokeAsync( StateHasChanged );
 
             if ( !cancellationToken.IsCancellationRequested )
                 await ReadData.InvokeAsync( new DataGridReadDataEventArgs<TItem>( DataGridReadDataMode.Paging, Columns, SortByColumns, CurrentPage, PageSize, 0, 0, cancellationToken ) );
@@ -1273,6 +1274,7 @@ public partial class DataGrid<TItem> : BaseDataGridComponent
         try
         {
             IsLoading = true;
+            await InvokeAsync( StateHasChanged );
 
             if ( !cancellationToken.IsCancellationRequested )
                 await ReadData.InvokeAsync( new DataGridReadDataEventArgs<TItem>( DataGridReadDataMode.Virtualize, Columns, SortByColumns, 0, 0, virtualizeOffset: startIdx, virtualizeCount: count, cancellationToken ) );

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -1257,6 +1257,7 @@ public partial class DataGrid<TItem> : BaseDataGridComponent
         {
             IsLoading = true;
             await InvokeAsync( StateHasChanged );
+            await Task.Yield();
 
             if ( !cancellationToken.IsCancellationRequested )
                 await ReadData.InvokeAsync( new DataGridReadDataEventArgs<TItem>( DataGridReadDataMode.Paging, Columns, SortByColumns, CurrentPage, PageSize, 0, 0, cancellationToken ) );
@@ -1274,7 +1275,6 @@ public partial class DataGrid<TItem> : BaseDataGridComponent
         try
         {
             IsLoading = true;
-            await InvokeAsync( StateHasChanged );
 
             if ( !cancellationToken.IsCancellationRequested )
                 await ReadData.InvokeAsync( new DataGridReadDataEventArgs<TItem>( DataGridReadDataMode.Virtualize, Columns, SortByColumns, 0, 0, virtualizeOffset: startIdx, virtualizeCount: count, cancellationToken ) );

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridFullColumnSpanRow.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridFullColumnSpanRow.razor.cs
@@ -11,7 +11,7 @@ public abstract class _BaseDataGridFullColumnSpanRow<TItem> : BaseDataGridCompon
     #region Properties
 
     protected override bool ShouldRender()
-        => false;
+        => RenderUpdates;
 
     protected bool HasCommandColumn
         => Columns.Any( x => x.ColumnType == DataGridColumnType.Command );
@@ -35,6 +35,8 @@ public abstract class _BaseDataGridFullColumnSpanRow<TItem> : BaseDataGridCompon
     [CascadingParameter] public DataGrid<TItem> ParentDataGrid { get; set; }
 
     [Parameter] public RenderFragment ChildContent { get; set; }
+
+    [Parameter] public bool RenderUpdates { get; set; }
 
     #endregion
 }


### PR DESCRIPTION
https://blazorise.com/support/issues/96/DataGrid-LoadingTemplate-not-displayed-during-OnReadData

Missing `StateHasChanged` after `IsLoading` is set to true.
However, from my tests an async execution would still trigger the `LoadingTemplate` correctly. So Blazor was still smart in that regard. (Otherwise we'd certainly have more open issues because of `LoadingTemplate` not working)

Only way I could reproduce the **LoadingTemplate** not working was to block the async thread by appling a `Thead.Sleep`.
![image](https://user-images.githubusercontent.com/22283161/222292733-f8844ba0-ec0d-4049-a2ff-2042bc6e3e60.png)
I guess the developer should make sure he's writting correct async code.

But by adding `Task.Yield` after `StateHasChanged` call we can force it to be definitely displayed for good measure. 

I'd rather not touch `HandleVirtualizeReadData` as it seems to be working fine and with no complaints.
