### PR TITLE
Prevent large performance hits after using the DropContainer/DropZone component

### DIFF
--- a/Source/Blazorise/Base/BaseDraggableComponent.cs
+++ b/Source/Blazorise/Base/BaseDraggableComponent.cs
@@ -22,6 +22,11 @@ public abstract class BaseDraggableComponent : BaseComponent, IDisposable, IAsyn
     /// </summary>
     private DotNetObjectReference<BaseDraggableComponent> dotNetObjectRef;
 
+    /// <summary>
+    /// Is <c>true</c> if the component needs to clean up the JS ThrottleDragEvent handler on <see cref="Dispose"/> or <see cref="DisposeAsync"/>.
+    /// </summary>
+    private bool jsEventsInitialized;
+
     #endregion
 
     #region Methods
@@ -33,6 +38,7 @@ public abstract class BaseDraggableComponent : BaseComponent, IDisposable, IAsyn
         {
             dotNetObjectRef = CreateDotNetObjectRef( this );
             await JSDragDropModule.InitializeThrottledDragEvents( ElementRef, ElementId, dotNetObjectRef );
+            jsEventsInitialized = true;
         }
         await base.OnFirstAfterRenderAsync();
     }
@@ -42,7 +48,11 @@ public abstract class BaseDraggableComponent : BaseComponent, IDisposable, IAsyn
     {
         if ( disposing )
         {
-            JSDragDropModule.DestroyThrottledDragEvents( ElementRef, ElementId );
+            if ( jsEventsInitialized )
+            {
+                JSDragDropModule.DestroyThrottledDragEvents( ElementRef, ElementId );
+            }
+
             DisposeDotNetObjectRef( dotNetObjectRef );
         }
 
@@ -54,7 +64,11 @@ public abstract class BaseDraggableComponent : BaseComponent, IDisposable, IAsyn
     {
         if ( disposing )
         {
-            await JSDragDropModule.DestroyThrottledDragEvents( ElementRef, ElementId );
+            if ( jsEventsInitialized )
+            {
+                await JSDragDropModule.DestroyThrottledDragEvents( ElementRef, ElementId );
+            }
+
             DisposeDotNetObjectRef( dotNetObjectRef );
         }
 


### PR DESCRIPTION
We noticed that after using the `DropContainer`/`DropZone` component all pages having (large) tables became very slow. As soon as the JS module has been initialized all table rows call the destroyThrottledDragEvents method (drapDrop.js:37) on `DisposeAsync`. If the table has 200 rows, the method is called at least 200 times (via RPC/SignalR Blazor server side <-> Browser).

The problem persists until the user opens a new session - reason: `JSDragDropModule` is registered as a scoped service and therefore holds state.

![image](https://user-images.githubusercontent.com/3825484/231532545-d21d2e47-159d-4256-bd0a-97db1c7b50c3.png)
