### PR TITLE
Docs : DataGrid Virtualize Example | Set a fixed row height

### DIFF
--- a/Documentation/Blazorise.Docs/Models/Snippets.generated.cs
+++ b/Documentation/Blazorise.Docs/Models/Snippets.generated.cs
@@ -7803,7 +7803,7 @@ List<ChartDataLabelsDataset> lineDataLabelsDatasets = new()
           Data=""@employeeList""
           @bind-SelectedRow=""@selectedEmployee""
           Responsive
-           RowStyling='(x,y ) => y.Style = ""height: 70px;""'
+          RowStyling='(x,y ) => y.Style = ""height: 70px;""'
           Virtualize
           VirtualizeOptions=""@(new() { DataGridHeight = ""250px""})"">
     <DataGridCommandColumn />

--- a/Documentation/Blazorise.Docs/Models/Snippets.generated.cs
+++ b/Documentation/Blazorise.Docs/Models/Snippets.generated.cs
@@ -7803,6 +7803,7 @@ List<ChartDataLabelsDataset> lineDataLabelsDatasets = new()
           Data=""@employeeList""
           @bind-SelectedRow=""@selectedEmployee""
           Responsive
+           RowStyling='(x,y ) => y.Style = ""height: 70px;""'
           Virtualize
           VirtualizeOptions=""@(new() { DataGridHeight = ""250px""})"">
     <DataGridCommandColumn />

--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/DataGrid/Code/DataGridVirtualizeExampleCode.html
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/DataGrid/Code/DataGridVirtualizeExampleCode.html
@@ -4,6 +4,7 @@
           <span class="htmlAttributeName">Data</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="sharpVariable"><span class="atSign">&#64;</span>employeeList</span><span class="quot">&quot;</span>
           <span class="htmlAttributeName"><span class="atSign">&#64;</span>bind-SelectedRow</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="sharpVariable"><span class="atSign">&#64;</span>selectedEmployee</span><span class="quot">&quot;</span>
           <span class="htmlAttributeName">Responsive</span>
+           <span class="htmlAttributeName">RowStyling</span><span class="htmlOperator">=</span><span class="htmlAttributeValue">&#39;(x,y ) =&gt; y.Style = &quot;height: 70px;&quot;&#39;</span>
           <span class="htmlAttributeName">Virtualize</span>
           <span class="htmlAttributeName">VirtualizeOptions</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue"><span class="atSign">&#64;</span>(new() { DataGridHeight = &quot;250px&quot;})</span><span class="quot">&quot;</span><span class="htmlTagDelimiter">&gt;</span>
     <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">DataGridCommandColumn</span> <span class="htmlTagDelimiter">/&gt;</span>

--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/DataGrid/Examples/DataGridVirtualizeExample.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/DataGrid/Examples/DataGridVirtualizeExample.razor
@@ -4,7 +4,7 @@
           Data="@employeeList"
           @bind-SelectedRow="@selectedEmployee"
           Responsive
-           RowStyling='(x,y ) => y.Style = "height: 70px;"'
+          RowStyling='(x,y ) => y.Style = "height: 70px;"'
           Virtualize
           VirtualizeOptions="@(new() { DataGridHeight = "250px"})">
     <DataGridCommandColumn />

--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/DataGrid/Examples/DataGridVirtualizeExample.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/DataGrid/Examples/DataGridVirtualizeExample.razor
@@ -4,6 +4,7 @@
           Data="@employeeList"
           @bind-SelectedRow="@selectedEmployee"
           Responsive
+           RowStyling='(x,y ) => y.Style = "height: 70px;"'
           Virtualize
           VirtualizeOptions="@(new() { DataGridHeight = "250px"})">
     <DataGridCommandColumn />


### PR DESCRIPTION
Does not fully close the issue, as user mentioned an additional issue where `DataGridHeight` & `DataGridMaxHeight` would not work. We await further feedback pertaining that issue as these seem to be working correctly.