### PR TITLE
Link: automatically add rel tag

### DIFF
--- a/Documentation/Blazorise.Docs/Pages/News/2024-07-15-release-notes-160.razor
+++ b/Documentation/Blazorise.Docs/Pages/News/2024-07-15-release-notes-160.razor
@@ -107,6 +107,14 @@
     Added a new <Code>SetLoading</Code> so you're able to control the loading state of the DataGrid.
 </Paragraph>
 
+<Heading Size="HeadingSize.Is4">
+    Automatic <Code>rel</Code> Attribute for Blazorise Link Component
+</Heading>
+
+<Paragraph>
+    Links with <Code>Target="Target.Blank"</Code> now automatically include <Code>rel="noopener noreferrer"</Code> for enhanced security and privacy. This update prevents new pages from accessing the original page, reducing phishing risks, and ensures referrer information is not sent to the target site, thereby enhancing the security and privacy of external links by default.
+</Paragraph>
+
 <Heading>
     Wrap Up
 </Heading>

--- a/Source/Blazorise.AntDesign/Components/CardLink.razor
+++ b/Source/Blazorise.AntDesign/Components/CardLink.razor
@@ -1,4 +1,4 @@
 ﻿@inherits Blazorise.CardLink
-<a @ref="@ElementRef" id="@ElementId" class="@ClassNames" href="@To" title="@Title" target="@TargetName" style="@StyleNames" @attributes="@Attributes">
+<a @ref="@ElementRef" id="@ElementId" class="@ClassNames" href="@To" rel="@GetRel()" title="@Title" target="@TargetName" style="@StyleNames" @attributes="@Attributes">
     @ChildContent
 </a>

--- a/Source/Blazorise.Tailwind/Components/_BarOnlyLink.razor
+++ b/Source/Blazorise.Tailwind/Components/_BarOnlyLink.razor
@@ -1,6 +1,6 @@
 ﻿@using Blazorise.Utilities;
 @inherits Blazorise.BaseLinkComponent
-<a id="@ElementId" href="@To" class="@ClassNames" style="@StyleNames" title="@Title" target="@TargetName" @onclick="@OnClickHandler" @onclick:preventDefault="@PreventDefault" @attributes="@Attributes">
+<a id="@ElementId" href="@To" rel="@GetRel()" class="@ClassNames" style="@StyleNames" title="@Title" target="@TargetName" @onclick="@OnClickHandler" @onclick:preventDefault="@PreventDefault" @attributes="@Attributes">
     @ChildContent
 </a>
 @code {

--- a/Source/Blazorise/Base/BaseLinkComponent.cs
+++ b/Source/Blazorise/Base/BaseLinkComponent.cs
@@ -215,6 +215,14 @@ public abstract class BaseLinkComponent : BaseComponent, IDisposable
     /// <returns>Href value.</returns>
     protected string GetTo() => Disabled ? null : To;
 
+    /// <summary>
+    /// Gets the rel attribute value.
+    /// </summary>
+    /// <returns>
+    /// Returns "noopener noreferrer" if the <see cref="Target"/> is set to <see cref="Target.Blank"/>.
+    /// </returns>
+    protected string GetRel() => Target == Target.Blank ? "noopener noreferrer" : null;
+
     #endregion
 
     #region Properties

--- a/Source/Blazorise/Components/Bar/BarLink.razor.cs
+++ b/Source/Blazorise/Components/Bar/BarLink.razor.cs
@@ -40,6 +40,14 @@ public partial class BarLink : BaseComponent
         return Clicked.InvokeAsync( eventArgs );
     }
 
+    /// <summary>
+    /// Gets the rel attribute value.
+    /// </summary>
+    /// <returns>
+    /// Returns "noopener noreferrer" if the <see cref="Target"/> is set to <see cref="Target.Blank"/>.
+    /// </returns>
+    protected string GetRel() => Target == Target.Blank ? "noopener noreferrer" : null;
+
     #endregion
 
     #region Properties

--- a/Source/Blazorise/Components/Breadcrumb/BreadcrumbLink.razor.cs
+++ b/Source/Blazorise/Components/Breadcrumb/BreadcrumbLink.razor.cs
@@ -49,6 +49,14 @@ public partial class BreadcrumbLink : BaseComponent
         return Clicked.InvokeAsync( eventArgs );
     }
 
+    /// <summary>
+    /// Gets the rel attribute value.
+    /// </summary>
+    /// <returns>
+    /// Returns "noopener noreferrer" if the <see cref="Target"/> is set to <see cref="Target.Blank"/>.
+    /// </returns>
+    protected string GetRel() => Target == Target.Blank ? "noopener noreferrer" : null;
+
     #endregion
 
     #region Properties

