### PR TITLE
FileEdit | Prefer to coalesce file ids so file ids persist

### DIFF
--- a/Source/Blazorise/wwwroot/fileEdit.js
+++ b/Source/Blazorise/wwwroot/fileEdit.js
@@ -78,7 +78,7 @@ function mapElementFilesToFileEntries(element) {
     element._blazorFilesById = {};
 
     let fileList = Array.prototype.map.call(element.files, function (file) {
-        file.id = ++nextFileId;
+        file.id = file.id ?? ++nextFileId;
         var fileEntry = {
             id: file.id,
             lastModified: new Date(file.lastModified).toISOString(),


### PR DESCRIPTION
Reason was because an operation that generated a js change event, would notify blazor of new ids for existing files, making it so any state was lost instead of kept.
This fixes the issue where state wasn't kept by just assigning new ids to files without id.

Issue was in the `FileEdit`, but it was more noticeable in `FilePicker` since it's more likely to be used with multiple files.

This is the kind of code user reported was not working as expected, but the issue could also be seen by going to the `FilePicker` page, adding various files, upload them all, and seeing, that for example, when a file was removed, the other files would loose state.
```
<Field>
    <FilePicker @ref=filePicker Multiple Upload="OnFileUpload" ShowMode="FilePickerShowMode.List" />
</Field>

<Button Clicked="UploadAll">Upload All</Button>
@code {
    private FilePicker filePicker;

    async Task UploadAll()
    {
        await filePicker.UploadAll();

        foreach ( var file in filePicker.FileEdit.Files.Where( x => x.Status == FileEntryStatus.Uploaded ) )
        {
            await filePicker.RemoveFile( file );
        }
    }

    async Task OnFileUpload( FileUploadEventArgs e )
    {
        try
        {
            using ( MemoryStream result = new MemoryStream() )
            {
                await e.File.OpenReadStream( long.MaxValue ).CopyToAsync( result );
            }
        }
        catch ( Exception exc )
        {
            Console.WriteLine( exc.Message );
        }
        finally
        {
            this.StateHasChanged();
        }
    }
}
```