### PR TITLE
DataGridSelectColumn: SetValue, consider ValueField if set

### DIFF
--- a/Source/Extensions/Blazorise.DataGrid/DataGridColumn.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGridColumn.cs
@@ -14,11 +14,11 @@ public partial class DataGridColumn<TItem> : BaseDataGridColumn<TItem>
 {
     #region Members
 
-    private readonly Lazy<Func<Type>> valueTypeGetter;
-    private readonly Lazy<Func<object>> defaultValueByType;
-    private readonly Lazy<Func<TItem, object>> valueGetter;
-    private readonly Lazy<Action<TItem, object>> valueSetter;
-    private readonly Lazy<Func<TItem, object>> sortFieldGetter;
+    protected readonly Lazy<Func<Type>> valueTypeGetter;
+    protected readonly Lazy<Func<object>> defaultValueByType;
+    protected readonly Lazy<Func<TItem, object>> valueGetter;
+    protected readonly Lazy<Action<TItem, object>> valueSetter;
+    protected readonly Lazy<Func<TItem, object>> sortFieldGetter;
 
     private Dictionary<DataGridSortMode, SortDirection> currentSortDirection { get; set; } = new();
 
@@ -110,7 +110,7 @@ public partial class DataGridColumn<TItem> : BaseDataGridColumn<TItem>
     /// </summary>
     /// <param name="item">Item for which to get the value.</param>
     /// <returns></returns>
-    internal object GetValue( TItem item )
+    protected internal object GetValue( TItem item )
         => !string.IsNullOrEmpty( Field )
             ? valueGetter.Value( item )
             : default;
@@ -120,7 +120,7 @@ public partial class DataGridColumn<TItem> : BaseDataGridColumn<TItem>
     /// </summary>
     /// <param name="item">Item for which to set the value.</param>
     /// <param name="value">Value to set.</param>
-    internal void SetValue( TItem item, object value )
+    protected internal virtual void SetValue( TItem item, object value )
     {
         if ( !string.IsNullOrEmpty( Field ) )
             valueSetter.Value( item, value );
@@ -131,7 +131,7 @@ public partial class DataGridColumn<TItem> : BaseDataGridColumn<TItem>
     /// </summary>
     /// <param name="item">Item for which to get the value.</param>
     /// <returns></returns>
-    internal object GetSortValue( TItem item )
+    protected internal object GetSortValue( TItem item )
         => sortFieldGetter.Value( item );
 
     /// <summary>

--- a/Source/Extensions/Blazorise.DataGrid/DataGridSelectColumn.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGridSelectColumn.cs
@@ -12,10 +12,12 @@ public class DataGridSelectColumn<TItem> : DataGridColumn<TItem>
     protected internal override void SetValue( TItem item, object value )
     {
         if ( !string.IsNullOrEmpty( Field ) )
+        {
             if ( ValueField is null )
                 valueSetter.Value( item, value );
             else
                 valueSetter.Value( item, ValueField( value ) );
+        }
     }
 
     /// <summary>

--- a/Source/Extensions/Blazorise.DataGrid/DataGridSelectColumn.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGridSelectColumn.cs
@@ -8,6 +8,16 @@ public class DataGridSelectColumn<TItem> : DataGridColumn<TItem>
 {
     public override DataGridColumnType ColumnType => DataGridColumnType.Select;
 
+    //<inheritdoc/>
+    protected internal override void SetValue( TItem item, object value )
+    {
+        if ( !string.IsNullOrEmpty( Field ) )
+            if ( ValueField is null )
+                valueSetter.Value( item, value );
+            else
+                valueSetter.Value( item, ValueField( value ) );
+    }
+
     /// <summary>
     /// Gets or sets the select data-source.
     /// </summary>


### PR DESCRIPTION
Code to test:
```
<DataGrid TItem="Employee" Data="@employeeList" PageSize="5" Responsive Editable Filterable EditMode="DataGridEditMode.Popup">
     <DataGridSelectColumn TItem="Employee" Field="@nameof( Employee.Role )" Caption="Gender" Editable
                           Data="RolesNamesSource" ValueField="(x) => ((UsersRoles)Enum.Parse(typeof(UsersRoles), (string)x))" TextField="(x) => (string)x" />
     <DataGridCommandColumn />
 </DataGrid>

 @code {

    private List<Employee> employeeList = new List<Employee>() { new Employee( UsersRoles.Standard ), new Employee( UsersRoles.Premium ), new Employee( UsersRoles.Admin ) };
    private List<string> RolesNamesSource = Enum.GetNames( typeof( UsersRoles ) ).ToList();

    protected override void OnInitialized()
    {

        base.OnInitialized();

    }

    class Employee
    {
        public Employee( UsersRoles role )
        {
            Role = role;
        }

        public UsersRoles Role { get; set; }
    }

    enum UsersRoles
    {
        Standard,
        Premium,
        Admin
    }

}
```