### PR TITLE
TreeView: Context Menu API

### DIFF
--- a/Demos/Blazorise.Demo/Pages/Tests/TreeViewPage.razor
+++ b/Demos/Blazorise.Demo/Pages/Tests/TreeViewPage.razor
@@ -45,6 +45,7 @@
             </CardBody>
             <CardBody>
                 <TreeView @ref="@treeViewRef"
+                          TNode="NodeInfo"
                           Nodes="Nodes"
                           SelectionMode="@selectionMode"
                           @bind-SelectedNode="selectedNode"
@@ -54,7 +55,9 @@
                           HasChildNodes="@(item => item.Children?.Any() == true)"
                           IsDisabled="@(item => item.Disabled)"
                           NodeStyling="@((item, style) => { style.TextColor = (item.Children?.Any() == true) ? TextColor.Primary : TextColor.Dark; style.Style = "font-weight:bold"; })"
-                          SelectedNodeStyling="@((item, style) => {style.Background = Background.Success; style.TextColor = TextColor.White; })">
+                          SelectedNodeStyling="@((item, style) => {style.Background = Background.Success; style.TextColor = TextColor.White; })"
+                          NodeContextMenu="@OnNodeContextMenu"
+                          NodeContextMenuPreventDefault>
                     <NodeContent>
                         <Icon Name="IconName.Folder" />
                         @context.Text

--- a/Demos/Blazorise.Demo/Pages/Tests/TreeViewPage.razor.cs
+++ b/Demos/Blazorise.Demo/Pages/Tests/TreeViewPage.razor.cs
@@ -5,6 +5,7 @@ using System.Security;
 using System.Threading.Tasks;
 using Blazorise.TreeView;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace Blazorise.Demo.Pages.Tests;
 
@@ -128,5 +129,12 @@ public partial class TreeViewPage : ComponentBase
             foreach ( var child in children )
                 queue.Enqueue( child );
         }
+    }
+
+    protected Task OnNodeContextMenu( TreeViewNodeMouseEventArgs<NodeInfo> eventArgs )
+    {
+        Console.WriteLine( $"NodeContextMenu: {eventArgs.Node.Text}" );
+
+        return Task.CompletedTask;
     }
 }

--- a/Documentation/Blazorise.Docs/Models/Snippets.generated.cs
+++ b/Documentation/Blazorise.Docs/Models/Snippets.generated.cs
@@ -9641,6 +9641,107 @@ services.AddValidatorsFromAssembly( typeof( App ).Assembly );";
     private List<string> list = new List<string> { ""Apple"", ""Banana"", ""Cherry"", ""Grapes"", ""Orange"", ""Pear"", ""Strawberry"" };
 }";
 
