### PR TITLE
DataGrid : Column Preventrowclick does not work anymore

### DIFF
--- a/Source/Blazorise/Components/Table/TableRowCell.razor
+++ b/Source/Blazorise/Components/Table/TableRowCell.razor
@@ -1,6 +1,10 @@
 ﻿@namespace Blazorise
 @inherits BaseDraggableComponent
-<td @ref="@ElementRef" id="@ElementId" class="@ClassNames" style="@StyleNames" @onclick="@OnClickHandler" colspan="@ColumnSpan" rowspan="@RowSpan"
+<td @ref="@ElementRef" id="@ElementId" class="@ClassNames" style="@StyleNames" 
+    @onclick="@OnClickHandler"
+    @onclick:preventDefault="@ClickPreventDefault"
+    @onclick:stopPropagation="@ClickStopPropagation"
+    colspan="@ColumnSpan" rowspan="@RowSpan"
     draggable="@DraggableString"
     @ondragend="@OnDragEndHandler"
     @ondragend:preventDefault="@DragEndPreventDefault"

--- a/Source/Blazorise/Components/Table/TableRowCell.razor.cs
+++ b/Source/Blazorise/Components/Table/TableRowCell.razor.cs
@@ -146,5 +146,15 @@ public partial class TableRowCell : BaseDraggableComponent
     /// </summary>
     [Parameter] public RenderFragment ChildContent { get; set; }
 
+    /// <summary>
+    /// Used to prevent the default action for an <see cref="OnClickHandler"/> event.
+    /// </summary>
+    [Parameter] public bool ClickPreventDefault { get; set; }
+
+    /// <summary>
+    /// Used to stop progation of the click action event.
+    /// </summary>
+    [Parameter] public bool ClickStopPropagation { get; set; }
+
     #endregion
 }

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridRow.razor
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridRow.razor
@@ -81,6 +81,7 @@
                 {
                     <TableRowCell @key=column
                                   @onclick=@(ParentDataGrid.IsCellEdit && ParentDataGrid.EditState != DataGridEditState.New ? async () => await ParentDataGrid.HandleCellEdit(column, GetCurrentItem()) : default)
+                                  ClickStopPropagation=@column.PreventRowClick
                                   TextAlignment="@column.TextAlignment" VerticalAlignment="@column.VerticalAlignment" Display="@column.Display" Flex="@column.Flex" Gap="@column.Gap" FixedPosition="@column.FixedPosition" Width="@column.BuildCellFluentSizing()"
                                   Style="@GetCellStyle(column, styling, selectedStyling, cellBatchEditStyling)" Class="@GetCellClass(column, styling, selectedStyling, cellBatchEditStyling)"
                                   Background="@GetCellBackground(styling, selectedStyling, cellBatchEditStyling)" Color="@GetCellColor(styling, selectedStyling, cellBatchEditStyling)" TextColor="@GetCellTextColor(styling, selectedStyling, cellBatchEditStyling)">


### PR DESCRIPTION
It seems we have removed mistakenly the stopPropagation attribute before when implementing a new feature.

![image](https://github.com/Megabit/Blazorise/assets/22283161/ca0df1c4-c066-48a3-95f4-918a59d2d035)

Razor components do not support having both `@onlick`, `@onlick:stopPropagation` so you need to use an actual **Parameter** and set it on the html element.

We would be introducing two new Parameters to `TableRowCell` in a patch. Not ideal, Should we move to 1.5? Or take the added change? @stsrki ?