### PR TITLE
DataGrid : Column Preventrowclick does not work anymore 

### DIFF
--- a/Documentation/Blazorise.Docs/Pages/Docs/Components/Tables/TablePage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Components/Tables/TablePage.razor
@@ -274,3 +274,30 @@
         Specifies the custom title content to be rendered inside the <Code>TableRowGroup</Code>. It has higher priority over the <Code>Title</Code> parameter.
     </DocsAttributesItem>
 </DocsAttributes>
+
+<DocsAttributes Title="TableRowcell">
+    <DocsAttributesItem Name="Color" Type="Color">
+        Gets or sets the cell variant color.
+    </DocsAttributesItem>
+    <DocsAttributesItem Name="RowSpan" Type="int?" Default="null">
+        Number of rows a cell should span.
+    </DocsAttributesItem>
+    <DocsAttributesItem Name="ColumnSpan" Type="int?" Default="null">
+        Number of columns a cell should span.
+    </DocsAttributesItem>
+    <DocsAttributesItem Name="FixedPosition" Type="TableColumnFixedPosition" Default="TableColumnFixedPosition.None">
+        Defines the fixed position of the row cell within the table.
+    </DocsAttributesItem>
+    <DocsAttributesItem Name="Clicked" Type="EventCallback<BLMouseEventArgs>">
+        Occurs when the row cell is clicked.
+    </DocsAttributesItem>
+    <DocsAttributesItem Name="ChildContent" Type="RenderFragment" Default="null">
+        Specifies the content to be rendered inside this <Code>TableRowCell</Code>.
+    </DocsAttributesItem>
+    <DocsAttributesItem Name="ClickPreventDefault" Type="bool" Default="false">
+        Used to prevent the default action for an <Code>OnClickHandler</Code>.
+    </DocsAttributesItem>
+    <DocsAttributesItem Name="ClickStopPropagation" Type="bool" Default="false">
+        Used to stop progation of the click action event.
+    </DocsAttributesItem>
+</DocsAttributes>

--- a/Documentation/Blazorise.Docs/Pages/News/2024-03-31-release-notes-150.razor
+++ b/Documentation/Blazorise.Docs/Pages/News/2024-03-31-release-notes-150.razor
@@ -1,0 +1,35 @@
+﻿@page "/news/release-notes/150"
+
+<Seo Canonical="news/release-notes/150" Title="Blazorise v1.5.0" Description="We are pleased to announce the release of version 1.5.0, which includes important bug fixes and enhancements. This release focuses on improving stability and addressing key issues identified by our user community." ImageUrl="img/news/150/v150.png" />
+
+<NewsPageImage Source="img/news/150/v150.png" Text="Blazorise v1.5.0" />
+
+<NewsPageTitle>
+    Release: Blazorise 1.5.0
+</NewsPageTitle>
+
+<Paragraph>
+    We are excited to announce the release of Blazorise 1.5.0. 
+</Paragraph>
+
+<NewsPageSubtitle>
+    What's New in 1.5.0
+</NewsPageSubtitle>
+
+<Heading Size="HeadingSize.Is3">
+    TableRowCell Support for click preventDefault & stopPropagation events.
+</Heading>
+
+<Paragraph>
+    Added support for TableRowCell to preventDefault and stopPropagation events on cell click, ClickPreventDefault and ClickStopPropagation respectively.
+</Paragraph>
+
+<Heading Size="HeadingSize.Is3">
+    DataGrid
+</Heading>
+
+<Paragraph>
+    Resolved an issue where the DataGrid PreventRowClick was not working as expected.
+</Paragraph>
+
+<NewsPagePostInfo UserName="Mladen Macanović" ImageName="mladen" PostedOn="March 31th, 2024" Read="3 min" />

--- a/Source/Blazorise/Components/Table/TableRowCell.razor
+++ b/Source/Blazorise/Components/Table/TableRowCell.razor
@@ -1,6 +1,10 @@
 ﻿@namespace Blazorise
 @inherits BaseDraggableComponent
-<td @ref="@ElementRef" id="@ElementId" class="@ClassNames" style="@StyleNames" @onclick="@OnClickHandler" colspan="@ColumnSpan" rowspan="@RowSpan"
+<td @ref="@ElementRef" id="@ElementId" class="@ClassNames" style="@StyleNames" 
+    @onclick="@OnClickHandler"
+    @onclick:preventDefault="@ClickPreventDefault"
+    @onclick:stopPropagation="@ClickStopPropagation"
+    colspan="@ColumnSpan" rowspan="@RowSpan"
     draggable="@DraggableString"
     @ondragend="@OnDragEndHandler"
     @ondragend:preventDefault="@DragEndPreventDefault"

--- a/Source/Blazorise/Components/Table/TableRowCell.razor.cs
+++ b/Source/Blazorise/Components/Table/TableRowCell.razor.cs
@@ -146,5 +146,15 @@ public partial class TableRowCell : BaseDraggableComponent
     /// </summary>
     [Parameter] public RenderFragment ChildContent { get; set; }
 
+    /// <summary>
+    /// Used to prevent the default action for an <see cref="OnClickHandler"/> event.
+    /// </summary>
+    [Parameter] public bool ClickPreventDefault { get; set; }
+
+    /// <summary>
+    /// Used to stop progation of the click action event.
+    /// </summary>
+    [Parameter] public bool ClickStopPropagation { get; set; }
+
     #endregion
 }

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridRow.razor
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridRow.razor
@@ -81,6 +81,7 @@
                 {
                     <TableRowCell @key=column
                                   @onclick=@(ParentDataGrid.IsCellEdit && ParentDataGrid.EditState != DataGridEditState.New ? async () => await ParentDataGrid.HandleCellEdit(column, GetCurrentItem()) : default)
+                                  ClickStopPropagation=@column.PreventRowClick
                                   TextAlignment="@column.TextAlignment" VerticalAlignment="@column.VerticalAlignment" Display="@column.Display" Flex="@column.Flex" Gap="@column.Gap" FixedPosition="@column.FixedPosition" Width="@column.BuildCellFluentSizing()"
                                   Style="@GetCellStyle(column, styling, selectedStyling, cellBatchEditStyling)" Class="@GetCellClass(column, styling, selectedStyling, cellBatchEditStyling)"
                                   Background="@GetCellBackground(styling, selectedStyling, cellBatchEditStyling)" Color="@GetCellColor(styling, selectedStyling, cellBatchEditStyling)" TextColor="@GetCellTextColor(styling, selectedStyling, cellBatchEditStyling)">


### PR DESCRIPTION
It seems we have removed mistakenly the stopPropagation attribute before when implementing a new feature.



Razor components do not support having both @onlick, @onlick:stopPropagation so you need to use an actual Parameter and set it on the html element.
