### PR TITLE
Autocomplete: Fix DropdownMenuTargetId race condition by pre allocating elementId on Initialization

### DIFF
--- a/Documentation/Blazorise.Docs/Layouts/DocsLayout.razor
+++ b/Documentation/Blazorise.Docs/Layouts/DocsLayout.razor
@@ -26,8 +26,7 @@
                                           Placeholder="Search..."
                                           Filter="AutocompleteFilter.Contains"
                                           CustomFilter="@(( item, searchValue ) => item.Name.IndexOf( searchValue, 0, StringComparison.CurrentCultureIgnoreCase ) >= 0 )"
-                                          SelectedValueChanged="@ComponentSearchSelectedValueChanged"
-                                          PositionStrategy="DropdownPositionStrategy.Absolute">
+                                          SelectedValueChanged="@ComponentSearchSelectedValueChanged">
                                 <NotFoundContent>
                                     Sorry... @context was not found! :(
                                 </NotFoundContent>

--- a/Source/Extensions/Blazorise.Components/Autocomplete.razor
+++ b/Source/Extensions/Blazorise.Components/Autocomplete.razor
@@ -26,6 +26,7 @@
         }
 
         <TextEdit @ref="@textEditRef"
+                  ElementId="@InputElementId"
                   Role="TextRole.Search"
                   Text="@Search"
                   TextChanged="@OnTextChangedHandler"

--- a/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
+++ b/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
@@ -1,4 +1,5 @@
 #region Using directives
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -12,6 +13,7 @@ using Blazorise.Utilities;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.Web.Virtualization;
+
 #endregion
 
 namespace Blazorise.Components;
@@ -23,10 +25,12 @@ namespace Blazorise.Components;
 /// <typeparam name="TValue">Type of an SelectedValue field.</typeparam>
 public partial class Autocomplete<TItem, TValue> : BaseAfterRenderComponent, IAsyncDisposable
 {
-    class NullableT<T>
+    private class NullableT<T>
     {
         public NullableT( T t ) => Value = t;
+
         public T Value;
+
         public static implicit operator T( NullableT<T> nullable ) => nullable == null ? default : nullable.Value;
     }
 
@@ -65,16 +69,16 @@ public partial class Autocomplete<TItem, TValue> : BaseAfterRenderComponent, IAs
     /// <summary>
     /// Allow dropdown visibility
     /// </summary>
-    bool canShowDropDown;
+    private bool canShowDropDown;
 
-    string currentSearch;
-    string currentSearchParam;
+    private string currentSearch;
+    private string currentSearchParam;
 
-    NullableT<TValue> selectedValue;
-    TValue selectedValueParam;
+    private NullableT<TValue> selectedValue;
+    private TValue selectedValueParam;
 
-    List<TValue> selectedValuesParam;
-    List<string> selectedTextsParam;
+    private List<TValue> selectedValuesParam;
+    private List<string> selectedTextsParam;
 
     #endregion
 
@@ -104,7 +108,6 @@ public partial class Autocomplete<TItem, TValue> : BaseAfterRenderComponent, IAs
         var selectedTextsParamChanged = parameters.TryGetValue<IEnumerable<string>>( nameof( SelectedTexts ), out var paramSelectedTexts )
             && !selectedTextsParam.AreEqualOrdered( paramSelectedTexts );
 
-
         await base.SetParametersAsync( parameters );
 
         await SynchronizeSingle( selectedValueParamChanged, selectedTextParamChanged );
@@ -129,7 +132,6 @@ public partial class Autocomplete<TItem, TValue> : BaseAfterRenderComponent, IAs
         else
             return new( Data.ToList(), TotalItems.HasValue ? TotalItems.Value : default );
     }
-
 
     private async Task SynchronizeSingle( bool selectedValueParamChanged, bool selectedTextParamChanged )
     {
@@ -238,6 +240,8 @@ public partial class Autocomplete<TItem, TValue> : BaseAfterRenderComponent, IAs
     /// <inheritdoc/>
     protected override async Task OnInitializedAsync()
     {
+        InputElementId = IdGenerator.Generate;
+
         ExecuteAfterRender( async () => await JSClosableModule.RegisterLight( ElementRef ) );
 
         if ( ManualReadMode )
@@ -260,8 +264,6 @@ public partial class Autocomplete<TItem, TValue> : BaseAfterRenderComponent, IAs
 
         await base.OnInitializedAsync();
     }
-
-
 
     /// <summary>
     /// Handles the search field onchange or oninput event.
@@ -333,7 +335,6 @@ public partial class Autocomplete<TItem, TValue> : BaseAfterRenderComponent, IAs
     /// <returns>Returns awaitable task</returns>
     protected async Task OnTextKeyDownHandler( KeyboardEventArgs eventArgs )
     {
-
         if ( eventArgs.Code == "Escape" )
         {
             await Close();
@@ -826,7 +827,6 @@ public partial class Autocomplete<TItem, TValue> : BaseAfterRenderComponent, IAs
         await ResetSelectedValue();
     }
 
-
     /// <summary>
     /// Clears the selected value and the search field.
     /// </summary>
@@ -914,7 +914,7 @@ public partial class Autocomplete<TItem, TValue> : BaseAfterRenderComponent, IAs
     /// Determines if Autocomplete can be closed
     /// </summary>
     /// <returns>True if Autocomplete can be closed.</returns>
-    /// 
+    ///
     [Obsolete( "IsSafeToClose is deprecated. This API now always returns true." )]
     public Task<bool> IsSafeToClose( string elementId, CloseReason closeReason, bool isChild )
     {
@@ -1100,7 +1100,7 @@ public partial class Autocomplete<TItem, TValue> : BaseAfterRenderComponent, IAs
     /// <summary>
     /// Gets the Element Id
     /// </summary>
-    public string InputElementId => textEditRef?.ElementId;
+    public string InputElementId { get; private set; }
 
     /// <summary>
     /// Gets the dropdown CSS styles.
@@ -1203,6 +1203,11 @@ public partial class Autocomplete<TItem, TValue> : BaseAfterRenderComponent, IAs
     [Inject] public IJSUtilitiesModule JSUtilitiesModule { get; set; }
 
     /// <summary>
+    /// Gets or set the IdGenerator.
+    /// </summary>
+    [Inject] public IIdGenerator IdGenerator { get; set; }
+
+    /// <summary>
     /// Gets or sets the dropdown element id.
     /// </summary>
     [Parameter] public string ElementId { get; set; }
@@ -1275,7 +1280,6 @@ public partial class Autocomplete<TItem, TValue> : BaseAfterRenderComponent, IAs
     /// Event handler used to detect when the autocomplete is opened.
     /// </summary>
     [Parameter] public EventCallback Opened { get; set; }
-
 
     /// <summary>
     /// Gets the data after all of the filters have being applied.


### PR DESCRIPTION
Fixed the issue by pre generating the Id instead.

`Position.Absolute` strategy was removed from the docs menu and left the default instead.