### PR TITLE
DataGrid: Fix Localization of Clear Button

### DIFF
--- a/Source/Extensions/Blazorise.DataGrid/_DataGridMenuFilter.razor
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridMenuFilter.razor
@@ -40,7 +40,7 @@
                 </Column>
                 <Column ColumnSize="ColumnSize.Is12" Flex="Flex.JustifyContent.End.AlignItems.Center" Gap="Gap.Is2">
                     <Button Clicked="@ParentDataGrid.FilterData" Color="Color.Primary">Filter</Button>
-                    <Button Clicked="@(() => ParentDataGrid.ClearFilter(Column.Field))" Color="Color.Light">Clear</Button>
+                    <Button Clicked="@(() => ParentDataGrid.ClearFilter(Column.Field))" Color="Color.Light">@Localizer.Localize( ParentDataGrid.Localizers?.ClearFilterButtonLocalizer, "Clear" )</Button>
                 </Column>
             }
             else


### PR DESCRIPTION
## Description

We noticed that the clear button text is currently hardcoded, even though a custom _ClearFilterButtonLocalizer_ and translations exist.
Now it uses the localizer.

### Questions / Unclear points
The filter button is also not localized, but for this one **no** translations currently exist. Therefore I've not added it yet. Is it possible for you to provide those? 

Additionally I'm not sure whether it is intended that the _less than_, _less than or equal_, _greater than_, _greater than or equal_ methods all refer to the _FilterMethodContainsLocalizer_. Translations already exist for these so I could easily add the new custom localizers if this is a mistake.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] The PR is submitted to the correct branch (`master` for dev, `rel-1.x` for maintenance).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
