### PR TITLE
Video: omit X-AxDRM-Message if httpRequestHeaders are undefined

### DIFF
--- a/Source/Extensions/Blazorise.Video/wwwroot/video.js
+++ b/Source/Extensions/Blazorise.Video/wwwroot/video.js
@@ -311,9 +311,9 @@ function applyDashProtectionData(dash, protection) {
             const protectionData = protection.data ? protection.data : {
                 "com.microsoft.playready": {
                     "serverURL": protection.serverUrl,
-                    "httpRequestHeaders": {
+                    "httpRequestHeaders": protection.httpRequestHeaders ? {
                         "X-AxDRM-Message": protection.httpRequestHeaders
-                    }
+                    } : null
                 }
             };
 
@@ -323,9 +323,9 @@ function applyDashProtectionData(dash, protection) {
             const protectionData = protection.data ? protection.data : {
                 "com.widevine.alpha": {
                     "serverURL": protection.serverUrl,
-                    "httpRequestHeaders": {
+                    "httpRequestHeaders": protection.httpRequestHeaders ? {
                         "X-AxDRM-Message": protection.httpRequestHeaders
-                    }
+                    } : null
                 }
             };
 


### PR DESCRIPTION
Closes #5478

Test code:

```
<Video Source="@("https://cdn.bitmovin.com/content/assets/art-of-motion_drm/mpds/11331.mpd")"
       StreamingLibrary="StreamingLibrary.Dash"
       ProtectionType="VideoProtectionType.Widevine"
       ProtectionServerUrl="https://cwip-shaka-proxy.appspot.com/no_auth" />
```