### PR TITLE
Licensing messages based on license state

### DIFF
--- a/Source/Blazorise/Base/BaseComponent.cs
+++ b/Source/Blazorise/Base/BaseComponent.cs
@@ -137,7 +137,7 @@ public abstract class BaseComponent : BaseAfterRenderComponent
         {
             if ( LicenseChecker.ShouldPrint() )
             {
-                await JSUtilitiesModule.Log( "%cThank you for using the free version of the Blazorise component library! We're happy to offer it to you for personal use. If you'd like to remove this message, consider purchasing a commercial license from https://blazorise.com/commercial. We appreciate your support!", "color: #3B82F6; padding: 0;" );
+                await JSUtilitiesModule.Log( $"%c{LicenseChecker.GetPrintMessage()}", "color: #3B82F6; padding: 0;" );
             }
         }
 

--- a/Source/Blazorise/Licensing/BlazoriseLicenseChecker.cs
+++ b/Source/Blazorise/Licensing/BlazoriseLicenseChecker.cs
@@ -16,7 +16,7 @@ public sealed class BlazoriseLicenseChecker
     #region Constructors
 
     /// <summary>
-    ///
+    /// A default <see cref="BlazoriseLicenseChecker"/> constructor.
     /// </summary>
     /// <param name="blazoriseLicenseProvider"></param>
     public BlazoriseLicenseChecker( BlazoriseLicenseProvider blazoriseLicenseProvider )
@@ -45,6 +45,31 @@ public sealed class BlazoriseLicenseChecker
         }
 
         return false;
+    }
+
+    internal string GetPrintMessage()
+    {
+        if (BlazoriseLicenseProvider.PrintResult == BlazoriseLicensePrintResult.Community )
+        {
+            return "Thank you for using the Blazorise component library with a Community License, which is free for individual use. For additional features and commercial use, consider upgrading your license at https://blazorise.com/commercial. We appreciate your support!";
+        }
+
+        if ( BlazoriseLicenseProvider.PrintResult == BlazoriseLicensePrintResult.CommunityExpired )
+        {
+            return "Your Community License for the Blazorise component library has expired. To continue using our library and receive updates, please renew your license at https://blazorise.com/acount. Thank you for your continued interest in Blazorise!";
+        }
+
+        if ( BlazoriseLicenseProvider.PrintResult == BlazoriseLicensePrintResult.LicensedExpired )
+        {
+            return "Your Commercial License for the Blazorise component library has expired. Please renew your license at https://blazorise.com/renew to maintain access to premium features and support. We appreciate your business and look forward to continuing our partnership!";
+        }
+
+        if ( BlazoriseLicenseProvider.PrintResult == BlazoriseLicensePrintResult.InvalidProductToken )
+        {
+            return "We've detected an invalid product token for your Blazorise component library. Please make sure your token is correct or visit https://blazorise.com/support for help. Protecting your software investment is important to us!";
+        }
+
+        return "Thank you for using the free version of the Blazorise component library! We're happy to offer it to you for personal use. If you'd like to remove this message, consider purchasing a commercial license from https://blazorise.com/commercial. We appreciate your support!";
     }
 
     /// <summary>

