### PR TITLE
Autocomplete: Only ResyncText if not Multiple

### DIFF
--- a/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
+++ b/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
@@ -507,8 +507,10 @@ public partial class Autocomplete<TItem, TValue> : BaseAfterRenderComponent, IAs
 
                 await Revalidate();
             }
-
-            await ResyncText();
+            else
+            {
+                await ResyncText();
+            }
 
             return;
         }


### PR DESCRIPTION
This should keep the autocomplete open when unselecting items.
This does not seem necessary for Multiple at all. Since the selection is applied to badges and not the input/text itself.