### PR TITLE
Modalprovider loses parameter reference when closing popup

### DIFF
--- a/Source/Blazorise/Interfaces/IModalService.cs
+++ b/Source/Blazorise/Interfaces/IModalService.cs
@@ -27,7 +27,7 @@ public interface IModalService
     /// Shows a Modal where the content is TComponent.
     /// </summary>
     /// <typeparam name="TComponent"></typeparam>
-    public Task<ModalInstance> Show<TComponent>();
+    public Task<ModalInstance> Show<TComponent>() where TComponent : notnull, IComponent;
 
     /// <summary>
     /// Shows a Modal where the content is TComponent.
@@ -35,7 +35,7 @@ public interface IModalService
     /// <typeparam name="TComponent"></typeparam>
     /// <param name="title"></param>
     /// <returns></returns>
-    public Task<ModalInstance> Show<TComponent>( string title );
+    public Task<ModalInstance> Show<TComponent>( string title ) where TComponent : notnull, IComponent;
 
     /// <summary>
     /// Shows a Modal where the content is TComponent.
@@ -43,44 +43,44 @@ public interface IModalService
     /// <typeparam name="TComponent"></typeparam>
     /// <param name="parameters"></param>
     /// <returns></returns>
-    public Task<ModalInstance> Show<TComponent>( Action<ModalProviderParameterBuilder<TComponent>> parameters );
+    public Task<ModalInstance> Show<TComponent>( Action<ModalProviderParameterBuilder<TComponent>> parameters ) where TComponent : notnull, IComponent;
 
     /// <summary>
     /// Shows a Modal where the content is TComponent.
     /// </summary>
     /// <typeparam name="TComponent"></typeparam>
-    /// <param name="parameters"></param>
-    /// <param name="modalInstanceOptions"></param>
-    /// <returns></returns>
-    public Task<ModalInstance> Show<TComponent>( Action<ModalProviderParameterBuilder<TComponent>> parameters, ModalInstanceOptions modalInstanceOptions );
-
-    /// <summary>
-    /// Shows a Modal where the content is TComponent.
-    /// </summary>
-    /// <typeparam name="TComponent"></typeparam>
-    /// <param name="title"></param>
-    /// <param name="parameters"></param>
-    /// <returns></returns>
-    public Task<ModalInstance> Show<TComponent>( string title, Action<ModalProviderParameterBuilder<TComponent>> parameters );
-
-    /// <summary>
-    /// Shows a Modal where the content is TComponent.
-    /// </summary>
-    /// <typeparam name="TComponent"></typeparam>
-    /// <param name="title"></param>
-    /// <param name="modalInstanceOptions"></param>
-    /// <returns></returns>
-    public Task<ModalInstance> Show<TComponent>( string title, ModalInstanceOptions modalInstanceOptions );
-
-    /// <summary>
-    /// Shows a Modal where the content is TComponent.
-    /// </summary>
-    /// <typeparam name="TComponent"></typeparam>
-    /// <param name="title"></param>
     /// <param name="parameters"></param>
     /// <param name="modalInstanceOptions"></param>
     /// <returns></returns>
-    public Task<ModalInstance> Show<TComponent>( string title, Action<ModalProviderParameterBuilder<TComponent>> parameters, ModalInstanceOptions modalInstanceOptions );
+    public Task<ModalInstance> Show<TComponent>( Action<ModalProviderParameterBuilder<TComponent>> parameters, ModalInstanceOptions modalInstanceOptions ) where TComponent : notnull, IComponent;
+
+    /// <summary>
+    /// Shows a Modal where the content is TComponent.
+    /// </summary>
+    /// <typeparam name="TComponent"></typeparam>
+    /// <param name="title"></param>
+    /// <param name="parameters"></param>
+    /// <returns></returns>
+    public Task<ModalInstance> Show<TComponent>( string title, Action<ModalProviderParameterBuilder<TComponent>> parameters ) where TComponent : notnull, IComponent;
+
+    /// <summary>
+    /// Shows a Modal where the content is TComponent.
+    /// </summary>
+    /// <typeparam name="TComponent"></typeparam>
+    /// <param name="title"></param>
+    /// <param name="modalInstanceOptions"></param>
+    /// <returns></returns>
+    public Task<ModalInstance> Show<TComponent>( string title, ModalInstanceOptions modalInstanceOptions ) where TComponent : notnull, IComponent;
+
+    /// <summary>
+    /// Shows a Modal where the content is TComponent.
+    /// </summary>
+    /// <typeparam name="TComponent"></typeparam>
+    /// <param name="title"></param>
+    /// <param name="parameters"></param>
+    /// <param name="modalInstanceOptions"></param>
+    /// <returns></returns>
+    public Task<ModalInstance> Show<TComponent>( string title, Action<ModalProviderParameterBuilder<TComponent>> parameters, ModalInstanceOptions modalInstanceOptions ) where TComponent : notnull, IComponent;
 
     /// <summary>
     /// Shows a Modal where the content is of componentType.

--- a/Source/Blazorise/Services/ModalService.cs
+++ b/Source/Blazorise/Services/ModalService.cs
@@ -21,36 +21,34 @@ public class ModalService : IModalService
         => ModalProvider = modalProvider;
 
     /// <inheritdoc/>
