### PR TITLE
DatePicker: Fix flatpickrWrapper is not defined error

### DIFF
--- a/Source/Blazorise/wwwroot/datePicker.js
+++ b/Source/Blazorise/wwwroot/datePicker.js
@@ -110,19 +110,19 @@ export function initialize(dotnetAdapter, element, elementId, options) {
 
                     picker.errorClassWatcher = new ClassWatcher(picker.altInput, options.validationStatus.errorClass, errorClassAddHandler, errorClassRemoveHandler);
                 }
-            }
-        }
 
-        if (options.validationStatus.successClass) {
-            function successClassAddHandler() {
-                flatpickrWrapper.classList.add(options.validationStatus.successClass);
-            }
+                if (options.validationStatus.successClass) {
+                    function successClassAddHandler() {
+                        flatpickrWrapper.classList.add(options.validationStatus.successClass);
+                    }
 
-            function successClassRemoveHandler() {
-                flatpickrWrapper.classList.remove(options.validationStatus.successClass);
-            }
+                    function successClassRemoveHandler() {
+                        flatpickrWrapper.classList.remove(options.validationStatus.successClass);
+                    }
 
-            picker.successClassWatcher = new ClassWatcher(picker.altInput, options.validationStatus.successClass, successClassAddHandler, successClassRemoveHandler);
+                    picker.successClassWatcher = new ClassWatcher(picker.altInput, options.validationStatus.successClass, successClassAddHandler, successClassRemoveHandler);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
First of all thanks for maintaining this library!

When updating from Blazorise 1.3.3 to the newest 1.4.3, we started to notice the following error logs in the console:

```
datePicker.js?v=1.4.3.0:118 Uncaught ReferenceError: flatpickrWrapper is not defined
    at ClassWatcher.successClassAddHandler [as classAddedCallback] (datePicker.js?v=1.4.3.0:118:17)
    at MutationObserver.mutationCallback (observer.js?v=1.4.3.0:90:30)
```

The component behavior seems to still be as excepted though.

I suspect that this is because in #5093 the successClassAddHandler functions were moved outside of the scope where the flatpickrWrapper is available. In the PR I unfortunately wasn't able to see why this was changed. The PR seems to me a bit unrelated to those functions.
I'm very open to change the PR if my analysis was incorrect! 