### PR TITLE
Fix Docs ITextLocalizerService changing the culture application wide

### DIFF
--- a/Documentation/Blazorise.Docs/Models/Snippets.generated.cs
+++ b/Documentation/Blazorise.Docs/Models/Snippets.generated.cs
@@ -8567,7 +8567,7 @@ builder.Services
 
     Task SelectCulture( string name )
     {
-        LocalizationService.ChangeLanguage( name );
+        LocalizationService.ChangeLanguage( name, false );
 
         return Task.CompletedTask;
     }

--- a/Documentation/Blazorise.Docs/Pages/Docs/Helpers/Localization/Code/ITextLocalizerServiceExampleCode.html
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Helpers/Localization/Code/ITextLocalizerServiceExampleCode.html
@@ -39,7 +39,7 @@
 
     Task SelectCulture( <span class="keyword">string</span> name )
     {
-        LocalizationService.ChangeLanguage( name );
+        LocalizationService.ChangeLanguage( name, <span class="keyword">false</span> );
 
         <span class="keyword">return</span> Task.CompletedTask;
     }

--- a/Documentation/Blazorise.Docs/Pages/Docs/Helpers/Localization/Examples/ITextLocalizerServiceExample.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Helpers/Localization/Examples/ITextLocalizerServiceExample.razor
@@ -37,7 +37,7 @@
 
     Task SelectCulture( string name )
     {
-        LocalizationService.ChangeLanguage( name );
+        LocalizationService.ChangeLanguage( name, false );
 
         return Task.CompletedTask;
     }

--- a/Documentation/Blazorise.Docs/Pages/Docs/Helpers/Localization/LocalizationPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Helpers/Localization/LocalizationPage.razor
@@ -49,6 +49,12 @@
 <DocsPageSection>
     <DocsPageSectionHeader Title="ITextLocalizerService">
         This is the preferred way and the easiest way of changing the components display text. To change a language you just need to inject <Code>ITextLocalizerService</Code> into your component or page and then call the <Code>ChangeLanguage</Code> method.
+        <Alert Color="Color.Info" Visible>
+            <AlertDescription>
+                <Strong>Note:</Strong> When using <strong>Blazor.Server</strong>, by default the <Code>ITextLocalizer.ChangeLanguage</Code> changes the default thread culture, this means it will be an application wide change.
+                If you want to change the language for a specific user, you need to use <Code>ITextLocalizerService.ChangeLanguage(mylanguage, false)</Code> instead.
+            </AlertDescription>
+        </Alert>
     </DocsPageSectionHeader>
     <DocsPageSectionContent>
         <ITextLocalizerServiceExample />

--- a/Tests/Blazorise.Tests/Components/DataGridComponentTest.cs
+++ b/Tests/Blazorise.Tests/Components/DataGridComponentTest.cs
@@ -116,12 +116,16 @@ public class DataGridComponentTest : TestContext
         );
 
         // validate
-        sortChanged
+        comp.WaitForAssertion( () =>
+        {
+            sortChanged
             .Should().HaveCount( 1 )
             .And
             .OnlyContain( e => e.ColumnFieldName == "Fraction" &&
                                e.FieldName == "FractionValue" &&
                                e.SortDirection == SortDirection.Descending );
+        } );
+
     }
 
     [Fact]
@@ -146,7 +150,9 @@ public class DataGridComponentTest : TestContext
         );
 
         // validate
-        sortingChanged
+        comp.WaitForAssertion( () =>
+        {
+            sortingChanged
             .Should().HaveCount( 1 )
             .And
             .ContainEquivalentOf( new DataGridSortChangedEventArgs(
@@ -154,6 +160,7 @@ public class DataGridComponentTest : TestContext
                  columnFieldName: nameof( Employee.Fraction ),
                  sortDirection: SortDirection.Descending
             ) );
+        } );
     }
 
     [Fact]
@@ -175,10 +182,13 @@ public class DataGridComponentTest : TestContext
         );
 
         // validate
-        comp.FindAll( "tbody tr td:nth-child(2)" )
-            .Select( x => x.TextContent )
-            .Should()
-            .BeEquivalentTo( expectedOrderedValues );
+        comp.WaitForAssertion( () =>
+        {
+            comp.FindAll( "tbody tr td:nth-child(2)" )
+                .Select( x => x.TextContent )
+                .Should()
+                .BeEquivalentTo( expectedOrderedValues );
+        } );
     }
 
     [Fact]
@@ -200,10 +210,13 @@ public class DataGridComponentTest : TestContext
         );
 
         // validate
-        comp.FindAll( "tbody tr td:nth-child(2)" )
-            .Select( x => x.TextContent )
-            .Should()
-            .BeEquivalentTo( expectedOrderedValues );
+        comp.WaitForAssertion( () =>
+        {
+            comp.FindAll( "tbody tr td:nth-child(2)" )
+                .Select( x => x.TextContent )
+                .Should()
+                .BeEquivalentTo( expectedOrderedValues );
+        } );
     }
 
     [Fact]
@@ -231,20 +244,23 @@ public class DataGridComponentTest : TestContext
         );
 
         // validate