-    public Task<ModalInstance> Show<TComponent>()
+    public Task<ModalInstance> Show<TComponent>() where TComponent : notnull, IComponent
         => Show( typeof( TComponent ) );
 
     /// <inheritdoc/>
-    public Task<ModalInstance> Show<TComponent>( string title )
+    public Task<ModalInstance> Show<TComponent>( string title ) where TComponent : notnull, IComponent
         => Show( title, typeof( TComponent ) );
 
     /// <inheritdoc/>
-    public Task<ModalInstance> Show<TComponent>( string title, ModalInstanceOptions modalProviderOptions )
+    public Task<ModalInstance> Show<TComponent>( string title, ModalInstanceOptions modalProviderOptions ) where TComponent : notnull, IComponent
         => Show<TComponent>( title, null, modalProviderOptions );
 
     /// <inheritdoc/>
-    public Task<ModalInstance> Show<TComponent>( Action<ModalProviderParameterBuilder<TComponent>> parameters )
+    public Task<ModalInstance> Show<TComponent>( Action<ModalProviderParameterBuilder<TComponent>> parameters ) where TComponent : notnull, IComponent
         => Show<TComponent>( string.Empty, parameters, null );
 
     /// <inheritdoc/>
-    public Task<ModalInstance> Show<TComponent>( Action<ModalProviderParameterBuilder<TComponent>> parameters, ModalInstanceOptions modalInstanceOptions )
+    public Task<ModalInstance> Show<TComponent>( Action<ModalProviderParameterBuilder<TComponent>> parameters, ModalInstanceOptions modalInstanceOptions ) where TComponent : notnull, IComponent
         => Show<TComponent>( string.Empty, parameters, modalInstanceOptions );
 
     /// <inheritdoc/>
-    public Task<ModalInstance> Show<TComponent>( string title, Action<ModalProviderParameterBuilder<TComponent>> parameters )
+    public Task<ModalInstance> Show<TComponent>( string title, Action<ModalProviderParameterBuilder<TComponent>> parameters ) where TComponent : notnull, IComponent
         => Show<TComponent>( title, parameters, null );
 
     /// <inheritdoc/>
-    public Task<ModalInstance> Show<TComponent>( string title, Action<ModalProviderParameterBuilder<TComponent>> parameters, ModalInstanceOptions modalInstanceOptions )
+    public Task<ModalInstance> Show<TComponent>( string title, Action<ModalProviderParameterBuilder<TComponent>> parameters, ModalInstanceOptions modalInstanceOptions ) where TComponent : notnull, IComponent
     {
-        ModalProviderParameterBuilder<TComponent> builder = new();
-        if ( parameters is not null )
-            parameters( builder );
-        return Show( title, typeof( TComponent ), builder.Parameters, modalInstanceOptions );
+        RenderFragment childContent = BuildParameterfulContent<TComponent>( parameters );
+        return Show( title, childContent, modalInstanceOptions );
     }
 
     /// <inheritdoc/>
@@ -72,18 +70,7 @@ public class ModalService : IModalService
     /// <inheritdoc/>
     public Task<ModalInstance> Show( string title, Type componentType, Dictionary<string, object> componentParameters = null, ModalInstanceOptions modalInstanceOptions = null )
     {
-        var childContent = new RenderFragment( __builder =>
-        {
-            __builder.OpenComponent( componentType );
-
-            if ( componentParameters is not null )
-            {
-                __builder.Attributes( componentParameters );
-            }
-
-            __builder.CloseComponent();
-        } );
-
+        RenderFragment childContent = BuildParameterfulContent( componentType, componentParameters );
         return Show( title, childContent, modalInstanceOptions );
     }
 
@@ -100,4 +87,40 @@ public class ModalService : IModalService
     /// <inheritdoc/>
     public Task Hide( ModalInstance modalInstance )
         => ModalProvider.Hide( modalInstance );
+
+    private static RenderFragment BuildParameterfulContent( Type componentType, Dictionary<string, object> componentParameters )
+    {
+        return new RenderFragment( __builder =>
+        {
+            __builder.OpenComponent( componentType );
+
+            if ( componentParameters is not null )
+            {
+                __builder.Attributes( componentParameters, 1 );
+            }
+
+            __builder.CloseComponent();
+        } );
+    }
+
+    private static RenderFragment BuildParameterfulContent<TComponent>( Action<ModalProviderParameterBuilder<TComponent>> parameters ) where TComponent : notnull, IComponent
+    {
+        return new RenderFragment( __builder =>
+        {
+            __builder.OpenComponent<TComponent>();
+
+            if ( parameters is not null )
+            {
+                ModalProviderParameterBuilder<TComponent> parameterBuilder = new();
+                parameters( parameterBuilder );
+
+                if ( parameterBuilder.Parameters is not null )
+                {
+                    __builder.Attributes( parameterBuilder.Parameters, 1 );
+                }
+            }
+
+            __builder.CloseComponent();
+        } );
+    }
 }


### PR DESCRIPTION
More info is found in the github issue.


Added where `TComponent : notnull, IComponent` to the `TComponent` version. While it is in theory a breaking change. If users use a non `IComponent` it will just throw an exception as it's not valid for blazor rendering.

What's notable is that we specifically capture the parameters setter provided by the user:
![image](https://github.com/Megabit/Blazorise/assets/22283161/498dfc52-a167-4493-9186-f0745e352231)
