### PR TITLE
DataGrid: Fix AggregateRow missing group indentation

### DIFF
--- a/Demos/Blazorise.Demo/Pages/Tests/DataGrid/GroupMultiplePage.razor
+++ b/Demos/Blazorise.Demo/Pages/Tests/DataGrid/GroupMultiplePage.razor
@@ -26,7 +26,7 @@
                             <SelectList Data="@dataGridRef.DisplayGroupedData"
                                         TItem="GroupContext<Employee>" TValue="string"
                                         TextField="x=> x.Key" ValueField="x=> x.Key"
-                            @bind-SelectedValue="_selectedGroupKey"></SelectList>
+                                        @bind-SelectedValue="_selectedGroupKey"></SelectList>
                         </FieldLabel>
                         <FieldBody>
                             <Button Color="Color.Primary" Clicked="@(() => dataGridRef.ExpandGroups(_selectedGroupKey))">Expand Selected Group</Button>
@@ -41,7 +41,7 @@
                             <SelectList Data="@dataGridRef.DisplayGroupedData?.SelectMany(x=> x.NestedGroup)?.GroupBy(x=> x.Key)?.Select(x=> x.First())"
                                         TItem="GroupContext<Employee>" TValue="string"
                                         TextField="x=> x.Key" ValueField="x=> x.Key"
-                            @bind-SelectedValue="_selectedNestedGroupKey"></SelectList>
+                                        @bind-SelectedValue="_selectedNestedGroupKey"></SelectList>
                         </FieldLabel>
                         <FieldBody>
                             <Button Color="Color.Primary" Clicked="@(() => dataGridRef.ExpandGroups(_selectedNestedGroupKey))">Expand Selected Group</Button>
@@ -74,7 +74,7 @@
                         </DataGridColumn>
                         <DataGridDateColumn TItem="Employee" Field="@nameof( Employee.DateOfBirth )" DisplayFormat="{0:dd.MM.yyyy}" Caption="Date Of Birth" Editable />
                         <DataGridNumericColumn TItem="Employee" Field="@nameof( Employee.Childrens )" Caption="Childrens" Editable Filterable="false" />
-                        <DataGridSelectColumn TItem="Employee" Field="@nameof( Employee.Gender )" Caption="Gender" Editable Data="EmployeeData.Genders" ValueField="(x) => ((Gender)x).Code" TextField="(x) => ((Gender)x).Description" />
+                        <DataGridSelectColumn TItem="Employee" Field="@nameof( Employee.Gender )" Caption="Gender" Editable Data="EmployeeData.Genders" ValueField="(x) => ((Gender)x).Code" TextField="(x) => ((Gender)x).Description" Groupable Grouping />
                         <DataGridColumn TItem="Employee" Field="@nameof( Employee.Salary )" Caption="Salary" Editable Width="140px" DisplayFormat="{0:C}" DisplayFormatProvider="@System.Globalization.CultureInfo.GetCultureInfo("fr-FR")" TextAlignment="TextAlignment.End">
                         </DataGridColumn>
                         <DataGridCheckColumn TItem="Employee" Field="@nameof(Employee.IsActive)" Caption="Active" Editable Filterable="false" Groupable Grouping>
@@ -83,6 +83,16 @@
                             </DisplayTemplate>
                         </DataGridCheckColumn>
                     </DataGridColumns>
+                    <DataGridAggregates>
+                        <DataGridAggregate TItem="Employee" Field="@nameof( Employee.Email )" Aggregate="DataGridAggregateType.Count">
+                            <DisplayTemplate>
+                                @($"Total emails: {context.Value}")
+                            </DisplayTemplate>
+                        </DataGridAggregate>
+                        <DataGridAggregate TItem="Employee" Field="@nameof( Employee.Salary )" Aggregate="DataGridAggregateType.Sum" DisplayFormat="{0:C}" DisplayFormatProvider="@System.Globalization.CultureInfo.GetCultureInfo("fr-FR")" />
+                        <DataGridAggregate TItem="Employee" Field="@nameof( Employee.IsActive )" Aggregate="DataGridAggregateType.TrueCount" />
+                        <DataGridAggregate TItem="Employee" Field="@nameof( Employee.Childrens )" Aggregate="DataGridAggregateType.Sum" />
+                    </DataGridAggregates>
                 </DataGrid>
             </CardBody>
         </Card>

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridAggregateRow.razor
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridAggregateRow.razor
@@ -1,7 +1,9 @@
 ﻿@typeparam TItem
 @inherits BaseDataGridComponent
 <TableRow Class="@Class" Style="@Style" Background="@Background" Color="@Color">
-
+    
+    @ParentDataGrid.groupIndentationFragment
+    
     @foreach ( var column in Columns )
     {
         @if ( column.ColumnType == DataGridColumnType.Command )


### PR DESCRIPTION
To test just go to the https://localhost:5001/tests/datagrid/group/multiple page. 
There's grouping + nesting enabled + aggregates.