### PR TITLE
SnackbarInfo Initialize IntervalBeforeClose correctly

### DIFF
--- a/Source/Extensions/Blazorise.Snackbar/SnackbarStack.razor.cs
+++ b/Source/Extensions/Blazorise.Snackbar/SnackbarStack.razor.cs
@@ -42,7 +42,9 @@ public partial class SnackbarStack : BaseComponent
             ShowActionButton = showActionButton;
             ActionButtonText = actionButtonText;
             ActionButtonIcon = actionButtonIcon;
-            IntervalBeforeClose = intervalBeforeClose + animationDuration;
+            IntervalBeforeClose = intervalBeforeClose is null
+                                    ? null
+                                    : intervalBeforeClose + ( animationDuration ?? 0 );
             AnimationDuration = animationDuration;
             Multiline = multiline;
         }


### PR DESCRIPTION
Issue was that `IntervalBeforeClose` was being summed with null and being turned into null