### PR TITLE
Prevent Server Thread Culture from being mutated in docs example

### DIFF
--- a/Build/Blazorise.props
+++ b/Build/Blazorise.props
@@ -14,7 +14,7 @@
 		<Company>Megabit</Company>
 		<Copyright>Copyright 2018-2023 Megabit</Copyright>
 		
-		<TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+		<TargetFrameworks>net6.0;net7.0</TargetFrameworks>
 		<OutputType>Library</OutputType>
 		<IsPackable>true</IsPackable>
 		<LangVersion>10.0</LangVersion>

--- a/Build/Blazorise.props
+++ b/Build/Blazorise.props
@@ -14,7 +14,7 @@
 		<Company>Megabit</Company>
 		<Copyright>Copyright 2018-2023 Megabit</Copyright>
 		
-		<TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+		<TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
 		<OutputType>Library</OutputType>
 		<IsPackable>true</IsPackable>
 		<LangVersion>10.0</LangVersion>

--- a/Documentation/Blazorise.Docs/Models/Snippets.generated.cs
+++ b/Documentation/Blazorise.Docs/Models/Snippets.generated.cs
@@ -9018,7 +9018,7 @@ builder.Services
 
     Task SelectCulture( string name )
     {
-        LocalizationService.ChangeLanguage( name );
+        LocalizationService.ChangeLanguage( name, false );
 
         return Task.CompletedTask;
     }

--- a/Documentation/Blazorise.Docs/Pages/Docs/Helpers/Localization/Code/CustomLanguageExampleCode.html
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Helpers/Localization/Code/CustomLanguageExampleCode.html
@@ -40,7 +40,7 @@
 
     Task SelectCulture( <span class="keyword">string</span> name )
     {
-        LocalizationService.ChangeLanguage( name );
+        LocalizationService.ChangeLanguage( name, <span class="keyword">false</span> );
 
         <span class="keyword">return</span> Task.CompletedTask;
     }

--- a/Documentation/Blazorise.Docs/Pages/Docs/Helpers/Localization/Examples/CustomLanguageExample.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Helpers/Localization/Examples/CustomLanguageExample.razor
@@ -39,7 +39,7 @@
 
     Task SelectCulture( string name )
     {
-        LocalizationService.ChangeLanguage( name );
+        LocalizationService.ChangeLanguage( name, false );
 
         return Task.CompletedTask;
     }


### PR DESCRIPTION
It seems like there was another place where users could mutate the server thread culture, no wonder it was in polish.
![image](https://github.com/Megabit/Blazorise/assets/22283161/8a5a1d9d-983b-43ac-b7cd-742e42e28a0e)
