### PR TITLE
BarLink: add missing CustomMatch parameter

### DIFF
--- a/Documentation/Blazorise.Docs/Pages/Docs/Components/Links/LinkPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Components/Links/LinkPage.razor
@@ -122,6 +122,9 @@
         URL matching behavior for a link.
     </DocsAttributesItem>
     <DocsAttributesItem Name="CustomMatch" Type="Func<string, bool>" Default="null">
+        A callback function that is used to compare current uri with the user defined uri. Must enable <Code>Match="Match.Custom"</Code> to be used.
+    </DocsAttributesItem>
+    <DocsAttributesItem Name="CustomMatch" Type="Func<string, bool>" Default="null">
         A callback function that is used to compare current uri with the user defined uri. Must enable <Code>Match.Custom</Code> to be used.
     </DocsAttributesItem>
     <DocsAttributesItem Name="Title" Type="string" Default="null">

--- a/Source/Blazorise.AntDesign/Components/BarLink.razor
+++ b/Source/Blazorise.AntDesign/Components/BarLink.razor
@@ -1,4 +1,4 @@
 ﻿@inherits Blazorise.BarLink
-<Anchor ElementId="@ElementId" Class="@ClassNames" Style="@StyleNames" To="@To" Clicked="@ClickHandler" Target="@Target" Title="@Title" Match="@Match" Attributes="@Attributes">
+<Anchor ElementId="@ElementId" Class="@ClassNames" Style="@StyleNames" To="@To" Clicked="@ClickHandler" Target="@Target" Title="@Title" Match="@Match" CustomMatch="@CustomMatch" Attributes="@Attributes">
     <span>@ChildContent</span>
 </Anchor>

--- a/Source/Blazorise.Tailwind/Components/BarLink.razor
+++ b/Source/Blazorise.Tailwind/Components/BarLink.razor
@@ -1,5 +1,5 @@
 ﻿@inherits Blazorise.BarLink
-<_BarOnlyLink ElementId="@ElementId" Class="@ClassNames" Style="@StyleNames" To="@To" Target="@Target" Title="@Title" Match="@Match" Mode="@ParentBar?.Mode" InsideDropdown="false" Clicked="@ClickHandler" Attributes="@Attributes">
+<_BarOnlyLink ElementId="@ElementId" Class="@ClassNames" Style="@StyleNames" To="@To" Target="@Target" Title="@Title" Match="@Match" CustomMatch="@CustomMatch" Mode="@ParentBar?.Mode" InsideDropdown="false" Clicked="@ClickHandler" Attributes="@Attributes">
     @ChildContent
 </_BarOnlyLink>
 @code {

--- a/Source/Blazorise/Components/Bar/BarLink.razor
+++ b/Source/Blazorise/Components/Bar/BarLink.razor
@@ -1,5 +1,5 @@
 ﻿@namespace Blazorise
 @inherits BaseComponent
-<Anchor ElementId="@ElementId" Class="@ClassNames" Style="@StyleNames" To="@To" Target="@Target" Title="@Title" Match="@Match" Clicked="@ClickHandler" Attributes="@Attributes">
+<Anchor ElementId="@ElementId" Class="@ClassNames" Style="@StyleNames" To="@To" Target="@Target" Title="@Title" Match="@Match" CustomMatch="@CustomMatch" Clicked="@ClickHandler" Attributes="@Attributes">
     @ChildContent
 </Anchor>

--- a/Source/Blazorise/Components/Bar/BarLink.razor.cs
+++ b/Source/Blazorise/Components/Bar/BarLink.razor.cs
@@ -1,4 +1,5 @@
 ﻿#region Using directives
+using System;
 using System.Threading.Tasks;
 using Blazorise.States;
 using Blazorise.Utilities;
@@ -63,6 +64,11 @@ public partial class BarLink : BaseComponent
     /// URL matching behavior for a link.
     /// </summary>
     [Parameter] public Match Match { get; set; } = Match.All;
+
+    /// <summary>
+    /// A callback function that is used to compare current uri with the user defined uri. Must enable <see cref="Match.Custom"/> to be used.
+    /// </summary>
+    [Parameter] public Func<string, bool> CustomMatch { get; set; }
 
     /// <summary>
     /// Specify extra information about the element.

--- a/Source/Extensions/Blazorise.Sidebar/SidebarLink.razor
+++ b/Source/Extensions/Blazorise.Sidebar/SidebarLink.razor
@@ -1,4 +1,4 @@
 ﻿@inherits BaseComponent
-<Anchor Class="@ClassNames" Style="@StyleNames" To="@To" Target="@Target" Title="@Title" Match="@Match" Clicked="@ClickHandler" Attributes="@LinkAttributes">
+<Anchor Class="@ClassNames" Style="@StyleNames" To="@To" Target="@Target" Title="@Title" Match="@Match" CustomMatch="@CustomMatch" Clicked="@ClickHandler" Attributes="@LinkAttributes">
     @ChildContent
 </Anchor>

--- a/Source/Extensions/Blazorise.Sidebar/SidebarLink.razor.cs
+++ b/Source/Extensions/Blazorise.Sidebar/SidebarLink.razor.cs
@@ -1,4 +1,5 @@
 ﻿#region Using directives
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -104,6 +105,11 @@ public partial class SidebarLink : BaseComponent
     /// URL matching behavior for a link.
     /// </summary>
     [Parameter] public Match Match { get; set; } = Match.All;
+
+    /// <summary>
+    /// A callback function that is used to compare current uri with the user defined uri. Must enable <see cref="Match.Custom"/> to be used.
+    /// </summary>
+    [Parameter] public Func<string, bool> CustomMatch { get; set; }
 
     /// <summary>
     /// Specify extra information about the element.


### PR DESCRIPTION
Closes #5567

I also added the same on SidebarLink.