+        public const string TreeViewContextMenuExample = @"@using System.Drawing
+
+<TreeView TNode=""Item""
+          Nodes=""Items""
+          GetChildNodes=""@(item => item.Children)""
+          HasChildNodes=""@(item => item.Children?.Any() == true)""
+          AutoExpandAll
+          @bind-SelectedNode=""selectedNode""
+          @bind-ExpandedNodes=""expandedNodes""
+          NodeContextMenu=""@OnNodeContextMenu""
+          NodeContextMenuPreventDefault>
+    <NodeContent>
+        <Icon Name=""IconName.Folder"" />
+        @context.Text
+    </NodeContent>
+</TreeView>
+
+@if ( showContextMenu )
+{
+    <Div Position=""Position.Fixed"" Background=""Background.Danger"" Style=""@($""left:{contextMenuPosX}px; top:{contextMenuPosY}px;"")"">
+        <ListGroup>
+            <ListGroupItem>
+                <Strong>Node: @contextMenuNode?.Text</Strong>
+            </ListGroupItem>
+            <ListGroupItem Clicked=""@(()=>OnContextItemEditClicked(contextMenuNode))"" Style=""cursor: pointer;"">
+                <Icon Name=""IconName.Edit"" TextColor=""TextColor.Secondary"" /> Edit
+            </ListGroupItem>
+            <ListGroupItem Clicked=""@(()=>OnContextItemDeleteClicked(contextMenuNode))"" Style=""cursor: pointer;"">
+                <Icon Name=""IconName.Delete"" TextColor=""TextColor.Danger"" /> Delete
+            </ListGroupItem>
+        </ListGroup>
+    </Div>
+}
+
+@code {
+    public class Item
+    {
+        public string Text { get; set; }
+        public IEnumerable<Item> Children { get; set; }
+    }
+
+    IEnumerable<Item> Items = new[]
+    {
+        new Item { Text = ""Item 1"" },
+        new Item
+        {
+            Text = ""Item 2"",
+            Children = new []
+            {
+                new Item { Text = ""Item 2.1"" },
+                new Item
+                {
+                    Text = ""Item 2.2"",
+                    Children = new []
+                    {
+                        new Item { Text = ""Item 2.2.1"" },
+                        new Item { Text = ""Item 2.2.2"" },
+                        new Item { Text = ""Item 2.2.3"" },
+                        new Item { Text = ""Item 2.2.4"" }
+                    }
+                },
+                new Item { Text = ""Item 2.3"" },
+                new Item { Text = ""Item 2.4"" }
+            }
+        },
+        new Item { Text = ""Item 3"" },
+    };
+
+    IList<Item> expandedNodes = new List<Item>();
+    Item selectedNode;
+
+    bool showContextMenu = false;
+    double contextMenuPosX;
+    double contextMenuPosY;
+    Item contextMenuNode;
+
+    protected Task OnNodeContextMenu( TreeViewNodeMouseEventArgs<Item> eventArgs )
+    {
+        showContextMenu = true;
+        contextMenuNode = eventArgs.Node;
+        contextMenuPosX = eventArgs.MouseEventArgs.ClientX;
+        contextMenuPosY = eventArgs.MouseEventArgs.ClientY;
+
+        return Task.CompletedTask;
+    }
+
+    protected Task OnContextItemEditClicked( Item item )
+    {
+        showContextMenu = false;
+
+        return Task.CompletedTask;
+    }
+
+    protected Task OnContextItemDeleteClicked( Item item )
+    {
+        showContextMenu = false;
+
+        return Task.CompletedTask;
+    }
+}";
+
         public const string TreeViewExample = @"<TreeView Nodes=""Items""
           GetChildNodes=""@(item => item.Children)""
           HasChildNodes=""@(item => item.Children?.Any() == true)""

