### PR TITLE
FileEdit / FilePicker handle fileinput disabled

### DIFF
--- a/Source/Blazorise/wwwroot/fileEdit.js
+++ b/Source/Blazorise/wwwroot/fileEdit.js
@@ -99,8 +99,10 @@ function mapElementFilesToFileEntries(element) {
 
 async function onDrop(e, element) {
     e.preventDefault();
-    console.log(element);
     let fileInput = element;
+
+    if (fileInput.disabled)
+        return;
 
     let _files = await getFilesAsync(e.dataTransfer, fileInput.webkitdirectory, fileInput.multiple);
     fileInput.files = _files;

--- a/Source/Blazorise/wwwroot/filePicker.js
+++ b/Source/Blazorise/wwwroot/filePicker.js
@@ -20,15 +20,23 @@ export function destroy(element, elementId) {
 function initializeDropZone(element) {
     let fileInput = setFileInput(element);
     if (fileInput) {
-        element.addEventListener("dragenter", onDragHover);
-        element.addEventListener("dragover", onDragHover);
+        element.addEventListener("dragenter", async (e) => await onDragHover(e, element), false);
+        element.addEventListener("dragover", async (e) => await onDragHover(e, element), false);
         element.addEventListener("dragleave", onDragLeave);
         element.addEventListener("drop", async (e) => await onDrop(e, element), false);
         element.addEventListener('paste', (e) => onPaste(e, element));
     }
 }
 
-function onDragHover(e) {
+function onDragHover(e, element) {
+    if (element.fileInput.disabled) {
+        e.dataTransfer.dropEffect = "none";
+        if (element.fileInput == e.target){
+            //Fallback to FileEdit behavior
+            return;
+        }
+
+    }
     e.preventDefault();
 }
 
@@ -38,8 +46,10 @@ function onDragLeave(e) {
 
 async function onDrop(e, element) {
     e.preventDefault();
-    console.log(element);
     let fileInput = getFileInput(element);
+
+    if (fileInput.disabled)
+        return;
 
     let _files = await getFilesAsync(e.dataTransfer, fileInput.webkitdirectory, fileInput.multiple);
     fileInput.files = _files;


### PR DESCRIPTION
`FilePicker` should now handle disabled and not allow the drop of files.


I did not make any changes to `ReadOnly`, as currently it seems the `ReadOnly` has no effect on the input file, and still allows regular click to browse files.