### PR TITLE
WIP | DataGrid | Observable

### DIFF
--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -775,9 +775,12 @@ public partial class DataGrid<TItem> : BaseDataGridComponent
     {
         await SelectRow( item );
 
-        var selectedTableRow = GetRowInfo( item )?.TableRow;
-        if ( selectedTableRow is not null )
-            await selectedTableRow.ElementRef.FocusAsync();
+        if ( Navigable )
+        {
+            var selectedTableRow = GetRowInfo( item )?.TableRow;
+            if ( selectedTableRow is not null )
+                await selectedTableRow.ElementRef.FocusAsync();
+        }
 
         await Refresh();
     }

--- a/Tests/BasicTestApp.Client/DataGridPerfComponent.razor
+++ b/Tests/BasicTestApp.Client/DataGridPerfComponent.razor
@@ -1,0 +1,110 @@
+﻿@using BasicTestApp.Client.PerfComponents;
+
+<DataGridPerf @ref="PerfRef"
+              TItem="Employee"
+              Data="@Data"
+                ShowPager
+                ShowPageSizes
+                Sortable
+              SortMode="DataGridSortMode.Single"
+                Editable
+              EditMode="@DataGridEditMode">
+    <DataGridColumns>
+        <DataGridCommandColumn TItem="Employee">
+            <NewCommandTemplate>
+                <Button ElementId="btnNew" Color="Color.Success" Clicked="@context.Clicked">@context.LocalizationString</Button>
+            </NewCommandTemplate>
+            <EditCommandTemplate>
+                <Button ElementId="btnEdit" Color="Color.Primary" Clicked="@context.Clicked">@context.LocalizationString</Button>
+            </EditCommandTemplate>
+            <SaveCommandTemplate>
+                <Button ElementId="btnSave" Type="ButtonType.Submit" PreventDefaultOnSubmit Color="Color.Primary" Clicked="@context.Clicked">@context.LocalizationString</Button>
+            </SaveCommandTemplate>
+            <DeleteCommandTemplate>
+                <Button ElementId="btnDelete" Color="Color.Danger" Clicked="@context.Clicked">@context.LocalizationString</Button>
+            </DeleteCommandTemplate>
+            <CancelCommandTemplate>
+                <Button ElementId="btnCancel" Color="Color.Secondary" Clicked="@context.Clicked">@context.LocalizationString</Button>
+            </CancelCommandTemplate>
+            <ClearFilterCommandTemplate>
+                <Button ElementId="btnClearFilter" Color="Color.Warning" Clicked="@context.Clicked">@context.LocalizationString</Button>
+            </ClearFilterCommandTemplate>
+            </DataGridCommandColumn>
+            <DataGridColumn TextAlignment="TextAlignment.Center"
+                        TItem="Employee"
+                        Field="@nameof( Employee.Fraction )"
+                        Caption="Fraction"
+                        SortField="@nameof( Employee.FractionValue )"
+                        SortDirection="SortDirection.Ascending"
+                        Editable="false" />
+            <DataGridColumn TItem="Employee"
+                        Field="@nameof( Employee.Name )"
+                        Caption="Name"
+                                Editable />
+    </DataGridColumns>
+    <EmptyTemplate>
+        No Records...
+    </EmptyTemplate>
+</DataGridPerf>
+
+
+
+@code {
+    public DataGridPerf<Employee> PerfRef;
+
+    protected override Task OnInitializedAsync()
+    {
+        return base.OnInitializedAsync();
+    }
+
+    protected override Task OnAfterRenderAsync( bool firstRender )
+    {
+        if ( firstRender )
+        {
+            PerfRef.PerfEvent += ( sender, args ) =>
+            {
+                Console.WriteLine( $"PerfEvent {PerfRef.RenderCalls}" );
+
+            };
+        }
+        return base.OnAfterRenderAsync( firstRender );
+    }
+
+    [Parameter]
+    public DataGridEditMode DataGridEditMode { get; set; }
+
+    [Parameter]
+    public List<Employee> Data { get; set; } = new()
+        {
+            new() { Name = "John", Fraction = "1/2" },
+            new() { Name = "Sarah", Fraction = "1/4" },
+            new() { Name = "Paul", Fraction = "1/8" },
+            new() { Name = "Ana", Fraction = "3/4" }
+        };
+
+    public class Employee
+    {
+        public string Name { get; set; }
+
+        public string Fraction { get; set; }
+
+        public decimal FractionValue
+        {
+            get
+            {
+                if ( !string.IsNullOrWhiteSpace( Fraction ) )
+                {
+                    var split = Fraction.Split( "/" );
+                    if ( split.Length == 2 )
+                    {
+                        return decimal.Parse( split[0] ) / decimal.Parse( split[1] );
+                    }
+                }
+
+                return 0;
+
+            }
+        }
+
+    }
+}

--- a/Tests/BasicTestApp.Client/PerfComponents/DataGridPerf.razor
+++ b/Tests/BasicTestApp.Client/PerfComponents/DataGridPerf.razor
@@ -1,0 +1,9 @@
+﻿@typeparam TItem
+@inherits DataGrid<TItem>
+@{
+    base.BuildRenderTree(__builder);
+}
+
+<button id="PerfReset" @onclick="ResetCalls"></button>
+<label id="PerfRenderCalls">@RenderCalls</label>
+<label id="PerfParametersSetCalls">@ParametersSetCalls</label>