--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/TreeView/Code/TreeViewContextMenuExampleCode.html
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/TreeView/Code/TreeViewContextMenuExampleCode.html
@@ -1,0 +1,105 @@
+<div class="blazorise-codeblock">
+<div class="html"><pre>
+<span class="atSign">&#64;</span>using System.Drawing
+
+<span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">TreeView</span> <span class="htmlAttributeName">TNode</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">Item</span><span class="quot">&quot;</span>
+          <span class="htmlAttributeName">Nodes</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">Items</span><span class="quot">&quot;</span>
+          <span class="htmlAttributeName">GetChildNodes</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue"><span class="atSign">&#64;</span>(item =&gt; item.Children)</span><span class="quot">&quot;</span>
+          <span class="htmlAttributeName">HasChildNodes</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue"><span class="atSign">&#64;</span>(item =&gt; item.Children?.Any() == true)</span><span class="quot">&quot;</span>
+          <span class="htmlAttributeName">AutoExpandAll</span>
+          <span class="htmlAttributeName"><span class="atSign">&#64;</span>bind-SelectedNode</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">selectedNode</span><span class="quot">&quot;</span>
+          <span class="htmlAttributeName"><span class="atSign">&#64;</span>bind-ExpandedNodes</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">expandedNodes</span><span class="quot">&quot;</span>
+          <span class="htmlAttributeName">NodeContextMenu</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="sharpVariable"><span class="atSign">&#64;</span>OnNodeContextMenu</span><span class="quot">&quot;</span>
+          <span class="htmlAttributeName">NodeContextMenuPreventDefault</span><span class="htmlTagDelimiter">&gt;</span>
+    <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">NodeContent</span><span class="htmlTagDelimiter">&gt;</span>
+        <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">Icon</span> <span class="htmlAttributeName">Name</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="enum">IconName</span><span class="enumValue">.Folder</span><span class="quot">&quot;</span> <span class="htmlTagDelimiter">/&gt;</span>
+        <span class="atSign">&#64;</span>context.Text
+    <span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">NodeContent</span><span class="htmlTagDelimiter">&gt;</span>
+<span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">TreeView</span><span class="htmlTagDelimiter">&gt;</span>
+
+<span class="atSign">&#64;</span>if ( showContextMenu )
+{
+    <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">Div</span> <span class="htmlAttributeName">Position</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="enum">Position</span><span class="enumValue">.Fixed</span><span class="quot">&quot;</span> <span class="htmlAttributeName">Background</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="enum">Background</span><span class="enumValue">.Danger</span><span class="quot">&quot;</span> <span class="htmlAttributeName">Style</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue"><span class="atSign">&#64;</span>($&quot;left:{contextMenuPosX}px; top:{contextMenuPosY}px;&quot;)</span><span class="quot">&quot;</span><span class="htmlTagDelimiter">&gt;</span>
+        <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">ListGroup</span><span class="htmlTagDelimiter">&gt;</span>
+            <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">ListGroupItem</span><span class="htmlTagDelimiter">&gt;</span>
+                <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">Strong</span><span class="htmlTagDelimiter">&gt;</span>Node: <span class="atSign">&#64;</span>contextMenuNode?.Text<span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">Strong</span><span class="htmlTagDelimiter">&gt;</span>
+            <span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">ListGroupItem</span><span class="htmlTagDelimiter">&gt;</span>
+            <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">ListGroupItem</span> <span class="htmlAttributeName">Clicked</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue"><span class="atSign">&#64;</span>(()=&gt;OnContextItemEditClicked(contextMenuNode))</span><span class="quot">&quot;</span> <span class="htmlAttributeName">Style</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">cursor: pointer;</span><span class="quot">&quot;</span><span class="htmlTagDelimiter">&gt;</span>
+                <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">Icon</span> <span class="htmlAttributeName">Name</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="enum">IconName</span><span class="enumValue">.Edit</span><span class="quot">&quot;</span> <span class="htmlAttributeName">TextColor</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="enum">TextColor</span><span class="enumValue">.Secondary</span><span class="quot">&quot;</span> <span class="htmlTagDelimiter">/&gt;</span> Edit
+            <span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">ListGroupItem</span><span class="htmlTagDelimiter">&gt;</span>
+            <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">ListGroupItem</span> <span class="htmlAttributeName">Clicked</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue"><span class="atSign">&#64;</span>(()=&gt;OnContextItemDeleteClicked(contextMenuNode))</span><span class="quot">&quot;</span> <span class="htmlAttributeName">Style</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">cursor: pointer;</span><span class="quot">&quot;</span><span class="htmlTagDelimiter">&gt;</span>
+                <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">Icon</span> <span class="htmlAttributeName">Name</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="enum">IconName</span><span class="enumValue">.Delete</span><span class="quot">&quot;</span> <span class="htmlAttributeName">TextColor</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="enum">TextColor</span><span class="enumValue">.Danger</span><span class="quot">&quot;</span> <span class="htmlTagDelimiter">/&gt;</span> Delete
+            <span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">ListGroupItem</span><span class="htmlTagDelimiter">&gt;</span>
+        <span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">ListGroup</span><span class="htmlTagDelimiter">&gt;</span>
+    <span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">Div</span><span class="htmlTagDelimiter">&gt;</span>
+}
+</pre></div>
+<div class="csharp"><pre>
+<span class="atSign">&#64;</span>code {
+    <span class="keyword">public</span> <span class="keyword">class</span> Item
+    {
+        <span class="keyword">public</span> <span class="keyword">string</span> Text { <span class="keyword">get</span>; <span class="keyword">set</span>; }
+        <span class="keyword">public</span> IEnumerable&lt;Item&gt; Children { <span class="keyword">get</span>; <span class="keyword">set</span>; }
+    }
+
+    IEnumerable&lt;Item&gt; Items = <span class="keyword">new</span>[]
+    {
+        <span class="keyword">new</span> Item { Text = <span class="string">&quot;Item 1&quot;</span> },
+        <span class="keyword">new</span> Item
+        {
+            Text = <span class="string">&quot;Item 2&quot;</span>,
+            Children = <span class="keyword">new</span> []
+            {
+                <span class="keyword">new</span> Item { Text = <span class="string">&quot;Item 2.1&quot;</span> },
+                <span class="keyword">new</span> Item
+                {
+                    Text = <span class="string">&quot;Item 2.2&quot;</span>,
+                    Children = <span class="keyword">new</span> []
+                    {
+                        <span class="keyword">new</span> Item { Text = <span class="string">&quot;Item 2.2.1&quot;</span> },
+                        <span class="keyword">new</span> Item { Text = <span class="string">&quot;Item 2.2.2&quot;</span> },
+                        <span class="keyword">new</span> Item { Text = <span class="string">&quot;Item 2.2.3&quot;</span> },
+                        <span class="keyword">new</span> Item { Text = <span class="string">&quot;Item 2.2.4&quot;</span> }
+                    }
+                },
+                <span class="keyword">new</span> Item { Text = <span class="string">&quot;Item 2.3&quot;</span> },
+                <span class="keyword">new</span> Item { Text = <span class="string">&quot;Item 2.4&quot;</span> }
+            }
+        },
+        <span class="keyword">new</span> Item { Text = <span class="string">&quot;Item 3&quot;</span> },
+    };
+
+    IList&lt;Item&gt; expandedNodes = <span class="keyword">new</span> List&lt;Item&gt;();
+    Item selectedNode;
+
+    <span class="keyword">bool</span> showContextMenu = <span class="keyword">false</span>;
+    <span class="keyword">double</span> contextMenuPosX;
+    <span class="keyword">double</span> contextMenuPosY;
+    Item contextMenuNode;
+
+    <span class="keyword">protected</span> Task OnNodeContextMenu( TreeViewNodeMouseEventArgs&lt;Item&gt; eventArgs )
+    {
+        showContextMenu = <span class="keyword">true</span>;
+        contextMenuNode = eventArgs.Node;
+        contextMenuPosX = eventArgs.MouseEventArgs.ClientX;
+        contextMenuPosY = eventArgs.MouseEventArgs.ClientY;
+
+        <span class="keyword">return</span> Task.CompletedTask;
+    }
+
+    <span class="keyword">protected</span> Task OnContextItemEditClicked( Item item )
+    {
+        showContextMenu = <span class="keyword">false</span>;
+
+        <span class="keyword">return</span> Task.CompletedTask;
+    }
+
+    <span class="keyword">protected</span> Task OnContextItemDeleteClicked( Item item )
+    {
+        showContextMenu = <span class="keyword">false</span>;
+
+        <span class="keyword">return</span> Task.CompletedTask;
+    }
+}
+</pre></div>
+</div>

