### PR TITLE
RichTextEdit: update to latest QuillJS

### DIFF
--- a/Documentation/Blazorise.Docs/Pages/News/2024-02-15-release-notes-150.razor
+++ b/Documentation/Blazorise.Docs/Pages/News/2024-02-15-release-notes-150.razor
@@ -225,4 +225,12 @@
     You can also set it to <Code>BarMenuToggleBehavior.AllowSingleMenu</Code> to only keep a menu open at a time.
 </Paragraph>
 
+<Heading Size="HeadingSize.Is3">
+    RichTextEdit
+</Heading>
+
+<Paragraph>
+    As with many other features in this release we have updated internals of RichTextEdit to work with the latest version of <Anchor To="https://github.com/quilljs/quill" Title="Link to Quill JS">Quill JS</Anchor> library. This update means there will be less security risks that were reported by using an older version.
+</Paragraph>
+
 <NewsPagePostInfo UserName="Mladen Macanović" ImageName="mladen" PostedOn="February 29th, 2024" Read="9 min" />

--- a/Source/Extensions/Blazorise.RichTextEdit/RichTextEditOptions.cs
+++ b/Source/Extensions/Blazorise.RichTextEdit/RichTextEditOptions.cs
@@ -25,7 +25,7 @@ public sealed class RichTextEditOptions
     /// <summary>
     /// The QuillJs version to load
     /// </summary>
-    public string QuillJsVersion { get; set; } = "1.3.7";
+    public string QuillJsVersion { get; set; } = "2.0.0-rc.2";
 
     /// <summary>
     /// Load the RichTextEdit scripts and stylesheets on demand.
@@ -45,18 +45,18 @@ public sealed class RichTextEditOptions
     {
         List<DynamicReference> references = new()
         {
-            new( $@"https://cdn.quilljs.com/{QuillJsVersion}/quill.js", Script ),
+            new( $@"https://cdn.jsdelivr.net/npm/quill@{QuillJsVersion}/dist/quill.js", Script ),
             new( @"_content/Blazorise.RichTextEdit/blazorise.richtextedit.bundle.scp.css", Stylesheet )
         };
 
         if ( UseBubbleTheme )
         {
-            references.Add( new( $@"https://cdn.quilljs.com/{QuillJsVersion}/quill.bubble.css", Stylesheet ) );
+            references.Add( new( $@"https://cdn.jsdelivr.net/npm/quill@{QuillJsVersion}/dist/quill.bubble.css", Stylesheet ) );
         }
 
         if ( UseShowTheme )
         {
-            references.Add( new( $@"https://cdn.quilljs.com/{QuillJsVersion}/quill.snow.css", Stylesheet ) );
+            references.Add( new( $@"https://cdn.jsdelivr.net/npm/quill@{QuillJsVersion}/dist/quill.snow.css", Stylesheet ) );
         }
 
         return references;


### PR DESCRIPTION
Closes #5032

It seems there are no breaking changes for the features that we use, according to https://quilljs.com/guides/upgrading-to-2-0

@njannink would you be available for a quick test of this update?