--- a/Tests/BasicTestApp.Client/PerfComponents/DataGridPerf.razor.cs
+++ b/Tests/BasicTestApp.Client/PerfComponents/DataGridPerf.razor.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Blazorise.DataGrid;
+
+namespace BasicTestApp.Client.PerfComponents;
+
+public partial class DataGridPerf<TItem> : DataGrid<TItem>
+{
+    public int RenderCalls { get; private set; }
+
+    public int ParametersSetCalls { get; private set; }
+
+    public event EventHandler<PerfEventArgs> PerfEvent;
+
+    public void ResetCalls()
+    {
+        RenderCalls = 0;
+        ParametersSetCalls = 0;
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        ParametersSetCalls++;
+        var time = Stopwatch.GetTimestamp();
+        await base.OnParametersSetAsync();
+        var timeElapsed = Stopwatch.GetElapsedTime( time );
+        Console.WriteLine( timeElapsed );
+    }
+
+    protected override async Task OnAfterRenderAsync( bool firstRender )
+    {
+        RenderCalls++;
+        var time = Stopwatch.GetTimestamp();
+        await base.OnAfterRenderAsync( firstRender );
+        var timeElapsed = Stopwatch.GetElapsedTime( time );
+        Console.WriteLine( timeElapsed );
+        PerfEvent?.Invoke( this, new PerfEventArgs() );
+    }
+
+    public class PerfEventArgs : EventArgs
+    {
+        public TimeSpan TimeElapsed { get; private set; }
+        public PerfEventType EventType { get; private set; }
+    }
+
+    public enum PerfEventType
+    {
+        OnParametersSet,
+        OnAfterRender
+    }
+}

--- a/Tests/Blazorise.E2E.Tests/Tests/Extensions/DataGrid/DataGridPerfTests.cs
+++ b/Tests/Blazorise.E2E.Tests/Tests/Extensions/DataGrid/DataGridPerfTests.cs
@@ -1,0 +1,27 @@
+﻿namespace Blazorise.E2E.Tests.Tests.Extensions.DataGrid;
+
+public class DataGridPerfTests : BlazorisePageTest
+{
+    [SetUp]
+    public async Task Init()
+    {
+        await SelectTestComponent<DataGridPerfComponent>();
+    }
+
+
+    [Test]
+    public async Task SelectRow_Should_RenderOnce()
+    {
+        var perfRenderCalls = Page.Locator( "#PerfRenderCalls" );
+        var perfReset = Page.Locator( "#PerfReset" );
+        var row = Page.Locator( "tbody tr.table-row-selectable:first-child" );
+
+        await perfReset.ClickAsync();
+        await row.ClickAsync();
+
+        var callsAfterSelection = await perfRenderCalls.InnerTextAsync();
+
+        Assert.AreEqual( 1, int.Parse( callsAfterSelection ) );
+    }
+
+}

--- a/Tests/Blazorise.Tests/Components/DataGridComponentTest.cs
+++ b/Tests/Blazorise.Tests/Components/DataGridComponentTest.cs
@@ -1,6 +1,5 @@
 ﻿#region Using directives
-using System.Linq;
-using System.Threading;
+using System.Threading.Tasks;
 using BasicTestApp.Client;
 using Blazorise.DataGrid;
 using Blazorise.Tests.Extensions;
@@ -17,6 +16,27 @@ public class DataGridComponentTest : TestContext
     {
         BlazoriseConfig.AddBootstrapProviders( Services );
         BlazoriseConfig.JSInterop.AddDataGrid( this.JSInterop );
+    }
+
+
+    [Fact]
+    public async Task OnSelection_Should_Render_EmptyTemplate()
+    {
+        //Arrange
+        var numRenders = 0;
+
+        //Act
+        var comp = RenderComponent<DataGridComponent>();
+
+        comp.OnAfterRender += ( sender, args ) =>
+        {
+            numRenders++;
+        };
+
+        var rowsFraction = comp.FindAll( "tbody tr.table-row-selectable" );
+        await rowsFraction[0].ClickAsync( new() { Detail = 1 } );
+        //Assert
+        Assert.Equal( 1, numRenders );
     }
 
     [Fact]


### PR DESCRIPTION
Closes #4706


--- 
**Notes:** 

Started by taking a look at #4406 which is where we first wanted to go with the `Data` auto property to avoid `DirtyFilter` every single time.
I noticed that the original improvement to reduce number of renders was slightly higher again. Due to now calling FocusAsync when selecting a row. This is for the `Navigable` feature, and it does not make sense to be called if it's not active.

While doing this, since it's not pratical to go test manually everytime, I wanted to figure a way to have tests in place so we can figure out this kind of perf regressions, bunit does have an OnAfterRender event, but since it mocks js calls out, it's not 100% representative of real world usage... so went with playwright to test it... so trying to prototype a simple approach to keep track of renders, it's kinda messy & not sure if this is the best approach...but probably better then nothing.

From researching I couldn't find someone who has a good approach at this yet.