--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/TreeView/Examples/TreeViewContextMenuExample.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/TreeView/Examples/TreeViewContextMenuExample.razor
@@ -1,0 +1,101 @@
+﻿@namespace Blazorise.Docs.Docs.Examples
+@using System.Drawing
+
+<TreeView TNode="Item"
+          Nodes="Items"
+          GetChildNodes="@(item => item.Children)"
+          HasChildNodes="@(item => item.Children?.Any() == true)"
+          AutoExpandAll
+          @bind-SelectedNode="selectedNode"
+          @bind-ExpandedNodes="expandedNodes"
+          NodeContextMenu="@OnNodeContextMenu"
+          NodeContextMenuPreventDefault>
+    <NodeContent>
+        <Icon Name="IconName.Folder" />
+        @context.Text
+    </NodeContent>
+</TreeView>
+
+@if ( showContextMenu )
+{
+    <Div Position="Position.Fixed" Background="Background.Danger" Style="@($"left:{contextMenuPosX}px; top:{contextMenuPosY}px;")">
+        <ListGroup>
+            <ListGroupItem>
+                <Strong>Node: @contextMenuNode?.Text</Strong>
+            </ListGroupItem>
+            <ListGroupItem Clicked="@(()=>OnContextItemEditClicked(contextMenuNode))" Style="cursor: pointer;">
+                <Icon Name="IconName.Edit" TextColor="TextColor.Secondary" /> Edit
+            </ListGroupItem>
+            <ListGroupItem Clicked="@(()=>OnContextItemDeleteClicked(contextMenuNode))" Style="cursor: pointer;">
+                <Icon Name="IconName.Delete" TextColor="TextColor.Danger" /> Delete
+            </ListGroupItem>
+        </ListGroup>
+    </Div>
+}
+
+@code {
+    public class Item
+    {
+        public string Text { get; set; }
+        public IEnumerable<Item> Children { get; set; }
+    }
+
+    IEnumerable<Item> Items = new[]
+    {
+        new Item { Text = "Item 1" },
+        new Item
+        {
+            Text = "Item 2",
+            Children = new []
+            {
+                new Item { Text = "Item 2.1" },
+                new Item
+                {
+                    Text = "Item 2.2",
+                    Children = new []
+                    {
+                        new Item { Text = "Item 2.2.1" },
+                        new Item { Text = "Item 2.2.2" },
+                        new Item { Text = "Item 2.2.3" },
+                        new Item { Text = "Item 2.2.4" }
+                    }
+                },
+                new Item { Text = "Item 2.3" },
+                new Item { Text = "Item 2.4" }
+            }
+        },
+        new Item { Text = "Item 3" },
+    };
+
+    IList<Item> expandedNodes = new List<Item>();
+    Item selectedNode;
+
+    bool showContextMenu = false;
+    double contextMenuPosX;
+    double contextMenuPosY;
+    Item contextMenuNode;
+
+    protected Task OnNodeContextMenu( TreeViewNodeMouseEventArgs<Item> eventArgs )
+    {
+        showContextMenu = true;
+        contextMenuNode = eventArgs.Node;
+        contextMenuPosX = eventArgs.MouseEventArgs.ClientX;
+        contextMenuPosY = eventArgs.MouseEventArgs.ClientY;
+
+        return Task.CompletedTask;
+    }
+
+    protected Task OnContextItemEditClicked( Item item )
+    {
+        showContextMenu = false;
+
+        return Task.CompletedTask;
+    }
+
+    protected Task OnContextItemDeleteClicked( Item item )
+    {
+        showContextMenu = false;
+
+        return Task.CompletedTask;
+    }
+}

