### PR TITLE
Autocomplete | Fix FreeTypingNotFoundTemplate not showing

### DIFF
--- a/Source/Extensions/Blazorise.Components/Autocomplete.razor
+++ b/Source/Extensions/Blazorise.Components/Autocomplete.razor
@@ -4,7 +4,7 @@
 @typeparam TItem
 @typeparam TValue
 
-<Dropdown ElementId="@ElementId" Class="@DropdownClassNames" Style="@CssStyle" Attributes="@Attributes" Visible="@(DropdownVisible || NotFoundVisible)" PositionStrategy="@PositionStrategy" DropdownMenuTargetId="@InputElementId" Disabled="@Disabled">
+<Dropdown ElementId="@ElementId" Class="@DropdownClassNames" Style="@CssStyle" Attributes="@Attributes" Visible="@(DropdownVisible || NotFoundVisible || FreeTypingNotFoundVisible)" PositionStrategy="@PositionStrategy" DropdownMenuTargetId="@InputElementId" Disabled="@Disabled">
     <Validation Validator="@(Validator ?? ValidationRule.None)" AsyncValidator="@AsyncValidator">
 
         @if ( IsMultiple && !SelectedTexts.IsNullOrEmpty() )

--- a/Tests/BasicTestApp.Client/Autocomplete_5038Component.razor
+++ b/Tests/BasicTestApp.Client/Autocomplete_5038Component.razor
@@ -1,0 +1,30 @@
+﻿<Autocomplete TItem="string"
+              TValue="string"
+              Data="@colors"
+              Placeholder="Search..."
+              Filter="AutocompleteFilter.StartsWith"
+              FreeTyping
+              TextField="@(( item ) => item)"
+              ValueField="@(( item ) => item)">
+    <FreeTypingNotFoundTemplate>
+         Add "@context"
+    </FreeTypingNotFoundTemplate>
+</Autocomplete>
+
+@code {
+    private List<string> colors = new List<string>
+    {
+        "Red",
+        "Orange",
+        "Yellow",
+        "Bright Green",
+        "Dark Green",
+        "Sky Blue",
+        "Blue",
+        "Purple",
+        "Hot Pink",
+        "Black",
+        "White",
+        "Gray"
+    };
+}

--- a/Tests/Blazorise.E2E.Tests/Tests/Extensions/Autocomplete/Autocomplete_5038_Tests.cs
+++ b/Tests/Blazorise.E2E.Tests/Tests/Extensions/Autocomplete/Autocomplete_5038_Tests.cs
@@ -18,6 +18,7 @@ public class Autocomplete_5038_Tests : BlazorisePageTest
     [Test]
     public async Task Test()
     {
+
         var sut = Page.Locator( ".b-is-autocomplete input[type=search]" );
         var dropdownMenu = Page.Locator( ".dropdown-menu.show" );
 

--- a/Tests/Blazorise.E2E.Tests/Tests/Extensions/Autocomplete/Autocomplete_5038_Tests.cs
+++ b/Tests/Blazorise.E2E.Tests/Tests/Extensions/Autocomplete/Autocomplete_5038_Tests.cs
@@ -1,0 +1,35 @@
+﻿namespace Blazorise.E2E.Tests.Tests.Extensions.Autocomplete;
+
+[Parallelizable( ParallelScope.Self )]
+[TestFixture]
+public class Autocomplete_5038_Tests : BlazorisePageTest
+{
+
+    [SetUp]
+    public async Task Init()
+    {
+        await SelectTestComponent<Autocomplete_5038Component>();
+    }
+
+    /// <summary>
+    /// When a value is already set, setting a different value programmatically and then revisiting should have updated the Current Search Value and options shown.
+    /// </summary>
+    /// <returns></returns>
+    [Test]
+    public async Task Test()
+    {
+        var sut = Page.Locator( ".b-is-autocomplete input[type=search]" );
+        var dropdownMenu = Page.Locator( ".dropdown-menu.show" );
+
+        await sut.ClickAsync();
+        await sut.FillAsync( "My Color" );
+        await sut.PressAsync( "Enter" );
+        await Expect( sut ).ToHaveValueAsync( "My Color" );
+
+        await dropdownMenu.WaitForAsync();
+        var option = ( await dropdownMenu.Locator( ".dropdown-item" ).AllAsync() ).Single();
+
+        await Expect( option ).ToHaveTextAsync( @"Add ""My Color""" );
+    }
+}
+

--- a/Tests/Blazorise.E2E.Tests/Tests/Extensions/Autocomplete/Autocomplete_5038_Tests.cs
+++ b/Tests/Blazorise.E2E.Tests/Tests/Extensions/Autocomplete/Autocomplete_5038_Tests.cs
@@ -12,7 +12,7 @@ public class Autocomplete_5038_Tests : BlazorisePageTest
     }
 
     /// <summary>
-    /// When a value is already set, setting a different value programmatically and then revisiting should have updated the Current Search Value and options shown.
+    /// Makes sure that when FreeTyping is set and a value is not found, the FreeTypingNotFoundtemplate is shown.
     /// </summary>
     /// <returns></returns>
     [Test]


### PR DESCRIPTION
Code provided by user which is also found on the added test:

```
<h3>AutocompleteTest</h3>

<Autocomplete TItem="string"
              TValue="string"
              Data="@colors"
              Placeholder="Search..."
              Filter="AutocompleteFilter.StartsWith"
              FreeTyping=true
              TextField="@(( item ) => item)"
              ValueField="@(( item ) => item)">
    <FreeTypingNotFoundTemplate>
        Sorry... @context was not found! :(
    </FreeTypingNotFoundTemplate>
</Autocomplete>

@code {
    private List<string> colors = new List<string>
    {
        "Red",
        "Orange",
        "Yellow",
        "Bright Green",
        "Dark Green",
        "Sky Blue",
        "Blue",
        "Purple",
        "Hot Pink",
        "Black",
        "White",
        "Gray"
    };
}
```