### PR TITLE
Carousel | Improve previous/next slide transition responsiveness

### DIFF
--- a/Source/Blazorise.Bulma/CarouselSlide.cs
+++ b/Source/Blazorise.Bulma/CarouselSlide.cs
@@ -1,0 +1,12 @@
+﻿#region Using directives
+#endregion
+
+namespace Blazorise.Bulma;
+
+public class CarouselSlide : Blazorise.CarouselSlide
+{
+    /// <summary>
+    /// The time it takes to animate the carousel slide transition.
+    /// </summary>
+    internal protected override int AnimationTime { get; set; } = 0;
+}

--- a/Source/Blazorise.Bulma/Config.cs
+++ b/Source/Blazorise.Bulma/Config.cs
@@ -44,6 +44,7 @@ public static class Config
         { typeof( Blazorise.CardTitle ), typeof( Bulma.CardTitle ) },
         { typeof( Blazorise.CardSubtitle ), typeof( Bulma.CardSubtitle ) },
         { typeof( Blazorise.Carousel ), typeof( Bulma.Carousel ) },
+        { typeof( Blazorise.CarouselSlide ), typeof( Bulma.CarouselSlide ) },
         { typeof( Blazorise.Check<> ), typeof( Bulma.Check<> ) },
         { typeof( Blazorise.DateEdit<> ), typeof( Bulma.DateEdit<> ) },
         { typeof( Blazorise.DropdownDivider ), typeof( Bulma.DropdownDivider ) },

--- a/Source/Blazorise.Material/CarouselSlide.cs
+++ b/Source/Blazorise.Material/CarouselSlide.cs
@@ -1,0 +1,12 @@
+﻿#region Using directives
+#endregion
+
+namespace Blazorise.Material;
+
+public class CarouselSlide : Blazorise.CarouselSlide
+{
+    /// <summary>
+    /// The time it takes to animate the carousel slide transition.
+    /// </summary>
+    internal protected override int AnimationTime { get; set; } = 250;
+}

--- a/Source/Blazorise.Material/Config.cs
+++ b/Source/Blazorise.Material/Config.cs
@@ -34,6 +34,7 @@ public static class Config
     public static IDictionary<Type, Type> ComponentMap => new Dictionary<Type, Type>( Bootstrap.Config.ComponentMap )
     {
         // material overrides
+        [typeof( Blazorise.CarouselSlide )] = typeof( Material.CarouselSlide ),
         [typeof( Blazorise.NumericPicker<> )] = typeof( Material.NumericPicker<> ),
         [typeof( Blazorise.Switch<> )] = typeof( Material.Switch<> ),
         [typeof( Blazorise.Step )] = typeof( Material.Step ),

--- a/Source/Blazorise.Tailwind/CarouselSlide.cs
+++ b/Source/Blazorise.Tailwind/CarouselSlide.cs
@@ -1,0 +1,12 @@
+﻿#region Using directives
+#endregion
+
+namespace Blazorise.Tailwind;
+
+public class CarouselSlide : Blazorise.CarouselSlide
+{
+    /// <summary>
+    /// The time it takes to animate the carousel slide transition.
+    /// </summary>
+    internal protected override int AnimationTime { get; set; } = 700;
+}

--- a/Source/Blazorise.Tailwind/Config.cs
+++ b/Source/Blazorise.Tailwind/Config.cs
@@ -65,6 +65,7 @@ public static class Config
         { typeof( Blazorise.CardImage ), typeof( Tailwind.CardImage ) },
         { typeof( Blazorise.CardText ), typeof( Tailwind.CardText ) },
         { typeof( Blazorise.Carousel ), typeof( Tailwind.Carousel ) },
+        { typeof( Blazorise.CarouselSlide ), typeof( Tailwind.CarouselSlide ) },
         { typeof( Blazorise.Check<> ), typeof( Tailwind.Check<> ) },
         { typeof( Blazorise.CloseButton ), typeof( Tailwind.CloseButton ) },
         { typeof( Blazorise.ColorPicker ), typeof( Tailwind.ColorPicker ) },

--- a/Source/Blazorise/Components/Carousel/Carousel.razor.cs
+++ b/Source/Blazorise/Components/Carousel/Carousel.razor.cs
@@ -445,8 +445,13 @@ public partial class Carousel : BaseComponent, IDisposable
         SetSlideDirection( previouslySelectedSlide );
 
         await InvokeAsync( StateHasChanged );
+        await Task.Delay( selectedSlide.AnimationTime );
 
-        ResetTransitionTimer();
+        await AnimationEnd( selectedSlide );
+        if ( AnimationRunning ) //Animation is still running for some reason, let's go ahead and setup a timer to reset it
+        {
+            ResetTransitionTimer();
+        }
     }
 
     private void SetSlideDirection( CarouselSlide slide )

--- a/Source/Blazorise/Components/Carousel/CarouselSlide.razor.cs
+++ b/Source/Blazorise/Components/Carousel/CarouselSlide.razor.cs
@@ -122,6 +122,11 @@ public partial class CarouselSlide : BaseComponent, IDisposable
 
     #region Properties
 
+    /// <summary>
+    /// The time it takes to animate the carousel slide transition.
+    /// </summary>
+    internal protected virtual int AnimationTime { get; set; } = 600;
+
     bool IndicatorActive
     {
         get


### PR DESCRIPTION
From my tests, this greatly improves responsiveness when switching between slides. The problem was that we were only setting the Animation to being ended after 2s. I'm not sure why we decided on that, seems like an oversight.

Notes:
- **AntDesign** is blocked from testing due to https://github.com/Megabit/Blazorise/issues/5222
- **Bulma** seems to have no animations, I'm not sure if it's intended or not, but it doesn't affect the viability of this PR. For now we made it so it considers bulma as having no animation, so it is very snappy when switching between slides with no animation.
  - https://github.com/Megabit/Blazorise/issues/5223