--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/TreeView/TreeViewPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/TreeView/TreeViewPage.razor
@@ -129,6 +129,33 @@
     <DocsPageSectionSource Code="TreeViewObservableExample" />
 </DocsPageSection>
 
+<DocsPageSection>
+    <DocsPageSectionHeader Title="Node Context Menu">
+        <Paragraph>
+            To integrate the context menu with the <Strong>TreeView</Strong>, you need to:
+        </Paragraph>
+        <OrderedList>
+            <OrderedListItem>
+                <Paragraph>
+                    Use the TreeView <Code>NodeContextMenu</Code> event to get the current node and show the menu.
+                </Paragraph>
+            </OrderedListItem>
+            <OrderedListItem>
+                <Paragraph>
+                    Use the context menu's <Code>MouseEventArgs</Code> parameter to handle the desired operation.
+                </Paragraph>
+            </OrderedListItem>
+        </OrderedList>
+        <Paragraph>
+            In this example, the context menu is used to show the menu items, put an item in edit mode and delete items.
+        </Paragraph>
+    </DocsPageSectionHeader>
+    <DocsPageSectionContent Outlined FullWidth>
+        <TreeViewContextMenuExample />
+    </DocsPageSectionContent>
+    <DocsPageSectionSource Code="TreeViewContextMenuExample" />
+</DocsPageSection>
+
 <DocsPageSubtitle>
     API
 </DocsPageSubtitle>

--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/TreeView/TreeViewPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/TreeView/TreeViewPage.razor
@@ -201,6 +201,12 @@
     <DocsAttributesItem Name="CollapseIconSize" Type="IconSize?" Default="null">
         Defines the size of the treenode collapse icon.
     </DocsAttributesItem>
+    <DocsAttributesItem Name="NodeContextMenu" Type="EventCallback<TreeViewNodeMouseEventArgs<TNode>>">
+        The event is fired when the node is right clicked to show the context menu.
+    </DocsAttributesItem>
+    <DocsAttributesItem Name="NodeContextMenuPreventDefault" Type="bool" Default="false">
+        Used to prevent the default action for a NodeContextMenu event.
+    </DocsAttributesItem>
 </DocsAttributes>
 
 <Heading Size="HeadingSize.Is3">

