### PR TITLE
Docs update for Autocomplete dropdown functionality

### DIFF
--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/Autocomplete/AutocompletePage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/Autocomplete/AutocompletePage.razor
@@ -173,7 +173,7 @@
         Placeholder for the empty search field.
     </DocsAttributesItem>
     <DocsAttributesItem Name="MinLength" Type="int" Default="1">
-        Minimum number of character needed to start search. Set this to 0 make the Autocomplete function like a dropdown.
+        Minimum number of character needed to start search. Set this to 0 to make the Autocomplete function like a dropdown.
     </DocsAttributesItem>
     <DocsAttributesItem Name="MaxMenuHeight" Type="string" Default="200px">
         Sets the maximum height of the dropdown menu.

--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/Autocomplete/AutocompletePage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/Autocomplete/AutocompletePage.razor
@@ -173,7 +173,7 @@
         Placeholder for the empty search field.
     </DocsAttributesItem>
     <DocsAttributesItem Name="MinLength" Type="int" Default="1">
-        Minimum number of character needed to start search.
+        Minimum number of character needed to start search. Set this to 0 make the Autocomplete function like a dropdown.
     </DocsAttributesItem>
     <DocsAttributesItem Name="MaxMenuHeight" Type="string" Default="200px">
         Sets the maximum height of the dropdown menu.

--- a/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
+++ b/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
@@ -1157,7 +1157,7 @@ public partial class Autocomplete<TItem, TValue> : BaseAfterRenderComponent, IAs
     [Parameter] public AutocompleteFilter Filter { get; set; } = AutocompleteFilter.StartsWith;
 
     /// <summary>
-    /// The minimum number of characters a user must type before a search is performed.
+    /// The minimum number of characters a user must type before a search is performed. Set this to 0 to make the Autocomplete function like a dropdown.
     /// </summary>
     [Parameter] public int MinLength { get; set; } = 1;
 


### PR DESCRIPTION
In order to make the Autocomplete pop the whole list on click (like a normal select list), you need to set MinLength to 0. It took me a long time to figure that out. A simple docs update will make it more clear for future developers.

I hope my branch name is appropriate. 