### PR TITLE
ThemeProvider: Fix generator for Bar background color

### DIFF
--- a/Source/Blazorise.AntDesign/AntDesignThemeGenerator.cs
+++ b/Source/Blazorise.AntDesign/AntDesignThemeGenerator.cs
@@ -841,11 +841,12 @@ public class AntDesignThemeGenerator : ThemeGenerator
                 .AppendLine( "}" );
         }
 
-           sb
-                .Append( ".ant-menu.ant-menu-root.ant-menu-dark.ant-menu-inline {" )
-                .Append( $"background-color: var(--b-bar-dark-background, #001529);" )
-                .Append( $"color: var(--b-bar-dark-color, rgba(255, 255, 255, 0.5));" )
-                .Append( "}" );
+        sb
+            .Append( ".ant-menu.ant-menu-root.ant-menu-dark.ant-menu-inline" )
+            .Append( "{" )
+            .Append( $"background-color: var(--b-bar-dark-background, #001529);" )
+            .Append( $"color: var(--b-bar-dark-color, rgba(255, 255, 255, 0.5));" )
+            .AppendLine( "}" );
     }
 
     protected override void GenerateParagraphVariantStyles( StringBuilder sb, Theme theme, string variant, string inTextColor )

--- a/Source/Blazorise.AntDesign/AntDesignThemeGenerator.cs
+++ b/Source/Blazorise.AntDesign/AntDesignThemeGenerator.cs
@@ -840,6 +840,12 @@ public class AntDesignThemeGenerator : ThemeGenerator
                 .Append( $"color: {yiqColor};" )
                 .AppendLine( "}" );
         }
+
+           sb
+                .Append( ".ant-menu.ant-menu-root.ant-menu-dark.ant-menu-inline {" )
+                .Append( $"background-color: var(--b-bar-dark-background, #001529);" )
+                .Append( $"color: var(--b-bar-dark-color, rgba(255, 255, 255, 0.5));" )
+                .Append( "}" );
     }
 
     protected override void GenerateParagraphVariantStyles( StringBuilder sb, Theme theme, string variant, string inTextColor )


### PR DESCRIPTION
closes #5188 


Here, I have tried everything I know to fix it, so when I put these classes in the theme provider, they are not added, even though by all logical parameters they should be added to the ant-menu... when I manually add these same classes inside scss -a, everything works without problems, take a look and give me some advice because I really don't see what the problem is with this approach