### PR TITLE
Fixed typo in ButtonPage.razor

### DIFF
--- a/Documentation/Blazorise.Docs/Pages/Docs/Components/Buttons/ButtonPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Components/Buttons/ButtonPage.razor
@@ -133,7 +133,7 @@
 
 <DocsPageSection>
     <DocsPageSectionHeader Title="Button group">
-        If you want to group buttons together on a single line, use the <Code Tag>Buttons</Code> xomponent.
+        If you want to group buttons together on a single line, use the <Code Tag>Buttons</Code> component.
     </DocsPageSectionHeader>
     <DocsPageSectionContent Outlined>
         <ButtonGroupExample />


### PR DESCRIPTION
## Description

Closes #5590
small typo on the docs page about the buttons