--- a/Source/Blazorise/Licensing/BlazoriseLicenseChecker.cs
+++ b/Source/Blazorise/Licensing/BlazoriseLicenseChecker.cs
@@ -49,7 +49,7 @@ public sealed class BlazoriseLicenseChecker
 
     internal string GetPrintMessage()
     {
-        if (BlazoriseLicenseProvider.PrintResult == BlazoriseLicensePrintResult.Community )
+        if ( BlazoriseLicenseProvider.PrintResult == BlazoriseLicensePrintResult.Community )
         {
             return "Thank you for using the Blazorise component library with a Community License, which is free for individual use. For additional features and commercial use, consider upgrading your license at https://blazorise.com/commercial. We appreciate your support!";
         }
@@ -61,7 +61,7 @@ public sealed class BlazoriseLicenseChecker
 
         if ( BlazoriseLicenseProvider.PrintResult == BlazoriseLicensePrintResult.LicensedExpired )
         {
-            return "Your Commercial License for the Blazorise component library has expired. Please renew your license at https://blazorise.com/renew to maintain access to premium features and support. We appreciate your business and look forward to continuing our partnership!";
+            return "Your Commercial License for the Blazorise component library has expired. Please renew your license at https://blazorise.com/account to maintain access to premium features and support. We appreciate your business and look forward to continuing our partnership!";
         }
 
         if ( BlazoriseLicenseProvider.PrintResult == BlazoriseLicensePrintResult.InvalidProductToken )

--- a/Source/Blazorise/Licensing/BlazoriseLicensePrintResult.cs
+++ b/Source/Blazorise/Licensing/BlazoriseLicensePrintResult.cs
@@ -1,0 +1,42 @@
+﻿namespace Blazorise.Licensing;
+
+/// <summary>
+/// Defines the result of the license validation for printing purposes
+/// </summary>
+public enum BlazoriseLicensePrintResult
+{
+    /// <summary>
+    /// Has not yet been set.
+    /// </summary>
+    None,
+
+    /// <summary>
+    /// License is issued to the community user.
+    /// </summary>
+    Community,
+
+    /// <summary>
+    /// License is issued to the community user, but has expired.
+    /// </summary>
+    CommunityExpired,
+
+    /// <summary>
+    /// License is issued to the commercial user.
+    /// </summary>
+    Licensed,
+
+    /// <summary>
+    /// License is issued to the commercial user, but has expired.
+    /// </summary>
+    LicensedExpired,
+
+    /// <summary>
+    /// License is in trial mode.
+    /// </summary>
+    Trial,
+
+    /// <summary>
+    /// License was unable to be validated.
+    /// </summary>
+    InvalidProductToken,
+}

--- a/Source/Blazorise/Licensing/BlazoriseLicenseProvider.cs
+++ b/Source/Blazorise/Licensing/BlazoriseLicenseProvider.cs
@@ -3,7 +3,6 @@ using System;
 using System.ComponentModel;
 using System.Reflection;
 using Blazorise.Licensing.Signing;
-using Blazorise.Modules;
 using Microsoft.JSInterop;
 #endregion
 
@@ -138,11 +137,11 @@ public sealed class BlazoriseLicenseProvider
     /// </summary>
     /// <param name="license"></param>
     /// <returns></returns>
-    private static BlazoriseLicensePrintResult ResolveBlazoriseLicensePrintResult(License license )
+    private static BlazoriseLicensePrintResult ResolveBlazoriseLicensePrintResult( License license )
     {
         var licenseResult = ResolveBlazoriseLicenseResult( license );
 
-        if ( licenseResult == BlazoriseLicenseResult.Unlicensed)
+        if ( licenseResult == BlazoriseLicenseResult.Unlicensed )
             return BlazoriseLicensePrintResult.InvalidProductToken;
 
         if ( licenseResult == BlazoriseLicenseResult.Community )

--- a/Source/Blazorise/Licensing/BlazoriseLicenseProvider.cs
+++ b/Source/Blazorise/Licensing/BlazoriseLicenseProvider.cs
@@ -45,7 +45,7 @@ public sealed class BlazoriseLicenseProvider
     #region Constructors
 
     /// <summary>
-    ///
+    /// A default <see cref="BlazoriseLicenseProvider"/> constructor.
     /// </summary>
     /// <param name="options"></param>
     /// <param name="jsRuntime"></param>
@@ -102,6 +102,8 @@ public sealed class BlazoriseLicenseProvider
                 {
                     Result = BlazoriseLicenseResult.Unlicensed;
                 }
+
+                PrintResult = ResolveBlazoriseLicensePrintResult( license );
             }
             else
             {
@@ -117,6 +119,8 @@ public sealed class BlazoriseLicenseProvider
                 {
                     Result = BlazoriseLicenseResult.Unlicensed;
                 }
+
+                PrintResult = ResolveBlazoriseLicensePrintResult( license );
             }
         }
         catch
@@ -127,6 +131,35 @@ public sealed class BlazoriseLicenseProvider
         {
             initialized = true;
         }