--- a/Documentation/Blazorise.Docs/Pages/News/2024-02-15-release-notes-150.razor
+++ b/Documentation/Blazorise.Docs/Pages/News/2024-02-15-release-notes-150.razor
@@ -259,4 +259,12 @@
     In this release, we've updated our AntDesign provider. Previously, we were using the older 4.0 version of AntDesign, which didn't do justice to this exceptional framework. Although we aim to upgrade to the latest AntDesign 5.1 version in the upcoming Blazorise milestone, this update addresses several issues identified while developing Blazorise 1.5.
 </Paragraph>
 
+<Heading Size="HeadingSize.Is3">
+    TreeView context menu
+</Heading>
+
+<Paragraph>
+    It is now possible to detect when the user right click on a TreeView node. By using the <Code>NodeContextMenu</Code> event callback you can detect the clicked Node and mouse coordinates tos how your custom context menu.
+</Paragraph>
+
 <NewsPagePostInfo UserName="Mladen Macanović" ImageName="mladen" PostedOn="February 29th, 2024" Read="9 min" />

--- a/Source/Extensions/Blazorise.TreeView/EventArguments/TreeViewNodeMouseEventArgs.cs
+++ b/Source/Extensions/Blazorise.TreeView/EventArguments/TreeViewNodeMouseEventArgs.cs
@@ -1,0 +1,36 @@
+﻿#region Using directives
+using System;
+using Microsoft.AspNetCore.Components.Web;
+#endregion
+
+namespace Blazorise.TreeView;
+
+/// <summary>
+/// Represents the arguments for a mouse event on a node within a TreeView control.
+/// This class provides all necessary information about the event, including the node involved and the specifics of the mouse action.
+/// </summary>
+/// <typeparam name="TNode">The type of the node involved in the mouse event. This allows for strong typing of the node object.</typeparam>
+public class TreeViewNodeMouseEventArgs<TNode> : EventArgs
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TreeViewNodeMouseEventArgs{TNode}"/> class.
+    /// </summary>
+    /// <param name="node">The node that was clicked or otherwise interacted with during the mouse event. This is the specific instance of <typeparamref name="TNode"/> that the event pertains to.</param>
+    /// <param name="mouseEventArgs">The details of the mouse event, including which mouse button was pressed, the number of clicks, and the position of the mouse. This parameter provides access to the underlying <see cref="MouseEventArgs"/> instance associated with the event.</param>
+    public TreeViewNodeMouseEventArgs( TNode node, MouseEventArgs mouseEventArgs )
+    {
+        Node = node;
+        MouseEventArgs = mouseEventArgs;
+    }
+
+    /// <summary>
+    /// Gets the node that is the target of the mouse event.
+    /// This property provides access to the specific node within the TreeView that the event is related to.
+    /// </summary>
+    public TNode Node { get; }
+
+    /// <summary>
+    /// Gets the details of the mouse event, including information about which button was pressed, the state of the mouse buttons, and the position of the mouse cursor at the time of the event.
+    /// </summary>
+    public MouseEventArgs MouseEventArgs { get; }
+}

--- a/Source/Extensions/Blazorise.TreeView/Internal/_TreeViewNode.razor
+++ b/Source/Extensions/Blazorise.TreeView/Internal/_TreeViewNode.razor
@@ -4,7 +4,7 @@
     <div class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
         @foreach ( var nodeState in NodeStates ?? Enumerable.Empty<TreeViewNodeState<TNode>>() )
         {
-            <div @key="@nodeState.Key">
+            <div @key="@nodeState.Key" @oncontextmenu="@((eventArgs)=>OnContextMenuHandler(nodeState, eventArgs))" @oncontextmenu:stopPropagation @oncontextmenu:preventDefault="@ContextMenuPreventDefault">
                 @if ( nodeState.HasChildren )
                 {
                     <span class="b-tree-view-node-icon" @onclick="@(() => ToggleNode(nodeState))">
@@ -48,7 +48,9 @@
                                    ExpandIconStyle="@ExpandIconStyle"
                                    CollapseIconName="@CollapseIconName"
                                    CollapseIconStyle="@CollapseIconStyle"
-                                   SelectionMode="@SelectionMode" />
+                                   SelectionMode="@SelectionMode"
+                                   ContextMenu="@ContextMenu"
+                                   ContextMenuPreventDefault="@ContextMenuPreventDefault" />
                 }
             </div>
         }

