### PR TITLE
Fix DetailRowTrigger not triggering when RowSelectable evaluates to false

### DIFF
--- a/Source/Extensions/Blazorise.DataGrid/_DataGridRow.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridRow.razor.cs
@@ -172,16 +172,15 @@ public abstract class _BaseDataGridRow<TItem> : BaseDataGridComponent
 
         var selectable = ParentDataGrid.RowSelectable?.Invoke( new( Item, clickFromMultiSelectCheck ? DataGridSelectReason.MultiSelectClick : DataGridSelectReason.RowClick ) ) ?? true;
 
-        if ( !selectable )
+        if ( selectable )
         {
-            clickFromMultiSelectCheck = false;
-            return;
+            if ( !clickFromMultiSelectCheck )
+                await HandleSingleSelectClick( eventArgs );
+
+            await HandleMultiSelectClick( eventArgs );
         }
 
-        if ( !clickFromMultiSelectCheck )
-            await HandleSingleSelectClick( eventArgs );
-
-        await HandleMultiSelectClick( eventArgs );
+        await ParentDataGrid.ToggleDetailRow( Item, DetailRowTriggerType.RowClick );
 
         clickFromMultiSelectCheck = false;
     }
@@ -227,7 +226,6 @@ public abstract class _BaseDataGridRow<TItem> : BaseDataGridComponent
             await ParentDataGrid.Select( Item );
         }
 
-        await ParentDataGrid.ToggleDetailRow( Item, DetailRowTriggerType.RowClick );
     }
 
     protected internal Task HandleDoubleClick( BLMouseEventArgs eventArgs )


### PR DESCRIPTION
Basically this fixes an issue where if `RowSelectable` evaluated to false, then `DetailRowTrigger` would not happen. 
`RowSelectable` should only affect whether the row is selectable or not as the naming implies.

As for the feature the user requested, **Trigger only DetailRow upon RowClick and not upon MultiSelect click**
- There is currently no way to know in the `DetailRowTriggerEventArgs` whether it was a multi select click or just a regular row click. We can think of introducing a new `DetailRowTriggerType.MultiSelectClick` in the next version.
  - Other than that a workaround will be provided to the user.

**Test Code:**

```
<DataGrid TItem=PositionAllocationViewModel Data=data SelectionMode="DataGridSelectionMode.Multiple" @bind-SelectedRows=SelectedPositions
          RowSelectable="RowSelectableHandler"
          
          DetailRowTrigger="@(GroupDetailRowTrigger)">
    <DataGridColumns>
        <DataGridMultiSelectColumn TItem="PositionAllocationViewModel" Width="30px"></DataGridMultiSelectColumn>
        <DataGridColumn TItem="PositionAllocationViewModel" Field="@nameof(PositionAllocationViewModel.Name)"></DataGridColumn>
    </DataGridColumns>
</DataGrid>

@code {
    private bool RowSelectableHandler( RowSelectableEventArgs<PositionAllocationViewModel> rowSelectableEventArgs )
    {
        Console.WriteLine( "RowSelectableHandler" );
        Console.WriteLine( rowSelectableEventArgs.SelectReason );
        return rowSelectableEventArgs.SelectReason is not DataGridSelectReason.RowClick;
    }

    private bool GroupDetailRowTrigger( DetailRowTriggerEventArgs<PositionAllocationViewModel> e )
    {
        Console.WriteLine( "GroupDetailRowTrigger" );
        // Not being called
        return SelectedPositions.Contains( e.Item );
    }
    private List<PositionAllocationViewModel> data = new()
    {
        new PositionAllocationViewModel { Id = 1, Name = "Alaska" },
        new PositionAllocationViewModel { Id = 2, Name = "California" },
        new PositionAllocationViewModel { Id = 3, Name = "Florida" },
        new PositionAllocationViewModel { Id = 4, Name = "Texas" },
        new PositionAllocationViewModel { Id = 5, Name = "Washington" },
    };
    private List<PositionAllocationViewModel> SelectedPositions = new();
    private class PositionAllocationViewModel
    {
        public int Id { get; set; }
        public string Name { get; set; }
    }
}
```