### PR TITLE
Autocomplete: Fix dropdown menu being anchored incorrectly

### DIFF
--- a/Documentation/Blazorise.Docs/Pages/Docs/Components/Dropdowns/DropdownPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Components/Dropdowns/DropdownPage.razor
@@ -180,7 +180,7 @@
     <DocsAttributesItem Name="PositionStrategy" Type="DropdownPositionStrategy" Default="DropdownPositionStrategy.Fixed">
         Defines the positioning strategy of the dropdown menu as a 'floating' element.
     </DocsAttributesItem>
-    <DocsAttributesItem Name="DropdownMenuAnchorId" Type="string">
+    <DocsAttributesItem Name="DropdownMenuTargetId" Type="string">
         Provides a custom anchor element id for the dropdown menu.
         This is useful when you want the dropdown menu to be anchored from a different element than the toggle.
     </DocsAttributesItem>

--- a/Documentation/Blazorise.Docs/Pages/Docs/Components/Dropdowns/DropdownPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Components/Dropdowns/DropdownPage.razor
@@ -180,6 +180,10 @@
     <DocsAttributesItem Name="PositionStrategy" Type="DropdownPositionStrategy" Default="DropdownPositionStrategy.Fixed">
         Defines the positioning strategy of the dropdown menu as a 'floating' element.
     </DocsAttributesItem>
+    <DocsAttributesItem Name="DropdownMenuAnchorId" Type="string">
+        Provides a custom anchor element id for the dropdown menu.
+        This is useful when you want the dropdown menu to be anchored from a different element than the toggle.
+    </DocsAttributesItem>
 </DocsAttributes>
 
 <DocsAttributes Title="DropdownMenu">

--- a/Documentation/Blazorise.Docs/Pages/News/2023-08-16-release-notes-130.razor
+++ b/Documentation/Blazorise.Docs/Pages/News/2023-08-16-release-notes-130.razor
@@ -331,7 +331,7 @@
 </Paragraph>
 
 <Paragraph>
-    Added a new <Code>DropdownMenuAnchorId</Code> parameter, that allows you to set a custom anchor element id for the dropdown menu. This is useful when you want the dropdown menu to be anchored from a different element than the toggle.
+    Added a new <Code>DropdownMenuTargetId</Code> parameter, that allows you to set a custom anchor element id for the dropdown menu. This is useful when you want the dropdown menu to be anchored from a different element than the toggle.
 </Paragraph>
 
 <Paragraph>

--- a/Documentation/Blazorise.Docs/Pages/News/2023-08-16-release-notes-130.razor
+++ b/Documentation/Blazorise.Docs/Pages/News/2023-08-16-release-notes-130.razor
@@ -331,6 +331,10 @@
 </Paragraph>
 
 <Paragraph>
+    Added a new <Code>DropdownMenuAnchorId</Code> parameter, that allows you to set a custom anchor element id for the dropdown menu. This is useful when you want the dropdown menu to be anchored from a different element than the toggle.
+</Paragraph>
+
+<Paragraph>
     Fixed an issue where in some certain cases, if buttons existed inside the Dropdown the menu positioning would not be handled correctly.
 </Paragraph>
 

