### PR TITLE
Autocomplete ConfirmKeys handled when the Dropdown is closed

### DIFF
--- a/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
+++ b/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
@@ -376,7 +376,7 @@ public partial class Autocomplete<TItem, TValue> : BaseAfterRenderComponent, IAs
                 return;
             }
 
-            if ( ActiveItemIndex >= 0 )
+            if ( ActiveItemIndex >= 0 && DropdownVisible )
             {
                 if ( FilteredData?.Count > 0 )
                 {


### PR DESCRIPTION
Closes #4622 

I am having issues with the user pressing the Confirm key when the dropdown is not visible and it auto assigns the "hidden" selected item/text the code has stored (behind the scene so to speak).

I just noticed I was supposed to create a new branch first (Sorry).