--- a/Source/Blazorise/Components/Card/CardLink.razor
+++ b/Source/Blazorise/Components/Card/CardLink.razor
@@ -1,5 +1,5 @@
 ﻿@namespace Blazorise
 @inherits BaseLinkComponent
-<a @ref="@ElementRef" id="@ElementId" href="@To" class="@ClassNames" style="@StyleNames" title="@Title" target="@TargetName" @onclick="@OnClickHandler" @onclick:preventDefault="@PreventDefault" @attributes="@Attributes">
+<a @ref="@ElementRef" id="@ElementId" href="@To" rel="@GetRel()" class="@ClassNames" style="@StyleNames" title="@Title" target="@TargetName" @onclick="@OnClickHandler" @onclick:preventDefault="@PreventDefault" @attributes="@Attributes">
     @ChildContent
 </a>

--- a/Source/Blazorise/Components/Link/Anchor.razor
+++ b/Source/Blazorise/Components/Link/Anchor.razor
@@ -1,5 +1,5 @@
 ﻿@namespace Blazorise
 @inherits Blazorise.Link
-<a @ref="@ElementRef" id="@ElementId" href="@GetTo()" class="@ClassNames" style="@StyleNames" title="@Title" target="@TargetName" aria-disabled="@AriaDisabledString" @onclick="@OnClickHandler" @onclick:preventDefault="@PreventDefault" @attributes="@Attributes">
+<a @ref="@ElementRef" id="@ElementId" href="@GetTo()" rel="@GetRel()" class="@ClassNames" style="@StyleNames" title="@Title" target="@TargetName" aria-disabled="@AriaDisabledString" @onclick="@OnClickHandler" @onclick:preventDefault="@PreventDefault" @attributes="@Attributes">
     @ChildContent
 </a>

--- a/Source/Blazorise/Components/Link/Link.razor
+++ b/Source/Blazorise/Components/Link/Link.razor
@@ -1,5 +1,5 @@
 ﻿@namespace Blazorise
 @inherits BaseLinkComponent
-<a @ref="@ElementRef" id="@ElementId" href="@GetTo()" class="@ClassNames" style="@StyleNames" title="@Title" target="@TargetName" aria-disabled="@AriaDisabledString" @onclick="@OnClickHandler" @onclick:preventDefault="@PreventDefault" @attributes="@Attributes">
+<a @ref="@ElementRef" id="@ElementId" href="@GetTo()" rel="@GetRel()" class="@ClassNames" style="@StyleNames" title="@Title" target="@TargetName" aria-disabled="@AriaDisabledString" @onclick="@OnClickHandler" @onclick:preventDefault="@PreventDefault" @attributes="@Attributes">
     @ChildContent
 </a>


### PR DESCRIPTION
Closes #5565

ChatGPT explained it better

When setting the Target attribute of a link to _blank in the Blazorise Link component, it is crucial to include the rel attribute to prevent potential security risks and improve SEO. The options provided are:

- rel="nofollow noreferrer"
- rel="noopener noreferrer nofollow"
- rel="noopener noreferrer"

Here's an analysis of each option:

### Option 1: rel="nofollow noreferrer"

- nofollow: Tells search engines not to follow the link, preventing the transfer of SEO value to the linked page.
- noreferrer: Prevents the browser from sending the referrer information to the target site.

### Option 2: rel="noopener noreferrer nofollow"

- noopener: Ensures that the new page runs in a separate process, which prevents the new page from being able to access the window.opener property and potentially gain control over the original page.
- noreferrer: As above, prevents the referrer information from being sent.
- nofollow: As above, prevents search engines from following the link.

### Option 3: rel="noopener noreferrer"

- noopener: As above, prevents the new page from being able to access the window.opener property.
- noreferrer: As above, prevents the referrer information from being sent.

Recommendation

The best option to use in the Blazorise Link component when the Target is set to _blank is:

- rel="noopener noreferrer"

Reasoning:

- Security: Using noopener is crucial for security as it prevents the new page from accessing the original page through the window.opener property, mitigating the risk of malicious activities such as phishing.
- Privacy: noreferrer ensures that no referrer information is sent to the new page, preserving user privacy.
- SEO: Including nofollow in the rel attribute can impact SEO by instructing search engines not to pass on link equity. While this might be desirable in some specific cases, it generally reduces the SEO benefit of linking to other pages. Unless you have a specific need to prevent search engines from following these links, it is typically better to omit nofollow.

By using rel="noopener noreferrer", you ensure a secure and privacy-conscious implementation without unnecessarily impacting SEO. If there is a specific requirement for nofollow, it can be added as needed on a case-by-case basis.