--- a/Source/Blazorise/Components/Dropdown/Dropdown.razor.cs
+++ b/Source/Blazorise/Components/Dropdown/Dropdown.razor.cs
@@ -67,7 +67,7 @@ public partial class Dropdown : BaseComponent, IAsyncDisposable
         if ( firstRender )
         {
             JSModule.Initialize( ElementRef, ElementId,
-                targetElementId: AnchorId ?? childrenDropdownToggles?.FirstOrDefault()?.ElementId ?? childrenButtonList?.FirstOrDefault()?.ElementId ?? "test",
+                targetElementId: AnchorId ?? childrenDropdownToggles?.FirstOrDefault()?.ElementId ?? childrenButtonList?.FirstOrDefault()?.ElementId,
                 menuElementId: childrenDropdownMenus?.FirstOrDefault()?.ElementId,
                 options: new
                 {

--- a/Source/Blazorise/Components/Dropdown/Dropdown.razor.cs
+++ b/Source/Blazorise/Components/Dropdown/Dropdown.razor.cs
@@ -67,7 +67,7 @@ public partial class Dropdown : BaseComponent, IAsyncDisposable
         if ( firstRender )
         {
             JSModule.Initialize( ElementRef, ElementId,
-                targetElementId: AnchorId ?? childrenDropdownToggles?.FirstOrDefault()?.ElementId ?? childrenButtonList?.FirstOrDefault()?.ElementId,
+                targetElementId: DropdownMenuAnchorId ?? childrenDropdownToggles?.FirstOrDefault()?.ElementId ?? childrenButtonList?.FirstOrDefault()?.ElementId,
                 menuElementId: childrenDropdownMenus?.FirstOrDefault()?.ElementId,
                 options: new
                 {
@@ -502,7 +502,7 @@ public partial class Dropdown : BaseComponent, IAsyncDisposable
     /// Provides a custom anchor element id for the dropdown menu.
     /// This is useful when you want the dropdown menu to be anchored from a different element than the toggle.
     /// </summary>
-    [Parameter] public string AnchorId { get; set; }
+    [Parameter] public string DropdownMenuAnchorId { get; set; }
 
     #endregion
 }

--- a/Source/Blazorise/Components/Dropdown/Dropdown.razor.cs
+++ b/Source/Blazorise/Components/Dropdown/Dropdown.razor.cs
@@ -67,7 +67,7 @@ public partial class Dropdown : BaseComponent, IAsyncDisposable
         if ( firstRender )
         {
             JSModule.Initialize( ElementRef, ElementId,
-                targetElementId: childrenDropdownToggles?.FirstOrDefault()?.ElementId ?? childrenButtonList?.FirstOrDefault()?.ElementId,
+                targetElementId: AnchorId ?? childrenDropdownToggles?.FirstOrDefault()?.ElementId ?? childrenButtonList?.FirstOrDefault()?.ElementId ?? "test",
                 menuElementId: childrenDropdownMenus?.FirstOrDefault()?.ElementId,
                 options: new
                 {
@@ -497,6 +497,12 @@ public partial class Dropdown : BaseComponent, IAsyncDisposable
     /// Defines the positioning strategy of the dropdown menu as a 'floating' element.
     /// </summary>
     [Parameter] public DropdownPositionStrategy PositionStrategy { get; set; } = DropdownPositionStrategy.Fixed;
+
+    /// <summary>
+    /// Providers a custom anchor element id for the dropdown menu.
+    /// This is useful when you want the dropdown menu to be anchored from a different element than the toggle.
+    /// </summary>
+    [Parameter] public string AnchorId { get; set; }
 
     #endregion
 }

--- a/Source/Blazorise/Components/Dropdown/Dropdown.razor.cs
+++ b/Source/Blazorise/Components/Dropdown/Dropdown.razor.cs
@@ -67,7 +67,7 @@ public partial class Dropdown : BaseComponent, IAsyncDisposable
         if ( firstRender )
         {
             JSModule.Initialize( ElementRef, ElementId,
-                targetElementId: DropdownMenuAnchorId ?? childrenDropdownToggles?.FirstOrDefault()?.ElementId ?? childrenButtonList?.FirstOrDefault()?.ElementId,
+                targetElementId: DropdownMenuTargetId ?? childrenDropdownToggles?.FirstOrDefault()?.ElementId ?? childrenButtonList?.FirstOrDefault()?.ElementId,
                 menuElementId: childrenDropdownMenus?.FirstOrDefault()?.ElementId,
                 options: new
                 {
@@ -499,10 +499,10 @@ public partial class Dropdown : BaseComponent, IAsyncDisposable
     [Parameter] public DropdownPositionStrategy PositionStrategy { get; set; } = DropdownPositionStrategy.Fixed;
 
     /// <summary>
-    /// Provides a custom anchor element id for the dropdown menu.
+    /// Provides an alternative, or custom anchor element id for the dropdown menu.
     /// <para>This is useful when you want the dropdown menu to be anchored from a different element than the toggle.</para>
     /// </summary>
-    [Parameter] public string DropdownMenuAnchorId { get; set; }
+    [Parameter] public string DropdownMenuTargetId { get; set; }
 
     #endregion
 }

--- a/Source/Blazorise/Components/Dropdown/Dropdown.razor.cs
+++ b/Source/Blazorise/Components/Dropdown/Dropdown.razor.cs
@@ -499,7 +499,7 @@ public partial class Dropdown : BaseComponent, IAsyncDisposable
     [Parameter] public DropdownPositionStrategy PositionStrategy { get; set; } = DropdownPositionStrategy.Fixed;
 
     /// <summary>
-    /// Providers a custom anchor element id for the dropdown menu.
+    /// Provides a custom anchor element id for the dropdown menu.
     /// This is useful when you want the dropdown menu to be anchored from a different element than the toggle.
     /// </summary>
     [Parameter] public string AnchorId { get; set; }

--- a/Source/Blazorise/Components/Dropdown/Dropdown.razor.cs
+++ b/Source/Blazorise/Components/Dropdown/Dropdown.razor.cs
@@ -500,7 +500,7 @@ public partial class Dropdown : BaseComponent, IAsyncDisposable
 
     /// <summary>
     /// Provides a custom anchor element id for the dropdown menu.
-    /// This is useful when you want the dropdown menu to be anchored from a different element than the toggle.
+    /// <para>This is useful when you want the dropdown menu to be anchored from a different element than the toggle.</para>
     /// </summary>
     [Parameter] public string DropdownMenuAnchorId { get; set; }
 

--- a/Source/Extensions/Blazorise.Components/Autocomplete.razor
+++ b/Source/Extensions/Blazorise.Components/Autocomplete.razor
@@ -4,7 +4,8 @@
 @typeparam TItem
 @typeparam TValue
 
-<Dropdown ElementId="@ElementId" Class="@DropdownClassNames" Style="@CssStyle" Attributes="@Attributes" Visible="@(DropdownVisible || NotFoundVisible)" PositionStrategy="@PositionStrategy">
+<Dropdown ElementId="@ElementId" Class="@DropdownClassNames" Style="@CssStyle" Attributes="@Attributes" Visible="@(DropdownVisible || NotFoundVisible)" PositionStrategy="@PositionStrategy"
+          AnchorId="@InputElementId">
     <Validation Validator="@(Validator ?? ValidationRule.None)" AsyncValidator="@AsyncValidator">
 
         @if ( IsMultiple && !SelectedTexts.IsNullOrEmpty() )

--- a/Source/Extensions/Blazorise.Components/Autocomplete.razor
+++ b/Source/Extensions/Blazorise.Components/Autocomplete.razor
@@ -4,8 +4,7 @@
 @typeparam TItem
 @typeparam TValue
 
-<Dropdown ElementId="@ElementId" Class="@DropdownClassNames" Style="@CssStyle" Attributes="@Attributes" Visible="@(DropdownVisible || NotFoundVisible)" PositionStrategy="@PositionStrategy"
-          AnchorId="@InputElementId">
+<Dropdown ElementId="@ElementId" Class="@DropdownClassNames" Style="@CssStyle" Attributes="@Attributes" Visible="@(DropdownVisible || NotFoundVisible)" PositionStrategy="@PositionStrategy" AnchorId="@InputElementId">
     <Validation Validator="@(Validator ?? ValidationRule.None)" AsyncValidator="@AsyncValidator">
 
         @if ( IsMultiple && !SelectedTexts.IsNullOrEmpty() )

--- a/Source/Extensions/Blazorise.Components/Autocomplete.razor
+++ b/Source/Extensions/Blazorise.Components/Autocomplete.razor
@@ -4,7 +4,7 @@
 @typeparam TItem
 @typeparam TValue
 
-<Dropdown ElementId="@ElementId" Class="@DropdownClassNames" Style="@CssStyle" Attributes="@Attributes" Visible="@(DropdownVisible || NotFoundVisible)" PositionStrategy="@PositionStrategy" AnchorId="@InputElementId">
+<Dropdown ElementId="@ElementId" Class="@DropdownClassNames" Style="@CssStyle" Attributes="@Attributes" Visible="@(DropdownVisible || NotFoundVisible)" PositionStrategy="@PositionStrategy" DropdownMenuAnchorId="@InputElementId">
     <Validation Validator="@(Validator ?? ValidationRule.None)" AsyncValidator="@AsyncValidator">
 
         @if ( IsMultiple && !SelectedTexts.IsNullOrEmpty() )

--- a/Source/Extensions/Blazorise.Components/Autocomplete.razor
+++ b/Source/Extensions/Blazorise.Components/Autocomplete.razor
@@ -4,7 +4,7 @@
 @typeparam TItem
 @typeparam TValue
 
-<Dropdown ElementId="@ElementId" Class="@DropdownClassNames" Style="@CssStyle" Attributes="@Attributes" Visible="@(DropdownVisible || NotFoundVisible)" PositionStrategy="@PositionStrategy" DropdownMenuAnchorId="@InputElementId">
+<Dropdown ElementId="@ElementId" Class="@DropdownClassNames" Style="@CssStyle" Attributes="@Attributes" Visible="@(DropdownVisible || NotFoundVisible)" PositionStrategy="@PositionStrategy" DropdownMenuTargetId="@InputElementId">
     <Validation Validator="@(Validator ?? ValidationRule.None)" AsyncValidator="@AsyncValidator">
 
         @if ( IsMultiple && !SelectedTexts.IsNullOrEmpty() )

--- a/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
+++ b/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
@@ -1090,6 +1090,11 @@ public partial class Autocomplete<TItem, TValue> : BaseAfterRenderComponent, IAs
     public ElementReference ElementRef => textEditRef.ElementRef;
 
     /// <summary>
+    /// Gets the Element Id
+    /// </summary>
+    public string InputElementId => textEditRef?.ElementId;
+
+    /// <summary>
     /// Gets the dropdown CSS styles.
     /// </summary>
     protected string CssStyle
@@ -1574,7 +1579,7 @@ public partial class Autocomplete<TItem, TValue> : BaseAfterRenderComponent, IAs
     /// <summary>
     /// Defines the positioning strategy of the dropdown menu as a 'floating' element.
     /// </summary>
-    [Parameter] public DropdownPositionStrategy PositionStrategy { get; set; } = DropdownPositionStrategy.Fixed;
+    [Parameter] public DropdownPositionStrategy PositionStrategy { get; set; } = DropdownPositionStrategy.Absolute;
 
     #endregion
 }


### PR DESCRIPTION
Well I had to introduce an anchorid to tell it to anchor off the input. What do you think?