--- a/Source/Extensions/Blazorise.TreeView/Internal/_TreeViewNode.razor.cs
+++ b/Source/Extensions/Blazorise.TreeView/Internal/_TreeViewNode.razor.cs
@@ -8,6 +8,7 @@ using Blazorise.Extensions;
 using Blazorise.TreeView.Extensions;
 using Blazorise.Utilities;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 #endregion
 
 namespace Blazorise.TreeView.Internal;
@@ -249,6 +250,17 @@ public partial class _TreeViewNode<TNode> : BaseComponent, IDisposable
         await InvokeAsync( StateHasChanged );
     }
 
+    /// <summary>
+    /// Event handler for <see cref="ContextMenu"/> event callback.
+    /// </summary>
+    /// <param name="nodeState">The node state that is being clicked.</param>
+    /// <param name="eventArgs">Supplies information about an contextmenu event that is being raised.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    protected virtual Task OnContextMenuHandler( TreeViewNodeState<TNode> nodeState, MouseEventArgs eventArgs )
+    {
+        return ContextMenu.InvokeAsync( new TreeViewNodeMouseEventArgs<TNode>( nodeState.Node, eventArgs ) );
+    }
+
     #endregion
 
     #region Properties
@@ -337,6 +349,16 @@ public partial class _TreeViewNode<TNode> : BaseComponent, IDisposable
     /// Gets or sets node styling.
     /// </summary>
     [Parameter] public Action<TNode, NodeStyling> NodeStyling { get; set; }
+
+    /// <summary>
+    /// The event is fired when an element or text selection is right clicked to show the context menu.
+    /// </summary>
+    [Parameter] public EventCallback<TreeViewNodeMouseEventArgs<TNode>> ContextMenu { get; set; }
+
+    /// <summary>
+    /// Used to prevent the default action for an <see cref="ContextMenu"/> event.
+    /// </summary>
+    [Parameter] public bool ContextMenuPreventDefault { get; set; }
 
     /// <summary>
     /// Specifies the content to be rendered inside this <see cref="_TreeViewNode{TNode}"/>.

--- a/Source/Extensions/Blazorise.TreeView/TreeView.razor
+++ b/Source/Extensions/Blazorise.TreeView/TreeView.razor
@@ -48,7 +48,9 @@
                            ExpandIconSize="@ExpandIconSize"
                            CollapseIconName="@CollapseIconName"
                            CollapseIconStyle="@CollapseIconStyle"
-                           CollapseIconSize="@CollapseIconSize">
+                           CollapseIconSize="@CollapseIconSize"
+                           ContextMenu="@NodeContextMenu"
+                           ContextMenuPreventDefault="@NodeContextMenuPreventDefault">
             </_TreeViewNode>
         </div>
     </CascadingValue>

--- a/Source/Extensions/Blazorise.TreeView/TreeView.razor.cs
+++ b/Source/Extensions/Blazorise.TreeView/TreeView.razor.cs
@@ -10,6 +10,7 @@ using Blazorise.TreeView.Extensions;
 using Blazorise.TreeView.Internal;
 using Blazorise.Utilities;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 #endregion
 
 namespace Blazorise.TreeView;
@@ -392,6 +393,16 @@ public partial class TreeView<TNode> : BaseComponent, IDisposable
     /// Gets or sets node styling.
     /// </summary>
     [Parameter] public Action<TNode, NodeStyling> NodeStyling { get; set; }
+
+    /// <summary>
+    /// The event is fired when the node is right clicked to show the context menu.
+    /// </summary>
+    [Parameter] public EventCallback<TreeViewNodeMouseEventArgs<TNode>> NodeContextMenu { get; set; }
+
+    /// <summary>
+    /// Used to prevent the default action for a <see cref="NodeContextMenu"/> event.
+    /// </summary>
+    [Parameter] public bool NodeContextMenuPreventDefault { get; set; }
 
     /// <summary>
     /// Specifies the content to be rendered inside this <see cref="TreeView{TNode}"/>.


### PR DESCRIPTION
Closes #5353

I used the MouseEventArgs instead of BLMouseEventArgs because I think we must abandon BLMouseEventArgs in the long run.