-        sortingChanged
-        .Should().HaveCount( 2 )
-        .And
-        .ContainEquivalentOf( new DataGridSortChangedEventArgs(
-             fieldName: nameof( Employee.FractionValue ),
-             columnFieldName: nameof( Employee.Fraction ),
-             sortDirection: SortDirection.Descending
-        ) );
+        comp.WaitForAssertion( () =>
+        {
+            sortingChanged
+                .Should().HaveCount( 2 )
+                .And
+                .ContainEquivalentOf( new DataGridSortChangedEventArgs(
+                 fieldName: nameof( Employee.FractionValue ),
+                 columnFieldName: nameof( Employee.Fraction ),
+                 sortDirection: SortDirection.Descending
+                ) );
 
-        sortingChanged.Should().ContainEquivalentOf( new DataGridSortChangedEventArgs(
-             fieldName: nameof( Employee.Name ),
-             columnFieldName: nameof( Employee.Name ),
-             sortDirection: SortDirection.Ascending
-        ) );
+            sortingChanged.Should().ContainEquivalentOf( new DataGridSortChangedEventArgs(
+                             fieldName: nameof( Employee.Name ),
+                             columnFieldName: nameof( Employee.Name ),
+                             sortDirection: SortDirection.Ascending
+                        ) );
+        } );
     }
 
     [Fact]
@@ -259,10 +275,13 @@ public class DataGridComponentTest : TestContext
         await dataGrid.Instance.ApplySorting( Array.Empty<DataGridSortColumnInfo>() );
 
         // validate
-        comp.FindAll( "tbody tr td:nth-child(2)" )
-            .Select( x => x.TextContent )
-            .Should()
-            .BeEquivalentTo( expectedOrderedValues );
+        comp.WaitForAssertion( () =>
+        {
+            comp.FindAll( "tbody tr td:nth-child(2)" )
+                .Select( x => x.TextContent )
+                .Should()
+                .BeEquivalentTo( expectedOrderedValues );
+        } );
     }
 
     [Fact]
@@ -281,10 +300,13 @@ public class DataGridComponentTest : TestContext
         );
 
         // validate
-        comp.FindAll( "tbody tr td:nth-child(2)" )
-            .Select( x => x.TextContent )
-            .Should()
-            .BeEquivalentTo( expectedOrderedValues );
+        comp.WaitForAssertion( () =>
+        {
+            comp.FindAll( "tbody tr td:nth-child(2)" )
+                .Select( x => x.TextContent )
+                .Should()
+                .BeEquivalentTo( expectedOrderedValues );
+        } );
     }
 
     [Fact]
@@ -299,10 +321,13 @@ public class DataGridComponentTest : TestContext
         await dataGrid.Instance.ApplySorting( Array.Empty<DataGridSortColumnInfo>() );
 
         // validate
-        comp.FindAll( "tbody tr td:nth-child(2)" )
-            .Select( x => x.TextContent )
-            .Should()
-            .BeEquivalentTo( expectedOrderedValues );
+        comp.WaitForAssertion( () =>
+        {
+            comp.FindAll( "tbody tr td:nth-child(2)" )
+                .Select( x => x.TextContent )
+                .Should()
+                .BeEquivalentTo( expectedOrderedValues );
+        } );
     }
 
     [Fact]
@@ -328,14 +353,17 @@ public class DataGridComponentTest : TestContext
         );
 
         // validate
-        sortingChanged
-            .Should().HaveCount( 1 )
-            .And
-            .ContainEquivalentOf( new DataGridSortChangedEventArgs(
-                 fieldName: nameof( Employee.Name ),
-                 columnFieldName: nameof( Employee.Name ),
-                 sortDirection: SortDirection.Descending
-            ) );
+        comp.WaitForAssertion( () =>
+        {
+            sortingChanged
+                .Should().HaveCount( 1 )
+                .And
+                .ContainEquivalentOf( new DataGridSortChangedEventArgs(
+                     fieldName: nameof( Employee.Name ),
+                     columnFieldName: nameof( Employee.Name ),
+                     sortDirection: SortDirection.Descending
+                ) );
+        } );
     }
 
     [Fact]
@@ -364,14 +392,17 @@ public class DataGridComponentTest : TestContext
         );
 
         // validate
-        sortingChanged
-            .Should().HaveCount( 1 )
-            .And
-            .ContainEquivalentOf( new DataGridSortChangedEventArgs(
-                 fieldName: nameof( Employee.FractionValue ),
-                 columnFieldName: nameof( Employee.Fraction ),
-                 sortDirection: SortDirection.Default
-            ) );
+        comp.WaitForAssertion( () =>
+        {
+            sortingChanged
+                .Should().HaveCount( 1 )
+                .And
+                .ContainEquivalentOf( new DataGridSortChangedEventArgs(
+                     fieldName: nameof( Employee.FractionValue ),
+                     columnFieldName: nameof( Employee.Fraction ),
+                     sortDirection: SortDirection.Default
+                ) );
+        } );
     }
 
     [Theory]


### PR DESCRIPTION
Fixes the recurring issue where our docs application would keep the language state application wide by changing our example to not set the default thread culture to the selected language/culture.

Added a note about this in the docs.

![image](https://github.com/Megabit/Blazorise/assets/22283161/bc8ed61b-0bed-4868-a1ae-605a4f05944a)