+    }
+
+    /// <summary>
+    /// Resolves the print result of the license validation by checking the license type and whether it is expired by checking against the actual internal resolved License Result state.
+    /// </summary>
+    /// <param name="license"></param>
+    /// <returns></returns>
+    private static BlazoriseLicensePrintResult ResolveBlazoriseLicensePrintResult(License license )
+    {
+        var licenseResult = ResolveBlazoriseLicenseResult( license );
+
+        if ( licenseResult == BlazoriseLicenseResult.Unlicensed)
+            return BlazoriseLicensePrintResult.InvalidProductToken;
+
+        if ( licenseResult == BlazoriseLicenseResult.Community )
+        {
+            return Result == BlazoriseLicenseResult.Community ? BlazoriseLicensePrintResult.Community : BlazoriseLicensePrintResult.CommunityExpired;
+        }
+
+        if ( licenseResult == BlazoriseLicenseResult.Licensed )
+        {
+            return Result == BlazoriseLicenseResult.Licensed ? BlazoriseLicensePrintResult.Licensed : BlazoriseLicensePrintResult.LicensedExpired;
+        }
+
+        if ( licenseResult == BlazoriseLicenseResult.Trial )
+            return BlazoriseLicensePrintResult.Trial;
+
+        return BlazoriseLicensePrintResult.None;
+
     }
 
     private static BlazoriseLicenseResult ResolveBlazoriseLicenseResult( License license )
@@ -305,6 +338,11 @@ public sealed class BlazoriseLicenseProvider
     /// Gets the result of the license validation.
     /// </summary>
     internal static BlazoriseLicenseResult Result { get; private set; } = BlazoriseLicenseResult.Initializing;
+
+    /// <summary>
+    /// Gets the print result of the license validation.
+    /// </summary>
+    internal static BlazoriseLicensePrintResult PrintResult { get; private set; } = BlazoriseLicensePrintResult.None;
 
     /// <summary>
     /// Indicates if the current app is running in WebAssembly mode.

--- a/Source/Blazorise/Licensing/BlazoriseLicenseProvider.cs
+++ b/Source/Blazorise/Licensing/BlazoriseLicenseProvider.cs
@@ -158,7 +158,6 @@ public sealed class BlazoriseLicenseProvider
             return BlazoriseLicensePrintResult.Trial;
 
         return BlazoriseLicensePrintResult.None;
-
     }
 
     private static BlazoriseLicenseResult ResolveBlazoriseLicenseResult( License license )

--- a/Source/Blazorise/Licensing/BlazoriseLicenseProvider.cs
+++ b/Source/Blazorise/Licensing/BlazoriseLicenseProvider.cs
@@ -351,13 +351,3 @@ public sealed class BlazoriseLicenseProvider
 
     #endregion
 }
-
-internal static class WebAssemblyRsaExtensions
-{
-    public static IVerifier_LoadAndVerify WithWebAssemblyRsaPublicKey( this IVerifier_WithVerifier signer, IJSRuntime jsRuntime, IVersionProvider versionProvider, string base64EncodedCsbBlobKey )
-    {
-        var rsaVerifier = new WebAssemblyRsaVerifier( jsRuntime, versionProvider, base64EncodedCsbBlobKey );
-        signer.WithVerifier( rsaVerifier );
-        return signer as IVerifier_LoadAndVerify;
-    }
-}

--- a/Source/Blazorise/Licensing/WebAssemblyRsaExtensions.cs
+++ b/Source/Blazorise/Licensing/WebAssemblyRsaExtensions.cs
@@ -1,0 +1,16 @@
+﻿#region Using directives
+using Blazorise.Modules;
+using Microsoft.JSInterop;
+#endregion
+
+namespace Blazorise.Licensing;
+
+internal static class WebAssemblyRsaExtensions
+{
+    public static IVerifier_LoadAndVerify WithWebAssemblyRsaPublicKey( this IVerifier_WithVerifier signer, IJSRuntime jsRuntime, IVersionProvider versionProvider, string base64EncodedCsbBlobKey )
+    {
+        var rsaVerifier = new WebAssemblyRsaVerifier( jsRuntime, versionProvider, base64EncodedCsbBlobKey );
+        signer.WithVerifier( rsaVerifier );
+        return signer as IVerifier_LoadAndVerify;
+    }
+}


### PR DESCRIPTION
I decided to add a separate `BlazoriseLicensePrintResult` so we don't mix logic as much