### PR TITLE
Increment dev release version

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
   
 env:
-  BUILD_VERSION: '1.5.0.0'
+  BUILD_VERSION: '1.6.0.0'
 
 jobs:
   build:


### PR DESCRIPTION
Might as well delete the 1.5 dev package versions as they are no longer required.