### PR TITLE
Select: Change MULTIPLE_DELIMITER to |~|

### DIFF
--- a/Source/Blazorise/Components/Select/Select.razor.cs
+++ b/Source/Blazorise/Components/Select/Select.razor.cs
@@ -26,7 +26,7 @@ public partial class Select<TValue> : BaseInputComponent<IReadOnlyList<TValue>>
 
     private readonly List<ISelectItem<TValue>> selectItems = new();
 
-    private const string MULTIPLE_DELIMITER = ",";
+    private const string MULTIPLE_DELIMITER = "|~|";
 
     #endregion
 


### PR DESCRIPTION
Code to reproduce/test : 
```

<SelectList TItem="string"
            TValue="string"
            Data="@(new List<string>{"1,9", "4", "78,4"})"
            Multiple
            TextField='@((item)=>item)'
            ValueField="@((item)=>item)"
            @bind-SelectedValues="@aux"
            Class="form-select" />


<Text>@string.Join( ',', aux )</Text>
@code
{
    IReadOnlyList<string> aux = new List<string>();
}
```