### PR TITLE
DataGrid: Add AutoGenerateColumns parameter

### DIFF
--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/DataGrid/DataGridApi.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/DataGrid/DataGridApi.razor
@@ -325,6 +325,10 @@
     <DocsAttributesItem Name="ColumnChooserTemplate" Type="RenderFragment<ColumnChooserContext<TItem>>">
         Gets or sets content of column chooser of pager.
     </DocsAttributesItem>
+    <DocsAttributesItem Name="AutoGenerateColumns" Type="bool" Default="true">
+        Gets or sets whether the DataGrid should automatically generate columns.
+        Columns will only be automatically generated if no columns have been provided.
+    </DocsAttributesItem>
 </DocsAttributes>
 
 <DocsAttributes Title="DataGrid Templates">

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -468,9 +468,9 @@ public partial class DataGrid<TItem> : BaseDataGridComponent
     {
         if ( firstRender )
         {
-            if ( Columns.IsNullOrEmpty() || Columns.Where( x => !( x.IsCommandColumn || x.IsMultiSelectColumn ) ).Count() == 0 )
+            if ( AutoGenerateColumns && ( Columns.IsNullOrEmpty() || !Columns.Any( x => !( x.IsCommandColumn || x.IsMultiSelectColumn ) ) ) )
             {
-                AutoGenerateColumns();
+                AutomaticallyGenerateColumns();
             }
 
             IsClientMacintoshOS = await IsUserAgentMacintoshOS();
@@ -497,7 +497,7 @@ public partial class DataGrid<TItem> : BaseDataGridComponent
     /// <summary>
     /// Auto generates columns based on the <typeparamref name="TItem"/> properties.
     /// </summary>
-    private void AutoGenerateColumns()
+    private void AutomaticallyGenerateColumns()
     {
         var properties = ReflectionHelper.GetPublicProperties<TItem>();
         foreach ( var property in properties )
@@ -3639,6 +3639,13 @@ public partial class DataGrid<TItem> : BaseDataGridComponent
     /// Gets or sets whether the column chooser is visible.
     /// </summary>
     [Parameter] public bool ShowColumnChooser { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the DataGrid should automatically generate columns.
+    /// <para>Columns will only be automatically generated if no columns have been provided.</para>
+    /// <para>Defaults to true.</para>
+    /// </summary>
+    [Parameter] public bool AutoGenerateColumns { get; set; } = true;
 
     #endregion
 }


### PR DESCRIPTION
To Test:

User is now able to disable the feature and make his own dynamic implementation at will.
```
<Button Color="Color.Primary" Clicked="AddColumns">Add dynamic columns</Button>

<DataGrid TItem="Book"
          Data="@Books"
          Responsive
          ShowPager
          ShowPageSizes
          AutoGenerateColumns=false>
    <DataGridColumns>
        @if ( Columns != null )
        {
            @foreach ( var column in Columns )
            {
                <DataGridColumn TItem="Book" Field="@column.Key" Caption="@column.Value">

                </DataGridColumn>
            }
        }
    </DataGridColumns>
</DataGrid>


@code {

    public class Book
    {
        public string Name { get; set; }

        public string Author { get; set; }
    }

    List<Book> Books = new();
    Dictionary<string, string> Columns;

    Task AddColumns()
    {
        Columns = new Dictionary<string, string>
        {
            { nameof(Book.Name), "Name" },
            { nameof(Book.Author), "Author" }
        };

        return Task.CompletedTask;
    }

}
```
![image](https://github.com/Megabit/Blazorise/assets/22283161/63e648ae-69f5-4e42-b67d-2ea358495126)
![image](https://github.com/Megabit/Blazorise/assets/22283161/d2729792-e932-47cf-a223-3b698c384d09)


**Still auto generates columns:**
https://localhost:5001/tests/datagrid/auto-generate-columns

![image](https://github.com/Megabit/Blazorise/assets/22283161/2067a501-0fde-4f7d-b915-a1a265872fb8)
