### PR TITLE
DataGridCellEdit | ReAdd entries for dynamic numeric inputs

### DIFF
--- a/Source/Extensions/Blazorise.DataGrid/_DataGridCellEdit.razor
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridCellEdit.razor
@@ -5,6 +5,46 @@
 {
     <TextEdit ElementId="@elementId" Text="@CellEditContext.CellValue?.ToString()" TextChanged="@OnEditValueChanged" ReadOnly="@Column.Readonly" />
 }
+else if ( ValueType == typeof( decimal ) )
+{
+    <NumericPicker TValue="decimal" Value="@((decimal)CellEditContext.CellValue)" ValueChanged="@OnEditValueChanged" ReadOnly="@Readonly" Step="@Step" Decimals="@Decimals" DecimalSeparator="@DecimalSeparator" Culture="@Culture" ShowStepButtons="@ShowStepButtons" EnableStep="@EnableStep" />
+}
+else if ( ValueType == typeof( decimal? ) )
+{
+    <NumericPicker TValue="decimal?" Value="@((decimal?)CellEditContext.CellValue)" ValueChanged="@OnEditValueChanged" ReadOnly="@Readonly" Step="@Step" Decimals="@Decimals" DecimalSeparator="@DecimalSeparator" Culture="@Culture" ShowStepButtons="@ShowStepButtons" EnableStep="@EnableStep" />
+}
+else if ( ValueType == typeof( double ) )
+{
+    <NumericPicker TValue="double" Value="@((double)CellEditContext.CellValue)" ValueChanged="@OnEditValueChanged" ReadOnly="@Readonly" Step="@Step" Decimals="@Decimals" DecimalSeparator="@DecimalSeparator" Culture="@Culture" ShowStepButtons="@ShowStepButtons" EnableStep="@EnableStep" />
+}
+else if ( ValueType == typeof( double? ) )
+{
+    <NumericPicker TValue="double?" Value="@(( double?)CellEditContext.CellValue)" ValueChanged="@OnEditValueChanged" ReadOnly="@Readonly" Step="@Step" Decimals="@Decimals" DecimalSeparator="@DecimalSeparator" Culture="@Culture" ShowStepButtons="@ShowStepButtons" EnableStep="@EnableStep" />
+}
+else if ( ValueType == typeof( float ) )
+{
+    <NumericPicker TValue="float" Value="@((float)CellEditContext.CellValue)" ValueChanged="@OnEditValueChanged" ReadOnly="@Readonly" Step="@Step" Decimals="@Decimals" DecimalSeparator="@DecimalSeparator" Culture="@Culture" ShowStepButtons="@ShowStepButtons" EnableStep="@EnableStep" />
+}
+else if ( ValueType == typeof( float? ) )
+{
+    <NumericPicker TValue="float?" Value="@((float?)CellEditContext.CellValue)" ValueChanged="@OnEditValueChanged" ReadOnly="@Readonly" Step="@Step" Decimals="@Decimals" DecimalSeparator="@DecimalSeparator" Culture="@Culture" ShowStepButtons="@ShowStepButtons" EnableStep="@EnableStep" />
+}
+else if ( ValueType == typeof( int ) )
+{
+    <NumericPicker TValue="int" Value="@((int)CellEditContext.CellValue)" ValueChanged="@OnEditValueChanged" ReadOnly="@Readonly" Step="@Step" Decimals="@Decimals" DecimalSeparator="@DecimalSeparator" Culture="@Culture" ShowStepButtons="@ShowStepButtons" EnableStep="@EnableStep" />
+}
+else if ( ValueType == typeof( int? ) )
+{
+    <NumericPicker TValue="int?" Value="@((int?)CellEditContext.CellValue)" ValueChanged="@OnEditValueChanged" ReadOnly="@Readonly" Step="@Step" Decimals="@Decimals" DecimalSeparator="@DecimalSeparator" Culture="@Culture" ShowStepButtons="@ShowStepButtons" EnableStep="@EnableStep" />
+}
+else if ( ValueType == typeof( long ) )
+{
+    <NumericPicker TValue="long" Value="@((long)CellEditContext.CellValue)" ValueChanged="@OnEditValueChanged" ReadOnly="@Readonly" Step="@Step" Decimals="@Decimals" DecimalSeparator="@DecimalSeparator" Culture="@Culture" ShowStepButtons="@ShowStepButtons" EnableStep="@EnableStep" />
+}
+else if ( ValueType == typeof( long? ) )
+{
+    <NumericPicker TValue="long?" Value="@((long?)CellEditContext.CellValue)" ValueChanged="@OnEditValueChanged" ReadOnly="@Readonly" Step="@Step" Decimals="@Decimals" DecimalSeparator="@DecimalSeparator" Culture="@Culture" ShowStepButtons="@ShowStepButtons" EnableStep="@EnableStep" />
+}
 else if ( ValueType == typeof( bool ) )
 {
     <Check ElementId="@elementId" TValue="bool" Checked="@((bool)CellEditContext.CellValue)" CheckedChanged="@OnEditValueChanged" ReadOnly="@Readonly" />

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridCellNumericEdit.razor
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridCellNumericEdit.razor
@@ -1,12 +1,9 @@
 @using System.Reflection;
+@using Blazorise.Utilities
 @typeparam TItem
 @inherits ComponentBase
 
-@if ( valueType == typeof( decimal ) || valueType == typeof( decimal? )
-   || valueType == typeof( double ) || valueType == typeof( double? )
-   || valueType == typeof( float ) || valueType == typeof( float? )
-   || valueType == typeof( int ) || valueType == typeof( int? )
-   || valueType == typeof( long ) || valueType == typeof( long? ) )
+@if ( TypeHelper.IsNumeric(valueType) )
 {
     @NumericPickerFragment
 }


### PR DESCRIPTION
Readding the entries for the dynamic numeric inputs. I'm not sure why we removed it, I think it was a mistake, because people might still use `DataGridColumn` with a numeric value as opposed to a `DataGridNumericColumn`