### PR TITLE
DataGrid: introduce CloneItemCreator parameter

### DIFF
--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/DataGrid/DataGridApi.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/DataGrid/DataGridApi.razor
@@ -238,6 +238,9 @@
     <DocsAttributesItem Name="EditItemCreator" Type="Func<TItem, TItem>">
         Function that, if set, is called to create a instance of the selected item to edit. If left null the selected item will be used.
     </DocsAttributesItem>
+    <DocsAttributesItem Name="CloneItemCreator" Type="Func<TItem, TItem>">
+        Function that, if set, is called to clone an instance of the saving item. If left null the built-in DeepClone method will be used.
+    </DocsAttributesItem>
     <DocsAttributesItem Name="ValidationItemCreator" Type="Func<TItem>">
         Function that, if set, is called to create a validation instance of an item that it's used as a separate instance for Datagrid's internal processing of validation. If left null, Datagrid will try to use it's own implementation to instantiate.
     </DocsAttributesItem>

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -880,7 +880,7 @@ public partial class DataGrid<TItem> : BaseDataGridComponent
 
         var rowSavingHandler = editState == DataGridEditState.New ? RowInserting : RowUpdating;
 
-        var editItemClone = editItem.DeepClone();
+        var editItemClone = CloneItemCreator != null ? CloneItemCreator.Invoke( editItem ) : editItem.DeepClone();
         SetItemEditedValues( editItemClone );
 
         if ( await IsSafeToProceed( rowSavingHandler, editItem, editItemClone, editedCellValues ) )
@@ -2637,6 +2637,11 @@ public partial class DataGrid<TItem> : BaseDataGridComponent
     /// Function that, if set, is called to create a instance of the selected item to edit. If left null the selected item will be used.
     /// </summary>
     [Parameter] public Func<TItem, TItem> EditItemCreator { get; set; }
+
+    /// <summary>
+    /// Function that, if set, is called to clone an instance of the saving item. If left null the built-in DeepClone method will be used.
+    /// </summary>
+    [Parameter] public Func<TItem, TItem> CloneItemCreator { get; set; }
 
     /// <summary>
     /// Adds stripes to the table.


### PR DESCRIPTION
Closes #5184

The culprit was not in #5184 example, but I'm just referencing it so that we can close the ticket.

As far as I was able to figure, the problem could be in the client possibly not having full-trust on their runtime objects. So DeepClone would fail. You can read about it on https://github.com/force-net/DeepCloner?tab=readme-ov-file#limitation

This PR introduces a new `CloneItemCreator` API. I am aware that we usually don't allow adding new APIs into existing versions but this time it was needed. I was able to test it on the client code and the change is working. On their side I just implement it as

```cs
MulticastAllocationEntry OnCloneItemCreator(MulticastAllocationEntry item)
{
    return item.ShallowClone();
}
```