### PR TITLE
Calculate input name attribute in SSR mode

### DIFF
--- a/Build/Blazorise.Client.props
+++ b/Build/Blazorise.Client.props
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>net8.0</TargetFramework>
 		<OutputType>Exe</OutputType>
-		<LangVersion>10.0</LangVersion>
+		<LangVersion>11.0</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Build/Blazorise.Demo.props
+++ b/Build/Blazorise.Demo.props
@@ -4,7 +4,7 @@
 		<TargetFramework>net8.0</TargetFramework>
 		<OutputType>Library</OutputType>
 		<IsPackable>true</IsPackable>
-		<LangVersion>10.0</LangVersion>
+		<LangVersion>11.0</LangVersion>
     	<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 	</PropertyGroup>
 

--- a/Build/Blazorise.Docs.props
+++ b/Build/Blazorise.Docs.props
@@ -4,7 +4,7 @@
 		<TargetFramework>net8.0</TargetFramework>
 		<OutputType>Library</OutputType>
 		<IsPackable>true</IsPackable>
-		<LangVersion>10.0</LangVersion>
+		<LangVersion>11.0</LangVersion>
     	<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 	</PropertyGroup>
 

--- a/Build/Blazorise.Server.RC.props
+++ b/Build/Blazorise.Server.RC.props
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFramework>net8.0</TargetFramework>
-		<LangVersion>10.0</LangVersion>
+		<LangVersion>11.0</LangVersion>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 	</PropertyGroup>
 

--- a/Build/Blazorise.Server.props
+++ b/Build/Blazorise.Server.props
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFramework>net8.0</TargetFramework>
-		<LangVersion>10.0</LangVersion>
+		<LangVersion>11.0</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Build/Blazorise.props
+++ b/Build/Blazorise.props
@@ -17,7 +17,7 @@
     <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <OutputType>Library</OutputType>
     <IsPackable>true</IsPackable>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>11.0</LangVersion>
 
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>

--- a/Documentation/Blazorise.Docs/Pages/Home/Components/CaptchaInput.razor.cs
+++ b/Documentation/Blazorise.Docs/Pages/Home/Components/CaptchaInput.razor.cs
@@ -1,18 +1,15 @@
 ﻿#region Using directives
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.Tracing;
 using System.Linq.Expressions;
 using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Blazorise.Captcha;
-using Blazorise.Docs.Domain;
 using Blazorise.Extensions;
 using Blazorise.Utilities;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Options;
-using Newtonsoft.Json.Linq;
 #endregion
 
 namespace Blazorise.Docs.Pages.Home.Components;
@@ -126,6 +123,17 @@ public partial class CaptchaInput : BaseInputComponent<bool>
             eventArgs.ErrorText = null;
     }
 
+    /// <inheritdoc/>
+    protected override string GetFormatedValueExpression()
+    {
+        if ( ValueExpression is null )
+            return null;
+
+        return HtmlFieldPrefix is not null
+            ? HtmlFieldPrefix.GetFieldName( ValueExpression )
+            : ExpressionFormatter.FormatLambda( ValueExpression );
+    }
+
     #endregion
 
     #region Properties
@@ -145,6 +153,4 @@ public partial class CaptchaInput : BaseInputComponent<bool>
     [Parameter] public Expression<Func<bool>> ValueExpression { get; set; }
 
     #endregion
-
-
 }

--- a/Documentation/Blazorise.Docs/Pages/News/2024-07-15-release-notes-160.razor
+++ b/Documentation/Blazorise.Docs/Pages/News/2024-07-15-release-notes-160.razor
@@ -155,6 +155,14 @@
     As an ongoing process to improve security of Blazorise dependencies, we have updated autoNumeric.js library to use the latest version.
 </Paragraph>
 
+<Heading Size="HeadingSize.Is4">
+    Better form support in SSR mode
+</Heading>
+
+<Paragraph>
+    In this release we have made some changes to enable beter support our input components like TextEdit, NumericEdit, etc. to work with server-side rendering. It works by automatically calculating the <Code>name</Code> attribute of form field which then helps it to properly POST the form.
+</Paragraph>
+
 <Heading>
     Wrap Up
 </Heading>

--- a/Source/Blazorise.AntDesign/Components/Select.razor
+++ b/Source/Blazorise.AntDesign/Components/Select.razor
@@ -29,7 +29,7 @@
             else
             {
                 <span class="ant-select-selection-search">
-                    <input @ref="@ElementRef" id="@InputElementId" class="ant-select-selection-search-input" role="combobox" tabindex="@TabIndex" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" readonly="true" multiple="@Multiple" aria-haspopup="listbox" aria-owns="@SelectListId" aria-controls="@SelectListId" aria-expanded="@InputAriaExpanded" autocomplete="off" aria-autocomplete="list" unselectable="on">
+                    <input @ref="@ElementRef" id="@InputElementId" name="@NameAttributeValue" class="ant-select-selection-search-input" role="combobox" tabindex="@TabIndex" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" readonly="true" multiple="@Multiple" aria-haspopup="listbox" aria-owns="@SelectListId" aria-controls="@SelectListId" aria-expanded="@InputAriaExpanded" autocomplete="off" aria-autocomplete="list" unselectable="on">
                 </span>
                 <span class="ant-select-selection-item">
                     @SelectedItem

--- a/Source/Blazorise.AntDesign/Components/Switch.razor
+++ b/Source/Blazorise.AntDesign/Components/Switch.razor
@@ -1,6 +1,6 @@
 ﻿@typeparam TValue
 @inherits Blazorise.Switch<TValue>
-<button @ref="@ElementRef" id="@ElementId" type="button" role="switch" class="@ClassNames" style="@StyleNames" disabled="@Disabled" aria-checked="@CurrentValueAsString?.ToLowerInvariant()" ant-click-animating="true" tabindex="@TabIndex" @onclick="@HandleButtonClick" @attributes="@Attributes">
+<button @ref="@ElementRef" id="@ElementId" type="button" name="@NameAttributeValue" role="switch" class="@ClassNames" style="@StyleNames" disabled="@Disabled" aria-checked="@CurrentValueAsString?.ToLowerInvariant()" ant-click-animating="true" tabindex="@TabIndex" @onclick="@HandleButtonClick" @attributes="@Attributes">
     <div class="ant-switch-handle"></div>
     <span class="ant-switch-inner">@ChildContent</span>
     <div class="ant-click-animating-node"></div>

--- a/Source/Blazorise.AntDesign/Components/TextEdit.razor
+++ b/Source/Blazorise.AntDesign/Components/TextEdit.razor
@@ -11,11 +11,11 @@ else
 {
     @if ( IsImmediate && IsDebounce )
     {
-        <input @ref="@ElementRef" id="@ElementId" type="@Type" inputmode="@Mode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" maxlength="@MaxLength" size="@VisibleCharacters" pattern="@Pattern" value="@CurrentValue" tabindex="@TabIndex" @onchange="@OnChangeHandler" @oninput="@OnInputHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+        <input @ref="@ElementRef" id="@ElementId" type="@Type" name="@NameAttributeValue" inputmode="@Mode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" maxlength="@MaxLength" size="@VisibleCharacters" pattern="@Pattern" value="@CurrentValue" tabindex="@TabIndex" @onchange="@OnChangeHandler" @oninput="@OnInputHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
     }
     else
     {
-        <input @ref="@ElementRef" id="@ElementId" type="@Type" inputmode="@Mode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" maxlength="@MaxLength" size="@VisibleCharacters" pattern="@Pattern" tabindex="@TabIndex" @bind-value="CurrentValueAsString" @bind-value:event="@BindValueEventName" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+        <input @ref="@ElementRef" id="@ElementId" type="@Type" name="@NameAttributeValue" inputmode="@Mode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" maxlength="@MaxLength" size="@VisibleCharacters" pattern="@Pattern" tabindex="@TabIndex" @bind-value="CurrentValueAsString" @bind-value:event="@BindValueEventName" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
     }
     @ChildContent
     @Feedback

--- a/Source/Blazorise.Bootstrap/Components/NumericPicker.razor
+++ b/Source/Blazorise.Bootstrap/Components/NumericPicker.razor
@@ -24,6 +24,6 @@ else
 {
     protected RenderFragment InputTemplate => __builder =>
     {
-        <input @ref="@ElementRef" id="@ElementId" inputmode="@InputMode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" size="@VisibleCharacters" step="@StepString" pattern="@Pattern" tabindex="@TabIndex" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+        <input @ref="@ElementRef" id="@ElementId" name="@NameAttributeValue" inputmode="@InputMode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" size="@VisibleCharacters" step="@StepString" pattern="@Pattern" tabindex="@TabIndex" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
     };
 }

--- a/Source/Blazorise.Bootstrap/Components/Switch.razor
+++ b/Source/Blazorise.Bootstrap/Components/Switch.razor
@@ -1,7 +1,7 @@
 ﻿@typeparam TValue
 @inherits Blazorise.Switch<TValue>
 <Control Role="@ControlRole.Switch" Inline="@Inline">
-    <input @ref="@ElementRef" id="@ElementId" type="checkbox" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" checked="@Checked" tabindex="@TabIndex" @onclick:preventDefault="@ReadOnly" @onchange="@OnChangeHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+    <input @ref="@ElementRef" id="@ElementId" type="checkbox" name="@NameAttributeValue" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" checked="@Checked" tabindex="@TabIndex" @onclick:preventDefault="@ReadOnly" @onchange="@OnChangeHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
     <Label Type="LabelType.Switch" For="@ElementId" Style="@Style" Cursor="@Cursor">@ChildContent</Label>
     @Feedback
 </Control>

--- a/Source/Blazorise.Bootstrap5/Components/NumericPicker.razor
+++ b/Source/Blazorise.Bootstrap5/Components/NumericPicker.razor
@@ -24,6 +24,6 @@ else
 {
     protected RenderFragment InputTemplate => __builder =>
     {
-        <input @ref="@ElementRef" id="@ElementId" inputmode="@InputMode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" size="@VisibleCharacters" step="@StepString" pattern="@Pattern" tabindex="@TabIndex" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+        <input @ref="@ElementRef" id="@ElementId" name="@NameAttributeValue" inputmode="@InputMode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" size="@VisibleCharacters" step="@StepString" pattern="@Pattern" tabindex="@TabIndex" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
     };
 }

--- a/Source/Blazorise.Bootstrap5/Components/Switch.razor
+++ b/Source/Blazorise.Bootstrap5/Components/Switch.razor
@@ -1,7 +1,7 @@
 ﻿@typeparam TValue
 @inherits Blazorise.Switch<TValue>
 <Control Role="@ControlRole.Switch" Inline="@Inline">
-    <input @ref="@ElementRef" id="@ElementId" type="checkbox" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" checked="@Checked" tabindex="@TabIndex" @onclick:preventDefault="@ReadOnly" @onchange="@OnChangeHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+    <input @ref="@ElementRef" id="@ElementId" type="checkbox" name="@NameAttributeValue" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" checked="@Checked" tabindex="@TabIndex" @onclick:preventDefault="@ReadOnly" @onchange="@OnChangeHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
     <Label Type="LabelType.Switch" For="@ElementId" Style="@Style" Cursor="@Cursor">@ChildContent</Label>
     @Feedback
 </Control>

--- a/Source/Blazorise.Bulma/Components/DateEdit.razor
+++ b/Source/Blazorise.Bulma/Components/DateEdit.razor
@@ -14,7 +14,7 @@ else
     private RenderFragment InputElement => __builder =>
     {
         <div class="control">
-            <input @ref="@ElementRef" id="@ElementId" type="@Mode" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" pattern="@Pattern" value="@CurrentValueAsString" tabindex="@TabIndex" @onchange="@OnChangeHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" placeholder="@Placeholder" min="@Min?.ToString(DateFormat)" max="@Max?.ToString(DateFormat)" step="@Step" @attributes="@Attributes" />
+            <input @ref="@ElementRef" id="@ElementId" type="@Mode" name="@NameAttributeValue" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" pattern="@Pattern" value="@CurrentValueAsString" tabindex="@TabIndex" @onchange="@OnChangeHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" placeholder="@Placeholder" min="@Min?.ToString(DateFormat)" max="@Max?.ToString(DateFormat)" step="@Step" @attributes="@Attributes" />
             @ChildContent
         </div>
         @Feedback

--- a/Source/Blazorise.Bulma/Components/MemoEdit.razor
+++ b/Source/Blazorise.Bulma/Components/MemoEdit.razor
@@ -5,11 +5,11 @@
         <div class="control">
             @if ( IsImmediate && IsDebounce )
             {
-                <textarea @ref="@ElementRef" id="@ElementId" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" data-pattern="@Pattern" maxlength="@MaxLength" rows="@Rows" tabindex="@TabIndex" value="@CurrentValue" @onchange="@OnChangeHandler" @oninput="@OnInputHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+                <textarea @ref="@ElementRef" id="@ElementId" name="@NameAttributeValue" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" data-pattern="@Pattern" maxlength="@MaxLength" rows="@Rows" tabindex="@TabIndex" value="@CurrentValue" @onchange="@OnChangeHandler" @oninput="@OnInputHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
             }
             else
             {
-                <textarea @ref="@ElementRef" id="@ElementId" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" data-pattern="@Pattern" maxlength="@MaxLength" rows="@Rows" tabindex="@TabIndex" @bind-value="CurrentValueAsString" @bind-value:event="@BindValueEventName" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+                <textarea @ref="@ElementRef" id="@ElementId" name="@NameAttributeValue" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" data-pattern="@Pattern" maxlength="@MaxLength" rows="@Rows" tabindex="@TabIndex" @bind-value="CurrentValueAsString" @bind-value:event="@BindValueEventName" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
             }
             @ChildContent
         </div>
@@ -21,11 +21,11 @@ else
     <div class="control">
         @if ( IsImmediate && IsDebounce )
         {
-            <textarea @ref="@ElementRef" id="@ElementId" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" data-pattern="@Pattern" maxlength="@MaxLength" rows="@Rows" tabindex="@TabIndex" value="@CurrentValue" @onchange="@OnChangeHandler" @oninput="@OnInputHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+            <textarea @ref="@ElementRef" id="@ElementId" name="@NameAttributeValue" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" data-pattern="@Pattern" maxlength="@MaxLength" rows="@Rows" tabindex="@TabIndex" value="@CurrentValue" @onchange="@OnChangeHandler" @oninput="@OnInputHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
         }
         else
         {
-            <textarea @ref="@ElementRef" id="@ElementId" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" data-pattern="@Pattern" maxlength="@MaxLength" rows="@Rows" tabindex="@TabIndex" @bind-value="CurrentValueAsString" @bind-value:event="@BindValueEventName" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+            <textarea @ref="@ElementRef" id="@ElementId" name="@NameAttributeValue" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" data-pattern="@Pattern" maxlength="@MaxLength" rows="@Rows" tabindex="@TabIndex" @bind-value="CurrentValueAsString" @bind-value:event="@BindValueEventName" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
         }
         @ChildContent
     </div>

--- a/Source/Blazorise.Bulma/Components/NumericEdit.razor
+++ b/Source/Blazorise.Bulma/Components/NumericEdit.razor
@@ -6,11 +6,11 @@
         <div class="control">
             @if ( IsImmediate && IsDebounce )
             {
-                <input @ref="@ElementRef" id="@ElementId" type="number" inputmode="@InputMode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" size="@VisibleCharacters" step="@StepString" pattern="@Pattern" tabindex="@TabIndex" value="@CurrentValueAsString" @oninput="@OnInputHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+                <input @ref="@ElementRef" id="@ElementId" type="number" name="@NameAttributeValue" inputmode="@InputMode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" size="@VisibleCharacters" step="@StepString" pattern="@Pattern" tabindex="@TabIndex" value="@CurrentValueAsString" @oninput="@OnInputHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
             }
             else
             {
-                <input @ref="@ElementRef" id="@ElementId" type="number" inputmode="@InputMode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" size="@VisibleCharacters" step="@StepString" pattern="@Pattern" tabindex="@TabIndex" @bind-value="@CurrentValueAsString" @bind-value:event="@BindValueEventName" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+                <input @ref="@ElementRef" id="@ElementId" type="number" name="@NameAttributeValue" inputmode="@InputMode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" size="@VisibleCharacters" step="@StepString" pattern="@Pattern" tabindex="@TabIndex" @bind-value="@CurrentValueAsString" @bind-value:event="@BindValueEventName" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
             }
             @ChildContent
         </div>
@@ -22,11 +22,11 @@ else
     <div class="control">
         @if ( IsImmediate && IsDebounce )
         {
-            <input @ref="@ElementRef" id="@ElementId" type="number" inputmode="@InputMode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" size="@VisibleCharacters" step="@StepString" pattern="@Pattern" tabindex="@TabIndex" value="@CurrentValueAsString" @oninput="@OnInputHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+            <input @ref="@ElementRef" id="@ElementId" type="number" name="@NameAttributeValue" inputmode="@InputMode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" size="@VisibleCharacters" step="@StepString" pattern="@Pattern" tabindex="@TabIndex" value="@CurrentValueAsString" @oninput="@OnInputHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
         }
         else
         {
-            <input @ref="@ElementRef" id="@ElementId" type="number" inputmode="@InputMode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" size="@VisibleCharacters" step="@StepString" pattern="@Pattern" tabindex="@TabIndex" @bind-value="@CurrentValueAsString" @bind-value:event="@BindValueEventName" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+            <input @ref="@ElementRef" id="@ElementId" type="number" name="@NameAttributeValue" inputmode="@InputMode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" size="@VisibleCharacters" step="@StepString" pattern="@Pattern" tabindex="@TabIndex" @bind-value="@CurrentValueAsString" @bind-value:event="@BindValueEventName" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
         }
         @ChildContent
     </div>

--- a/Source/Blazorise.Bulma/Components/NumericPicker.razor
+++ b/Source/Blazorise.Bulma/Components/NumericPicker.razor
@@ -22,6 +22,6 @@ else
 {
     protected RenderFragment InputTemplate => __builder =>
     {
-        <input @ref="@ElementRef" id="@ElementId" inputmode="@InputMode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" size="@VisibleCharacters" step="@StepString" pattern="@Pattern" tabindex="@TabIndex" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+        <input @ref="@ElementRef" id="@ElementId" name="@NameAttributeValue" inputmode="@InputMode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" size="@VisibleCharacters" step="@StepString" pattern="@Pattern" tabindex="@TabIndex" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
     };
 }

--- a/Source/Blazorise.Bulma/Components/Select.razor
+++ b/Source/Blazorise.Bulma/Components/Select.razor
@@ -6,7 +6,7 @@
         <div class="field">
             <div class="control">
                 <div class="@ClassNames" style="@StyleNames">
-                    <select @ref="@ElementRef" id="@ElementId" disabled="@Disabled" readonly="@ReadOnly" multiple="@Multiple" size="@MaxVisibleItems" tabindex="@TabIndex" value="@CurrentValueAsString" @onchange="@OnChangeHandler" @attributes="@Attributes">
+                    <select @ref="@ElementRef" id="@ElementId" name="@NameAttributeValue" disabled="@Disabled" readonly="@ReadOnly" multiple="@Multiple" size="@MaxVisibleItems" tabindex="@TabIndex" value="@CurrentValueAsString" @onchange="@OnChangeHandler" @attributes="@Attributes">
                         @ChildContent
                     </select>
                 </div>
@@ -18,7 +18,7 @@
     {
         <div class="control">
             <div class="@ClassNames" style="@StyleNames">
-                <select @ref="@ElementRef" id="@ElementId" disabled="@Disabled" readonly="@ReadOnly" multiple="@Multiple" size="@MaxVisibleItems" tabindex="@TabIndex" value="@CurrentValueAsString" @onchange="@OnChangeHandler" @attributes="@Attributes">
+                <select @ref="@ElementRef" id="@ElementId" name="@NameAttributeValue" disabled="@Disabled" readonly="@ReadOnly" multiple="@Multiple" size="@MaxVisibleItems" tabindex="@TabIndex" value="@CurrentValueAsString" @onchange="@OnChangeHandler" @attributes="@Attributes">
                     @ChildContent
                 </select>
             </div>

--- a/Source/Blazorise.Bulma/Components/Switch.razor
+++ b/Source/Blazorise.Bulma/Components/Switch.razor
@@ -3,7 +3,7 @@
 @if ( ParentIsFieldBody )
 {
     <div class="field">
-        <input @ref="@ElementRef" id="@ElementId" type="checkbox" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" checked="@CurrentValue" tabindex="@TabIndex" @onclick:preventDefault="@ReadOnly" @onchange="@OnChangeHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+        <input @ref="@ElementRef" id="@ElementId" type="checkbox" name="@NameAttributeValue" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" checked="@CurrentValue" tabindex="@TabIndex" @onclick:preventDefault="@ReadOnly" @onchange="@OnChangeHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
         <Label Type="LabelType.Switch" For="@ElementId" Style="@Style" Cursor="@Cursor">
             @ChildContent
         </Label>
@@ -12,7 +12,7 @@
 }
 else
 {
-    <input @ref="@ElementRef" id="@ElementId" type="checkbox" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" checked="@CurrentValue" tabindex="@TabIndex" @onclick:preventDefault="@ReadOnly" @onchange="@OnChangeHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+    <input @ref="@ElementRef" id="@ElementId" type="checkbox" name="@NameAttributeValue" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" checked="@CurrentValue" tabindex="@TabIndex" @onclick:preventDefault="@ReadOnly" @onchange="@OnChangeHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
     <Label Type="LabelType.Switch" For="@ElementId" Style="@Style" Cursor="@Cursor">
         @ChildContent
     </Label>

--- a/Source/Blazorise.Bulma/Components/TextEdit.razor
+++ b/Source/Blazorise.Bulma/Components/TextEdit.razor
@@ -5,11 +5,11 @@
         <div class="control">
             @if ( IsImmediate && IsDebounce )
             {
-                <input @ref="@ElementRef" id="@ElementId" type="@Type" inputmode="@Mode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" maxlength="@MaxLength" size="@VisibleCharacters" pattern="@Pattern" tabindex="@TabIndex" value="@Text" @onchange="@OnChangeHandler" @oninput="@OnInputHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+                <input @ref="@ElementRef" id="@ElementId" type="@Type" name="@NameAttributeValue" inputmode="@Mode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" maxlength="@MaxLength" size="@VisibleCharacters" pattern="@Pattern" tabindex="@TabIndex" value="@Text" @onchange="@OnChangeHandler" @oninput="@OnInputHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
             }
             else
             {
-                <input @ref="@ElementRef" id="@ElementId" type="@Type" inputmode="@Mode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" maxlength="@MaxLength" size="@VisibleCharacters" pattern="@Pattern" tabindex="@TabIndex" @bind-value="CurrentValueAsString" @bind-value:event="@BindValueEventName" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+                <input @ref="@ElementRef" id="@ElementId" type="@Type" name="@NameAttributeValue" inputmode="@Mode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" maxlength="@MaxLength" size="@VisibleCharacters" pattern="@Pattern" tabindex="@TabIndex" @bind-value="CurrentValueAsString" @bind-value:event="@BindValueEventName" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
             }
             @ChildContent
         </div>
@@ -21,11 +21,11 @@ else
     <div class="control">
         @if ( IsImmediate && IsDebounce )
         {
-            <input @ref="@ElementRef" id="@ElementId" type="@Type" inputmode="@Mode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" maxlength="@MaxLength" size="@VisibleCharacters" pattern="@Pattern" tabindex="@TabIndex" value="@Text" @onchange="@OnChangeHandler" @oninput="@OnInputHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+            <input @ref="@ElementRef" id="@ElementId" type="@Type" name="@NameAttributeValue" inputmode="@Mode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" maxlength="@MaxLength" size="@VisibleCharacters" pattern="@Pattern" tabindex="@TabIndex" value="@Text" @onchange="@OnChangeHandler" @oninput="@OnInputHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
         }
         else
         {
-            <input @ref="@ElementRef" id="@ElementId" type="@Type" inputmode="@Mode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" maxlength="@MaxLength" size="@VisibleCharacters" pattern="@Pattern" tabindex="@TabIndex" @bind-value="CurrentValueAsString" @bind-value:event="@BindValueEventName" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+            <input @ref="@ElementRef" id="@ElementId" type="@Type" name="@NameAttributeValue" inputmode="@Mode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" maxlength="@MaxLength" size="@VisibleCharacters" pattern="@Pattern" tabindex="@TabIndex" @bind-value="CurrentValueAsString" @bind-value:event="@BindValueEventName" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
         }
         @ChildContent
     </div>

--- a/Source/Blazorise.Bulma/Components/TimeEdit.razor
+++ b/Source/Blazorise.Bulma/Components/TimeEdit.razor
@@ -14,7 +14,7 @@ else
     private RenderFragment InputElement => __builder =>
     {
         <div class="control">
-            <input @ref="@ElementRef" id="@ElementId" type="time" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" pattern="@Pattern" step="@Step" value="@CurrentValueAsString" tabindex="@TabIndex" @onchange="@OnChangeHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" placeholder="@Placeholder" @attributes="@Attributes" />
+            <input @ref="@ElementRef" id="@ElementId" type="time" name="@NameAttributeValue" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" pattern="@Pattern" step="@Step" value="@CurrentValueAsString" tabindex="@TabIndex" @onchange="@OnChangeHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" placeholder="@Placeholder" @attributes="@Attributes" />
             @ChildContent
         </div>
         @Feedback

--- a/Source/Blazorise.FluentUI2/Components/ColorEdit.razor
+++ b/Source/Blazorise.FluentUI2/Components/ColorEdit.razor
@@ -17,6 +17,6 @@ else
 @code {
     private RenderFragment InputElement => __builder =>
     {
-        <input @ref="@ElementRef" id="@ElementId" type="color" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" value="@CurrentValueAsString" tabindex="@TabIndex" @onchange="@OnChangeHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+        <input @ref="@ElementRef" id="@ElementId" type="color" name="@NameAttributeValue" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" value="@CurrentValueAsString" tabindex="@TabIndex" @onchange="@OnChangeHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
     };
 }

--- a/Source/Blazorise.FluentUI2/Components/ColorPicker.razor
+++ b/Source/Blazorise.FluentUI2/Components/ColorPicker.razor
@@ -17,7 +17,7 @@ else
 @code {
     private RenderFragment InputElement => __builder =>
     {
-        <span @ref="@ElementRef" id="@ElementId" class="@ClassNames" style="@StyleNames" value="@CurrentValueAsString" tabindex="@TabIndex" aria-disabled="@Disabled.ToString().ToLowerInvariant()" @onchange="@OnChangeHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes">
+        <span @ref="@ElementRef" id="@ElementId" name="@NameAttributeValue" class="@ClassNames" style="@StyleNames" value="@CurrentValueAsString" tabindex="@TabIndex" aria-disabled="@Disabled.ToString().ToLowerInvariant()" @onchange="@OnChangeHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes">
             <span class="@ColorPreviewClassNames"></span>
             <span class="@ColorValueClassNames"></span>
         </span>

--- a/Source/Blazorise.FluentUI2/Components/DateEdit.razor
+++ b/Source/Blazorise.FluentUI2/Components/DateEdit.razor
@@ -18,6 +18,6 @@ else
 @code {
     private RenderFragment InputElement => __builder =>
     {
-        <input @ref="@ElementRef" id="@ElementId" type="@Mode" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" pattern="@Pattern" step="@Step" value="@CurrentValueAsString" @onchange="@OnChangeHandler" placeholder="@Placeholder" min="@Min?.ToString(DateFormat)" max="@Max?.ToString(DateFormat)" tabindex="@TabIndex" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+        <input @ref="@ElementRef" id="@ElementId" type="@Mode" name="@NameAttributeValue" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" pattern="@Pattern" step="@Step" value="@CurrentValueAsString" @onchange="@OnChangeHandler" placeholder="@Placeholder" min="@Min?.ToString(DateFormat)" max="@Max?.ToString(DateFormat)" tabindex="@TabIndex" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
     };
 }

--- a/Source/Blazorise.FluentUI2/Components/DatePicker.razor
+++ b/Source/Blazorise.FluentUI2/Components/DatePicker.razor
@@ -18,6 +18,6 @@ else
 @code {
     private RenderFragment InputElement => __builder =>
     {
-        <input @ref="@ElementRef" id="@ElementId" type="text" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" pattern="@Pattern" value="@CurrentValueAsString" @onchange="@OnChangeHandler" @onclick="@OnClickHandler" placeholder="@Placeholder" min="@Min?.ToString(Utilities.Parsers.InternalDateFormat)" max="@Max?.ToString(Utilities.Parsers.InternalDateFormat)" tabindex="@TabIndex" @attributes="@Attributes" />
+        <input @ref="@ElementRef" id="@ElementId" type="text" name="@NameAttributeValue" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" pattern="@Pattern" value="@CurrentValueAsString" @onchange="@OnChangeHandler" @onclick="@OnClickHandler" placeholder="@Placeholder" min="@Min?.ToString(Utilities.Parsers.InternalDateFormat)" max="@Max?.ToString(Utilities.Parsers.InternalDateFormat)" tabindex="@TabIndex" @attributes="@Attributes" />
     };
 }

--- a/Source/Blazorise.FluentUI2/Components/MemoEdit.razor
+++ b/Source/Blazorise.FluentUI2/Components/MemoEdit.razor
@@ -19,11 +19,11 @@ else
     {
         @if ( IsImmediate && IsDebounce )
         {
-            <textarea @ref="@ElementRef" id="@ElementId" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" data-pattern="@Pattern" maxlength="@MaxLength" rows="@Rows" tabindex="@TabIndex" value="@CurrentValue" @onchange="@OnChangeHandler" @oninput="@OnInputHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+            <textarea @ref="@ElementRef" id="@ElementId" name="@NameAttributeValue" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" data-pattern="@Pattern" maxlength="@MaxLength" rows="@Rows" tabindex="@TabIndex" value="@CurrentValue" @onchange="@OnChangeHandler" @oninput="@OnInputHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
         }
         else
         {
-            <textarea @ref="@ElementRef" id="@ElementId" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" data-pattern="@Pattern" maxlength="@MaxLength" rows="@Rows" tabindex="@TabIndex" @bind-value="CurrentValueAsString" @bind-value:event="@BindValueEventName" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+            <textarea @ref="@ElementRef" id="@ElementId" name="@NameAttributeValue" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" data-pattern="@Pattern" maxlength="@MaxLength" rows="@Rows" tabindex="@TabIndex" @bind-value="CurrentValueAsString" @bind-value:event="@BindValueEventName" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
         }
     };
 }

--- a/Source/Blazorise.FluentUI2/Components/NumericEdit.razor
+++ b/Source/Blazorise.FluentUI2/Components/NumericEdit.razor
@@ -20,11 +20,11 @@ else
     {
         @if ( IsImmediate && IsDebounce )
         {
-            <input @ref="@ElementRef" id="@ElementId" type="number" inputmode="@InputMode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" size="@VisibleCharacters" step="@StepString" pattern="@Pattern" tabindex="@TabIndex" value="@CurrentValueAsString" @oninput="@OnInputHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+            <input @ref="@ElementRef" id="@ElementId" type="number" name="@NameAttributeValue" inputmode="@InputMode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" size="@VisibleCharacters" step="@StepString" pattern="@Pattern" tabindex="@TabIndex" value="@CurrentValueAsString" @oninput="@OnInputHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
         }
         else
         {
-            <input @ref="@ElementRef" id="@ElementId" type="number" inputmode="@InputMode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" size="@VisibleCharacters" step="@StepString" pattern="@Pattern" tabindex="@TabIndex" @bind-value="@CurrentValueAsString" @bind-value:event="@BindValueEventName" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+            <input @ref="@ElementRef" id="@ElementId" type="number" name="@NameAttributeValue" inputmode="@InputMode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" size="@VisibleCharacters" step="@StepString" pattern="@Pattern" tabindex="@TabIndex" @bind-value="@CurrentValueAsString" @bind-value:event="@BindValueEventName" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
         }
     };
 }

--- a/Source/Blazorise.FluentUI2/Components/NumericPicker.razor
+++ b/Source/Blazorise.FluentUI2/Components/NumericPicker.razor
@@ -22,6 +22,6 @@
 {
     protected RenderFragment InputElement => __builder =>
     {
-        <input @ref="@ElementRef" id="@ElementId" inputmode="@InputMode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" size="@VisibleCharacters" step="@StepString" pattern="@Pattern" tabindex="@TabIndex" aria-valuemin="@Min" aria-valuemax="@Max" aria-valuenow="@CurrentValueAsString" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+        <input @ref="@ElementRef" id="@ElementId" name="@NameAttributeValue" inputmode="@InputMode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" size="@VisibleCharacters" step="@StepString" pattern="@Pattern" tabindex="@TabIndex" aria-valuemin="@Min" aria-valuemax="@Max" aria-valuenow="@CurrentValueAsString" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
     };
 }

--- a/Source/Blazorise.FluentUI2/Components/Select.razor
+++ b/Source/Blazorise.FluentUI2/Components/Select.razor
@@ -20,7 +20,7 @@
 @code {
     private RenderFragment InputElement => __builder =>
     {
-        <select @ref="@ElementRef" id="@ElementId" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" multiple="@Multiple" size="@MaxVisibleItems" value="@CurrentValueAsString" tabindex="@TabIndex" @onchange="@OnChangeHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes">
+        <select @ref="@ElementRef" id="@ElementId" name="@NameAttributeValue" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" multiple="@Multiple" size="@MaxVisibleItems" value="@CurrentValueAsString" tabindex="@TabIndex" @onchange="@OnChangeHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes">
             @ChildContent
         </select>
         @if ( !Multiple )

--- a/Source/Blazorise.FluentUI2/Components/Slider.razor
+++ b/Source/Blazorise.FluentUI2/Components/Slider.razor
@@ -42,7 +42,7 @@ else
 
     private RenderFragment SliderElement => __builder =>
     {
-        <input @ref="@ElementRef" id="@ElementId" type="range" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" step="@StepString" min="@MinString" max="@MaxString" tabindex="@TabIndex" @bind-value="@CurrentValueAsString" @bind-value:event="oninput" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes">
+        <input @ref="@ElementRef" id="@ElementId" type="range" name="@NameAttributeValue" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" step="@StepString" min="@MinString" max="@MaxString" tabindex="@TabIndex" @bind-value="@CurrentValueAsString" @bind-value:event="oninput" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes">
         <div class="fui-Slider__rail"></div>
         <div class="fui-Slider__thumb"></div>
     };

--- a/Source/Blazorise.FluentUI2/Components/Switch.razor
+++ b/Source/Blazorise.FluentUI2/Components/Switch.razor
@@ -17,7 +17,7 @@ else
 @code {
     private RenderFragment InputElement => __builder =>
     {
-        <input @ref="@ElementRef" id="@ElementId" type="checkbox" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" checked="@CurrentValue" tabindex="@TabIndex" @onclick:preventDefault="@ReadOnly" @onchange="@OnChangeHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+        <input @ref="@ElementRef" id="@ElementId" type="checkbox" name="@NameAttributeValue" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" checked="@CurrentValue" tabindex="@TabIndex" @onclick:preventDefault="@ReadOnly" @onchange="@OnChangeHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
 
         <div aria-hidden="true" class="fui-Switch__indicator">
             <svg fill="currentColor" class="fui-Switch__indicator__icon" aria-hidden="true" width="1em" height="1em" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M10 2a8 8 0 1 0 0 16 8 8 0 0 0 0-16Z" fill="currentColor"></path></svg>

--- a/Source/Blazorise.FluentUI2/Components/TextEdit.razor
+++ b/Source/Blazorise.FluentUI2/Components/TextEdit.razor
@@ -19,11 +19,11 @@ else
     {
         @if ( IsImmediate && IsDebounce )
         {
-            <input @ref="@ElementRef" id="@ElementId" type="@Type" inputmode="@Mode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" aria-readonly="@ReadOnlyAsString" maxlength="@MaxLength" size="@VisibleCharacters" pattern="@Pattern" tabindex="@TabIndex" value="@CurrentValue" @oninput="@OnInputHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+            <input @ref="@ElementRef" id="@ElementId" type="@Type" name="@NameAttributeValue" inputmode="@Mode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" aria-readonly="@ReadOnlyAsString" maxlength="@MaxLength" size="@VisibleCharacters" pattern="@Pattern" tabindex="@TabIndex" value="@CurrentValue" @oninput="@OnInputHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
         }
         else
         {
-            <input @ref="@ElementRef" id="@ElementId" type="@Type" inputmode="@Mode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" aria-readonly="@ReadOnlyAsString" maxlength="@MaxLength" size="@VisibleCharacters" pattern="@Pattern" tabindex="@TabIndex" @bind-value="CurrentValueAsString" @bind-value:event="@BindValueEventName" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+            <input @ref="@ElementRef" id="@ElementId" type="@Type" name="@NameAttributeValue" inputmode="@Mode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" aria-readonly="@ReadOnlyAsString" maxlength="@MaxLength" size="@VisibleCharacters" pattern="@Pattern" tabindex="@TabIndex" @bind-value="CurrentValueAsString" @bind-value:event="@BindValueEventName" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
         }
     };
 }

--- a/Source/Blazorise.FluentUI2/Components/TimeEdit.razor
+++ b/Source/Blazorise.FluentUI2/Components/TimeEdit.razor
@@ -18,6 +18,6 @@ else
 @code {
     private RenderFragment InputElement => __builder =>
     {
-        <input @ref="@ElementRef" id="@ElementId" type="time" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" pattern="@Pattern" step="@Step" value="@CurrentValueAsString" tabindex="@TabIndex" @onchange="@OnChangeHandler" placeholder="@Placeholder" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+        <input @ref="@ElementRef" id="@ElementId" type="time" name="@NameAttributeValue" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" pattern="@Pattern" step="@Step" value="@CurrentValueAsString" tabindex="@TabIndex" @onchange="@OnChangeHandler" placeholder="@Placeholder" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
     };
 }

--- a/Source/Blazorise.FluentUI2/Components/TimePicker.razor
+++ b/Source/Blazorise.FluentUI2/Components/TimePicker.razor
@@ -18,6 +18,6 @@ else
 @code {
     private RenderFragment InputElement => __builder =>
     {
-        <input @ref="@ElementRef" id="@ElementId" type="text" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" pattern="@Pattern" value="@CurrentValueAsString" tabindex="@TabIndex" @onchange="@OnChangeHandler" @onclick="@OnClickHandler" placeholder="@Placeholder" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+        <input @ref="@ElementRef" id="@ElementId" type="text" name="@NameAttributeValue" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" pattern="@Pattern" value="@CurrentValueAsString" tabindex="@TabIndex" @onchange="@OnChangeHandler" @onclick="@OnClickHandler" placeholder="@Placeholder" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
     };
 }

--- a/Source/Blazorise.Material/Components/NumericPicker.razor
+++ b/Source/Blazorise.Material/Components/NumericPicker.razor
@@ -1,5 +1,5 @@
 ﻿@typeparam TValue
 @inherits Blazorise.NumericPicker<TValue>
-<input @ref="@ElementRef" id="@ElementId" inputmode="@InputMode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" size="@VisibleCharacters" step="@StepString" pattern="@Pattern" tabindex="@TabIndex" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+<input @ref="@ElementRef" id="@ElementId" name="@NameAttributeValue" inputmode="@InputMode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" size="@VisibleCharacters" step="@StepString" pattern="@Pattern" tabindex="@TabIndex" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
 @ChildContent
 @Feedback

--- a/Source/Blazorise.Material/Components/Switch.razor
+++ b/Source/Blazorise.Material/Components/Switch.razor
@@ -1,7 +1,7 @@
 ﻿@typeparam TValue
 @inherits Blazorise.Switch<TValue>
 <Control Role="@ControlRole.Switch" Inline="@Inline">
-    <input @ref="@ElementRef" id="@ElementId" type="checkbox" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" checked="@Checked" tabindex="@TabIndex" @onclick:preventDefault="@ReadOnly" @onchange="@OnChangeHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+    <input @ref="@ElementRef" id="@ElementId" type="checkbox" name="@NameAttributeValue" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" checked="@Checked" tabindex="@TabIndex" @onclick:preventDefault="@ReadOnly" @onchange="@OnChangeHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
     <span class="custom-control-track"></span>
     <Label Type="LabelType.Switch" For="@ElementId" Style="@Style" Cursor="@Cursor">@ChildContent</Label>
     @Feedback

--- a/Source/Blazorise.Tailwind/Components/ColorPicker.razor
+++ b/Source/Blazorise.Tailwind/Components/ColorPicker.razor
@@ -8,7 +8,7 @@
             <div class="w-4 h-4 rounded shadow border" :style="{ 'background-color': selected.value }" style="@($"background-color: {CurrentValueAsString};")"></div>
         </span>
     </div>
-    <input @ref="@ElementRef" id="@ElementId" type="text" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" value="@CurrentValueAsString" tabindex="@TabIndex" @onchange="@OnChangeHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+    <input @ref="@ElementRef" id="@ElementId" type="text" name="@NameAttributeValue" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" value="@CurrentValueAsString" tabindex="@TabIndex" @onchange="@OnChangeHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
     @ChildContent
     @Feedback
 </div>

--- a/Source/Blazorise.Tailwind/Components/Switch.razor
+++ b/Source/Blazorise.Tailwind/Components/Switch.razor
@@ -2,7 +2,7 @@
 @inherits Blazorise.Switch<TValue>
 <Control Role="@ControlRole.Switch" Inline="@Inline">
     <Label Type="LabelType.Switch" For="@ElementId" Style="@Style" Cursor="@Cursor">
-        <input @ref="@ElementRef" id="@ElementId" type="checkbox" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" checked="@Checked" tabindex="@TabIndex" @onclick:preventDefault="@ReadOnly" @onchange="@OnChangeHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+        <input @ref="@ElementRef" id="@ElementId" type="checkbox" name="@NameAttributeValue" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" checked="@Checked" tabindex="@TabIndex" @onclick:preventDefault="@ReadOnly" @onchange="@OnChangeHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
         <div class="@BackgroundClassNames"></div>
         <span class="ml-3 text-sm font-medium text-gray-900 dark:text-gray-300">@ChildContent</span>
     </Label>

--- a/Source/Blazorise/Base/BaseCheckComponent.cs
+++ b/Source/Blazorise/Base/BaseCheckComponent.cs
@@ -56,6 +56,17 @@ public abstract class BaseCheckComponent<TValue> : BaseInputComponent<TValue>
         return CheckedChanged.InvokeAsync( Checked );
     }
 
+    /// <inheritdoc/>
+    protected override string GetFormatedValueExpression()
+    {
+        if ( CheckedExpression is null )
+            return null;
+
+        return HtmlFieldPrefix is not null
+            ? HtmlFieldPrefix.GetFieldName( CheckedExpression )
+            : ExpressionFormatter.FormatLambda( CheckedExpression );
+    }
+
     #endregion
 
     #region Properties

--- a/Source/Blazorise/Base/BaseInputComponent.razor.cs
+++ b/Source/Blazorise/Base/BaseInputComponent.razor.cs
@@ -65,12 +65,7 @@ public abstract class BaseInputComponent<TValue> : BaseComponent, IValidationInp
     /// <inheritdoc/>
     public override async Task SetParametersAsync( ParameterView parameters )
     {
-        if ( !hasInitializedParameters )
-        {
-            shouldGenerateFieldNames = !OperatingSystem.IsBrowser();
-
-            hasInitializedParameters = true;
-        }
+        InitializeParameters();
 
         await base.SetParametersAsync( parameters );
 
@@ -152,7 +147,7 @@ public abstract class BaseInputComponent<TValue> : BaseComponent, IValidationInp
     /// <summary>
     /// Initializes parameters that are not going to be changed again.
     /// </summary>
-    protected void IntializeParameters()
+    protected void InitializeParameters()
     {
         if ( hasInitializedParameters )
             return;

--- a/Source/Blazorise/Base/BaseInputComponent.razor.cs
+++ b/Source/Blazorise/Base/BaseInputComponent.razor.cs
@@ -5,7 +5,6 @@ using Blazorise.Extensions;
 using Blazorise.Modules;
 using Blazorise.Utilities;
 using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.AspNetCore.Components.Web;
 #endregion
 
@@ -70,11 +69,11 @@ public abstract class BaseInputComponent<TValue> : BaseComponent, IValidationInp
         await base.SetParametersAsync( parameters );
 
         // For modals we need to make sure that autofocus is applied every time the modal is opened.
-        if ( parameters.TryGetValue<bool>( nameof( Autofocus ), out var autofocus ) && this.autofocus != autofocus )
+        if ( parameters.TryGetValue<bool>( nameof( Autofocus ), out var paramAutofocus ) && autofocus != paramAutofocus )
         {
-            this.autofocus = autofocus;
+            autofocus = paramAutofocus;
 
-            if ( autofocus )
+            if ( paramAutofocus )
             {
                 if ( ParentFocusableContainer is not null )
                 {

--- a/Source/Blazorise/Components/ColorEdit/ColorEdit.razor
+++ b/Source/Blazorise/Components/ColorEdit/ColorEdit.razor
@@ -1,5 +1,5 @@
 ﻿@namespace Blazorise
 @inherits BaseInputComponent<string>
-<input @ref="@ElementRef" id="@ElementId" type="color" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" value="@CurrentValueAsString" tabindex="@TabIndex" @onchange="@OnChangeHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+<input @ref="@ElementRef" id="@ElementId" type="color" name="@NameAttributeValue" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" value="@CurrentValueAsString" tabindex="@TabIndex" @onchange="@OnChangeHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
 @ChildContent
 @Feedback

--- a/Source/Blazorise/Components/ColorEdit/ColorEdit.razor.cs
+++ b/Source/Blazorise/Components/ColorEdit/ColorEdit.razor.cs
@@ -84,6 +84,17 @@ public partial class ColorEdit : BaseInputComponent<string>, ISelectableComponen
         return JSUtilitiesModule.Select( ElementRef, ElementId, focus ).AsTask();
     }
 
+    /// <inheritdoc/>
+    protected override string GetFormatedValueExpression()
+    {
+        if ( ColorExpression is null )
+            return null;
+
+        return HtmlFieldPrefix is not null
+            ? HtmlFieldPrefix.GetFieldName( ColorExpression )
+            : ExpressionFormatter.FormatLambda( ColorExpression );
+    }
+
     #endregion
 
     #region Properties

--- a/Source/Blazorise/Components/ColorPicker/ColorPicker.razor
+++ b/Source/Blazorise/Components/ColorPicker/ColorPicker.razor
@@ -1,6 +1,6 @@
 ﻿@namespace Blazorise
 @inherits BaseInputComponent<string>
-<div @ref="@ElementRef" id="@ElementId" class="@ClassNames" style="@StyleNames" value="@CurrentValueAsString" tabindex="@TabIndex" aria-disabled="@Disabled.ToString().ToLowerInvariant()" @onchange="@OnChangeHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes">
+<div @ref="@ElementRef" id="@ElementId" name="@NameAttributeValue" class="@ClassNames" style="@StyleNames" value="@CurrentValueAsString" tabindex="@TabIndex" aria-disabled="@Disabled.ToString().ToLowerInvariant()" @onchange="@OnChangeHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes">
     <div class="b-input-color-picker-preview">
         <span class="b-input-color-picker-curent-color"></span>
     </div>

--- a/Source/Blazorise/Components/ColorPicker/ColorPicker.razor.cs
+++ b/Source/Blazorise/Components/ColorPicker/ColorPicker.razor.cs
@@ -200,6 +200,17 @@ public partial class ColorPicker : BaseInputComponent<string>, ISelectableCompon
         return CurrentValueHandler( value );
     }
 
+    /// <inheritdoc/>
+    protected override string GetFormatedValueExpression()
+    {
+        if ( ColorExpression is null )
+            return null;
+
+        return HtmlFieldPrefix is not null
+            ? HtmlFieldPrefix.GetFieldName( ColorExpression )
+            : ExpressionFormatter.FormatLambda( ColorExpression );
+    }
+
     #endregion
 
     #region Properties

--- a/Source/Blazorise/Components/DateEdit/DateEdit.razor
+++ b/Source/Blazorise/Components/DateEdit/DateEdit.razor
@@ -1,6 +1,6 @@
 ﻿@namespace Blazorise
 @typeparam TValue
 @inherits BaseTextInput<TValue>
-<input @ref="@ElementRef" id="@ElementId" type="@Mode" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" pattern="@Pattern" step="@Step" value="@CurrentValueAsString" @onchange="@OnChangeHandler" placeholder="@Placeholder" min="@Min?.ToString(DateFormat)" max="@Max?.ToString(DateFormat)" tabindex="@TabIndex" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+<input @ref="@ElementRef" id="@ElementId" type="@Mode" name="@NameAttributeValue" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" pattern="@Pattern" step="@Step" value="@CurrentValueAsString" @onchange="@OnChangeHandler" placeholder="@Placeholder" min="@Min?.ToString(DateFormat)" max="@Max?.ToString(DateFormat)" tabindex="@TabIndex" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
 @ChildContent
 @Feedback

--- a/Source/Blazorise/Components/DateEdit/DateEdit.razor.cs
+++ b/Source/Blazorise/Components/DateEdit/DateEdit.razor.cs
@@ -113,6 +113,17 @@ public partial class DateEdit<TValue> : BaseTextInput<TValue>
         return JSUtilitiesModule.ShowPicker( ElementRef, ElementId ).AsTask();
     }
 
+    /// <inheritdoc/>
+    protected override string GetFormatedValueExpression()
+    {
+        if ( DateExpression is null )
+            return null;
+
+        return HtmlFieldPrefix is not null
+            ? HtmlFieldPrefix.GetFieldName( DateExpression )
+            : ExpressionFormatter.FormatLambda( DateExpression );
+    }
+
     #endregion
 
     #region Properties

--- a/Source/Blazorise/Components/DatePicker/DatePicker.razor
+++ b/Source/Blazorise/Components/DatePicker/DatePicker.razor
@@ -1,6 +1,6 @@
 ﻿@namespace Blazorise
 @typeparam TValue
 @inherits BaseTextInput<IReadOnlyList<TValue>>
-<input @ref="@ElementRef" id="@ElementId" type="text" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" pattern="@Pattern" value="@CurrentValueAsString" @onchange="@OnChangeHandler" @onclick="@OnClickHandler" placeholder="@Placeholder" min="@Min?.ToString(Utilities.Parsers.InternalDateFormat)" max="@Max?.ToString(Utilities.Parsers.InternalDateFormat)" tabindex="@TabIndex" @attributes="@Attributes" />
+<input @ref="@ElementRef" id="@ElementId" type="text" name="@NameAttributeValue" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" pattern="@Pattern" value="@CurrentValueAsString" @onchange="@OnChangeHandler" @onclick="@OnClickHandler" placeholder="@Placeholder" min="@Min?.ToString(Utilities.Parsers.InternalDateFormat)" max="@Max?.ToString(Utilities.Parsers.InternalDateFormat)" tabindex="@TabIndex" @attributes="@Attributes" />
 @ChildContent
 @Feedback

--- a/Source/Blazorise/Components/DatePicker/DatePicker.razor.cs
+++ b/Source/Blazorise/Components/DatePicker/DatePicker.razor.cs
@@ -477,6 +477,17 @@ public partial class DatePicker<TValue> : BaseTextInput<IReadOnlyList<TValue>>, 
     /// <inheritdoc/>
     protected override bool IsSameAsInternalValue( IReadOnlyList<TValue> value ) => value.AreEqual( InternalValue );
 
+    /// <inheritdoc/>
+    protected override string GetFormatedValueExpression()
+    {
+        if ( DateExpression is null )
+            return null;
+
+        return HtmlFieldPrefix is not null
+            ? HtmlFieldPrefix.GetFieldName( DateExpression )
+            : ExpressionFormatter.FormatLambda( DateExpression );
+    }
+
     #endregion
 
     #region Properties

--- a/Source/Blazorise/Components/FileEdit/FileEdit.razor.cs
+++ b/Source/Blazorise/Components/FileEdit/FileEdit.razor.cs
@@ -11,7 +11,6 @@ using Blazorise.Modules;
 using Blazorise.Utilities;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
-using static System.Net.WebRequestMethods;
 #endregion
 
 namespace Blazorise;
@@ -261,6 +260,12 @@ public partial class FileEdit : BaseInputComponent<IFileEntry[]>, IFileEdit,
     public Task ShowPicker()
     {
         return JSUtilitiesModule.ShowPicker( ElementRef, ElementId ).AsTask();
+    }
+
+    /// <inheritdoc/>
+    protected override string GetFormatedValueExpression()
+    {
+        return null;
     }
 
     #endregion

--- a/Source/Blazorise/Components/InputMask/InputMask.razor
+++ b/Source/Blazorise/Components/InputMask/InputMask.razor
@@ -2,11 +2,11 @@
 @inherits BaseTextInput<string>
 @if ( IsImmediate && IsDebounce )
 {
-    <input @ref="@ElementRef" id="@ElementId" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" pattern="@Pattern" tabindex="@TabIndex" value="@CurrentValueAsString" @oninput="@OnInputHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+    <input @ref="@ElementRef" id="@ElementId" name="@NameAttributeValue" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" pattern="@Pattern" tabindex="@TabIndex" value="@CurrentValueAsString" @oninput="@OnInputHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
 }
 else
 {
-    <input @ref="@ElementRef" id="@ElementId" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" pattern="@Pattern" tabindex="@TabIndex" @bind-value="CurrentValueAsString" @bind-value:event="@BindValueEventName" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+    <input @ref="@ElementRef" id="@ElementId" name="@NameAttributeValue" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" pattern="@Pattern" tabindex="@TabIndex" @bind-value="CurrentValueAsString" @bind-value:event="@BindValueEventName" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
 }
 @ChildContent
 @Feedback

--- a/Source/Blazorise/Components/InputMask/InputMask.razor.cs
+++ b/Source/Blazorise/Components/InputMask/InputMask.razor.cs
@@ -182,6 +182,17 @@ public partial class InputMask : BaseTextInput<string>, IAsyncDisposable
         return Cleared.InvokeAsync();
     }
 
+    /// <inheritdoc/>
+    protected override string GetFormatedValueExpression()
+    {
+        if ( ValueExpression is null )
+            return null;
+
+        return HtmlFieldPrefix is not null
+            ? HtmlFieldPrefix.GetFieldName( ValueExpression )
+            : ExpressionFormatter.FormatLambda( ValueExpression );
+    }
+
     #endregion
 
     #region Properties

--- a/Source/Blazorise/Components/MemoEdit/MemoEdit.razor
+++ b/Source/Blazorise/Components/MemoEdit/MemoEdit.razor
@@ -2,11 +2,11 @@
 @inherits BaseInputComponent<string>
 @if ( IsImmediate && IsDebounce )
 {
-    <textarea @ref="@ElementRef" id="@ElementId" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" data-pattern="@Pattern" maxlength="@MaxLength" rows="@Rows" tabindex="@TabIndex" value="@CurrentValue" @onchange="@OnChangeHandler" @oninput="@OnInputHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+    <textarea @ref="@ElementRef" id="@ElementId" name="@NameAttributeValue" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" data-pattern="@Pattern" maxlength="@MaxLength" rows="@Rows" tabindex="@TabIndex" value="@CurrentValue" @onchange="@OnChangeHandler" @oninput="@OnInputHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
 }
 else
 {
-    <textarea @ref="@ElementRef" id="@ElementId" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" data-pattern="@Pattern" maxlength="@MaxLength" rows="@Rows" tabindex="@TabIndex" @bind-value="CurrentValueAsString" @bind-value:event="@BindValueEventName" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+    <textarea @ref="@ElementRef" id="@ElementId" name="@NameAttributeValue" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" data-pattern="@Pattern" maxlength="@MaxLength" rows="@Rows" tabindex="@TabIndex" @bind-value="CurrentValueAsString" @bind-value:event="@BindValueEventName" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
 }
 @ChildContent
 @Feedback

--- a/Source/Blazorise/Components/MemoEdit/MemoEdit.razor.cs
+++ b/Source/Blazorise/Components/MemoEdit/MemoEdit.razor.cs
@@ -219,6 +219,17 @@ public partial class MemoEdit : BaseInputComponent<string>, ISelectableComponent
         await JSUtilitiesModule.Select( ElementRef, ElementId, focus );
     }
 
+    /// <inheritdoc/>
+    protected override string GetFormatedValueExpression()
+    {
+        if ( TextExpression is null )
+            return null;
+
+        return HtmlFieldPrefix is not null
+            ? HtmlFieldPrefix.GetFieldName( TextExpression )
+            : ExpressionFormatter.FormatLambda( TextExpression );
+    }
+
     #endregion
 
     #region Properties

--- a/Source/Blazorise/Components/NumericEdit/NumericEdit.razor
+++ b/Source/Blazorise/Components/NumericEdit/NumericEdit.razor
@@ -3,11 +3,11 @@
 @inherits Blazorise.BaseTextInput<TValue>
 @if ( IsImmediate && IsDebounce )
 {
-    <input @ref="@ElementRef" id="@ElementId" type="number" inputmode="@InputMode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" size="@VisibleCharacters" step="@StepString" pattern="@Pattern" tabindex="@TabIndex" value="@CurrentValueAsString" @oninput="@OnInputHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+    <input @ref="@ElementRef" id="@ElementId" type="number" name="@NameAttributeValue" inputmode="@InputMode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" size="@VisibleCharacters" step="@StepString" pattern="@Pattern" tabindex="@TabIndex" value="@CurrentValueAsString" @oninput="@OnInputHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
 }
 else
 {
-    <input @ref="@ElementRef" id="@ElementId" type="number" inputmode="@InputMode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" size="@VisibleCharacters" step="@StepString" pattern="@Pattern" tabindex="@TabIndex" @bind-value="@CurrentValueAsString" @bind-value:event="@BindValueEventName" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+    <input @ref="@ElementRef" id="@ElementId" type="number" name="@NameAttributeValue" inputmode="@InputMode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" size="@VisibleCharacters" step="@StepString" pattern="@Pattern" tabindex="@TabIndex" @bind-value="@CurrentValueAsString" @bind-value:event="@BindValueEventName" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
 }
 @ChildContent
 @Feedback

--- a/Source/Blazorise/Components/NumericEdit/NumericEdit.razor.cs
+++ b/Source/Blazorise/Components/NumericEdit/NumericEdit.razor.cs
@@ -185,6 +185,17 @@ public partial class NumericEdit<TValue> : BaseTextInput<TValue>, IAsyncDisposab
         return Task.CompletedTask;
     }
 
+    /// <inheritdoc/>
+    protected override string GetFormatedValueExpression()
+    {
+        if ( ValueExpression is null )
+            return null;
+
+        return HtmlFieldPrefix is not null
+            ? HtmlFieldPrefix.GetFieldName( ValueExpression )
+            : ExpressionFormatter.FormatLambda( ValueExpression );
+    }
+
     #endregion
 
     #region Properties

--- a/Source/Blazorise/Components/NumericPicker/NumericPicker.razor
+++ b/Source/Blazorise/Components/NumericPicker/NumericPicker.razor
@@ -1,6 +1,6 @@
 ﻿@namespace Blazorise
 @typeparam TValue
 @inherits Blazorise.BaseTextInput<TValue>
-<input @ref="@ElementRef" id="@ElementId" inputmode="@InputMode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" size="@VisibleCharacters" step="@StepString" pattern="@Pattern" tabindex="@TabIndex" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+<input @ref="@ElementRef" id="@ElementId" name="@NameAttributeValue" inputmode="@InputMode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" size="@VisibleCharacters" step="@StepString" pattern="@Pattern" tabindex="@TabIndex" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
 @ChildContent
 @Feedback

--- a/Source/Blazorise/Components/NumericPicker/NumericPicker.razor.cs
+++ b/Source/Blazorise/Components/NumericPicker/NumericPicker.razor.cs
@@ -456,6 +456,17 @@ public partial class NumericPicker<TValue> : BaseTextInput<TValue>, INumericPick
     /// <returns>Number of decimals.</returns>
     protected int GetDecimals() => isIntegerType ? 0 : Decimals;
 
+    /// <inheritdoc/>
+    protected override string GetFormatedValueExpression()
+    {
+        if ( ValueExpression is null )
+            return null;
+
+        return HtmlFieldPrefix is not null
+            ? HtmlFieldPrefix.GetFieldName( ValueExpression )
+            : ExpressionFormatter.FormatLambda( ValueExpression );
+    }
+
     #endregion
 
     #region Properties

--- a/Source/Blazorise/Components/Radio/RadioGroup.razor.cs
+++ b/Source/Blazorise/Components/Radio/RadioGroup.razor.cs
@@ -116,6 +116,17 @@ public partial class RadioGroup<TValue> : BaseInputComponent<TValue>
         RadioCheckedChanged?.Invoke( this, new( CheckedValue ) );
     }
 
+    /// <inheritdoc/>
+    protected override string GetFormatedValueExpression()
+    {
+        if ( CheckedValueExpression is null )
+            return null;
+
+        return HtmlFieldPrefix is not null
+            ? HtmlFieldPrefix.GetFieldName( CheckedValueExpression )
+            : ExpressionFormatter.FormatLambda( CheckedValueExpression );
+    }
+
     #endregion
 
     #region Properties

--- a/Source/Blazorise/Components/Select/Select.razor
+++ b/Source/Blazorise/Components/Select/Select.razor
@@ -3,7 +3,7 @@
 @inherits BaseInputComponent<IReadOnlyList<TValue>>
 @attribute [CascadingTypeParameter( nameof( TValue ) )]
 <CascadingValue Value="@this" IsFixed>
-    <select @ref="@ElementRef" id="@ElementId" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" multiple="@Multiple" size="@MaxVisibleItems" value="@CurrentValueAsString" tabindex="@TabIndex" @onchange="@OnChangeHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes">
+    <select @ref="@ElementRef" id="@ElementId" name="@NameAttributeValue" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" multiple="@Multiple" size="@MaxVisibleItems" value="@CurrentValueAsString" tabindex="@TabIndex" @onchange="@OnChangeHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes">
         @ChildContent
     </select>
     @Feedback

--- a/Source/Blazorise/Components/Select/Select.razor.cs
+++ b/Source/Blazorise/Components/Select/Select.razor.cs
@@ -203,6 +203,25 @@ public partial class Select<TValue> : BaseInputComponent<IReadOnlyList<TValue>>
             selectItems.Remove( selectItem );
     }
 
+    /// <inheritdoc/>
+    protected override string GetFormatedValueExpression()
+    {
+        if ( Multiple && SelectedValuesExpression is not null )
+        {
+            return HtmlFieldPrefix is not null
+                ? HtmlFieldPrefix.GetFieldName( SelectedValuesExpression )
+                : ExpressionFormatter.FormatLambda( SelectedValuesExpression );
+        }
+        else if ( SelectedValueExpression is not null )
+        {
+            return HtmlFieldPrefix is not null
+                ? HtmlFieldPrefix.GetFieldName( SelectedValueExpression )
+                : ExpressionFormatter.FormatLambda( SelectedValueExpression );
+        }
+
+        return null;
+    }
+
     #endregion
 
     #region Properties

--- a/Source/Blazorise/Components/Slider/Slider.razor
+++ b/Source/Blazorise/Components/Slider/Slider.razor
@@ -1,6 +1,6 @@
 ﻿@namespace Blazorise
 @typeparam TValue
 @inherits Blazorise.BaseInputComponent<TValue>
-<input @ref="@ElementRef" id="@ElementId" type="range" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" step="@StepString" min="@MinString" max="@MaxString" tabindex="@TabIndex" @bind-value="@CurrentValueAsString" @bind-value:event="oninput" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes">
+<input @ref="@ElementRef" id="@ElementId" type="range" name="@NameAttributeValue" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" step="@StepString" min="@MinString" max="@MaxString" tabindex="@TabIndex" @bind-value="@CurrentValueAsString" @bind-value:event="oninput" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes">
 @ChildContent
 @Feedback

--- a/Source/Blazorise/Components/Slider/Slider.razor.cs
+++ b/Source/Blazorise/Components/Slider/Slider.razor.cs
@@ -108,6 +108,17 @@ public partial class Slider<TValue> : BaseInputComponent<TValue>
         };
     }
 
+    /// <inheritdoc/>
+    protected override string GetFormatedValueExpression()
+    {
+        if ( ValueExpression is null )
+            return null;
+
+        return HtmlFieldPrefix is not null
+            ? HtmlFieldPrefix.GetFieldName( ValueExpression )
+            : ExpressionFormatter.FormatLambda( ValueExpression );
+    }
+
     #endregion
 
     #region Properties

--- a/Source/Blazorise/Components/TextEdit/TextEdit.razor
+++ b/Source/Blazorise/Components/TextEdit/TextEdit.razor
@@ -2,11 +2,11 @@
 @inherits BaseTextInput<string>
 @if ( IsImmediate && IsDebounce )
 {
-    <input @ref="@ElementRef" id="@ElementId" type="@Type" inputmode="@Mode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" aria-readonly="@ReadOnlyAsString" maxlength="@MaxLength" size="@VisibleCharacters" pattern="@Pattern" tabindex="@TabIndex" value="@CurrentValue" @oninput="@OnInputHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+    <input @ref="@ElementRef" id="@ElementId" type="@Type" name="@NameAttributeValue" inputmode="@Mode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" aria-readonly="@ReadOnlyAsString" maxlength="@MaxLength" size="@VisibleCharacters" pattern="@Pattern" tabindex="@TabIndex" value="@CurrentValue" @oninput="@OnInputHandler" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
 }
 else
 {
-    <input @ref="@ElementRef" id="@ElementId" type="@Type" inputmode="@Mode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" aria-readonly="@ReadOnlyAsString" maxlength="@MaxLength" size="@VisibleCharacters" pattern="@Pattern" tabindex="@TabIndex" @bind-value="CurrentValueAsString" @bind-value:event="@BindValueEventName" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+    <input @ref="@ElementRef" id="@ElementId" type="@Type" name="@NameAttributeValue" inputmode="@Mode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@Disabled" readonly="@ReadOnly" aria-readonly="@ReadOnlyAsString" maxlength="@MaxLength" size="@VisibleCharacters" pattern="@Pattern" tabindex="@TabIndex" @bind-value="CurrentValueAsString" @bind-value:event="@BindValueEventName" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
 }
 @ChildContent
 @Feedback

--- a/Source/Blazorise/Components/TextEdit/TextEdit.razor.cs
+++ b/Source/Blazorise/Components/TextEdit/TextEdit.razor.cs
@@ -6,6 +6,7 @@ using Blazorise.Extensions;
 using Blazorise.Modules;
 using Blazorise.Utilities;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Forms;
 #endregion
 
 namespace Blazorise;
@@ -89,6 +90,17 @@ public partial class TextEdit : BaseTextInput<string>, IAsyncDisposable
     protected override Task<ParseValue<string>> ParseValueFromStringAsync( string value )
     {
         return Task.FromResult( new ParseValue<string>( true, value, null ) );
+    }
+
+    /// <inheritdoc/>
+    protected override string GetFormatedValueExpression()
+    {
+        if ( TextExpression is null )
+            return null;
+
+        return HtmlFieldPrefix is not null
+            ? HtmlFieldPrefix.GetFieldName( TextExpression )
+            : ExpressionFormatter.FormatLambda( TextExpression );
     }
 
     #endregion

--- a/Source/Blazorise/Components/TimeEdit/TimeEdit.razor
+++ b/Source/Blazorise/Components/TimeEdit/TimeEdit.razor
@@ -1,6 +1,6 @@
 ﻿@namespace Blazorise
 @typeparam TValue
 @inherits BaseTextInput<TValue>
-<input @ref="@ElementRef" id="@ElementId" type="time" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" pattern="@Pattern" step="@Step" value="@CurrentValueAsString" tabindex="@TabIndex" @onchange="@OnChangeHandler" placeholder="@Placeholder" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+<input @ref="@ElementRef" id="@ElementId" type="time" name="@NameAttributeValue" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" pattern="@Pattern" step="@Step" value="@CurrentValueAsString" tabindex="@TabIndex" @onchange="@OnChangeHandler" placeholder="@Placeholder" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
 @ChildContent
 @Feedback

--- a/Source/Blazorise/Components/TimeEdit/TimeEdit.razor.cs
+++ b/Source/Blazorise/Components/TimeEdit/TimeEdit.razor.cs
@@ -122,6 +122,17 @@ public partial class TimeEdit<TValue> : BaseTextInput<TValue>
         return JSUtilitiesModule.ShowPicker( ElementRef, ElementId ).AsTask();
     }
 
+    /// <inheritdoc/>
+    protected override string GetFormatedValueExpression()
+    {
+        if ( TimeExpression is null )
+            return null;
+
+        return HtmlFieldPrefix is not null
+            ? HtmlFieldPrefix.GetFieldName( TimeExpression )
+            : ExpressionFormatter.FormatLambda( TimeExpression );
+    }
+
     #endregion
 
     #region Properties

--- a/Source/Blazorise/Components/TimePicker/TimePicker.razor
+++ b/Source/Blazorise/Components/TimePicker/TimePicker.razor
@@ -1,6 +1,6 @@
 ﻿@namespace Blazorise
 @typeparam TValue
 @inherits BaseTextInput<TValue>
-<input @ref="@ElementRef" id="@ElementId" type="text" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" pattern="@Pattern" value="@CurrentValueAsString" tabindex="@TabIndex" @onchange="@OnChangeHandler" @onclick="@OnClickHandler" placeholder="@Placeholder" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
+<input @ref="@ElementRef" id="@ElementId" type="text" name="@NameAttributeValue" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" pattern="@Pattern" value="@CurrentValueAsString" tabindex="@TabIndex" @onchange="@OnChangeHandler" @onclick="@OnClickHandler" placeholder="@Placeholder" @onkeydown="@OnKeyDownHandler" @onkeypress="@OnKeyPressHandler" @onkeyup="@OnKeyUpHandler" @onblur="@OnBlurHandler" @onfocus="@OnFocusHandler" @onfocusin="@OnFocusInHandler" @onfocusout="@OnFocusOutHandler" @attributes="@Attributes" />
 @ChildContent
 @Feedback

--- a/Source/Blazorise/Components/TimePicker/TimePicker.razor.cs
+++ b/Source/Blazorise/Components/TimePicker/TimePicker.razor.cs
@@ -8,6 +8,7 @@ using Blazorise.Modules;
 using Blazorise.Utilities;
 using Blazorise.Vendors;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.AspNetCore.Components.Web;
 #endregion
 
@@ -269,6 +270,17 @@ public partial class TimePicker<TValue> : BaseTextInput<TValue>, IAsyncDisposabl
         {
             amPM = new[] { Localizer["AM"], Localizer["PM"] }
         };
+    }
+
+    /// <inheritdoc/>
+    protected override string GetFormatedValueExpression()
+    {
+        if ( TimeExpression is null )
+            return null;
+
+        return HtmlFieldPrefix is not null
+            ? HtmlFieldPrefix.GetFieldName( TimeExpression )
+            : ExpressionFormatter.FormatLambda( TimeExpression );
     }
 
     #endregion

--- a/Source/Blazorise/Utilities/Builders/ReverseStringBuilder.cs
+++ b/Source/Blazorise/Utilities/Builders/ReverseStringBuilder.cs
@@ -1,0 +1,166 @@
+﻿using System;
+using System.Buffers;
+using System.Globalization;
+
+namespace Blazorise.Utilities;
+
+/// <summary>
+/// Copy from https://github.com/dotnet/aspnetcore/blob/ee4a0e9801c4e1e673d0373e1c51a6790de174cc/src/Components/Shared/src/ExpressionFormatting/ReverseStringBuilder.cs#L22
+/// </summary>
+internal ref struct ReverseStringBuilder
+{
+    public const int MinimumRentedArraySize = 1024;
+
+    private static readonly ArrayPool<char> s_arrayPool = ArrayPool<char>.Shared;
+
+    private int _nextEndIndex;
+    private Span<char> _currentBuffer;
+    private SequenceSegment _fallbackSequenceSegment = null;
+
+    // For testing.
+    internal int SequenceSegmentCount => _fallbackSequenceSegment?.Count() ?? 0;
+
+    public ReverseStringBuilder( int conservativeEstimatedStringLength )
+    {
+        var array = s_arrayPool.Rent( conservativeEstimatedStringLength );
+        _fallbackSequenceSegment = new( array );
+        _currentBuffer = array;
+        _nextEndIndex = _currentBuffer.Length;
+    }
+
+    public ReverseStringBuilder( Span<char> initialBuffer )
+    {
+        _currentBuffer = initialBuffer;
+        _nextEndIndex = _currentBuffer.Length;
+    }
+
+    public bool Empty => _nextEndIndex == _currentBuffer.Length;
+
+    public void InsertFront( scoped ReadOnlySpan<char> span )
+    {
+        var startIndex = _nextEndIndex - span.Length;
+        if ( startIndex >= 0 )
+        {
+            // The common case. There is enough space in the current buffer to copy the given span.
+            // No additional work needs to be done here after the copy.
+            span.CopyTo( _currentBuffer[startIndex..] );
+            _nextEndIndex = startIndex;
+            return;
+        }
+
+        // There wasn't enough space in the current buffer.
+        // What we do next depends on whether we're writing to the provided "initial" buffer or a rented one.
+
+        if ( _fallbackSequenceSegment is null )
+        {
+            // We've been writing to a stack-allocated buffer, but there is no more room on the stack.
+            // We rent new memory with a length sufficiently larger than the initial buffer
+            // and copy the contents over.
+            var remainingLength = -startIndex;
+            var sizeToRent = _currentBuffer.Length + Math.Max( MinimumRentedArraySize, remainingLength * 2 );
+            var newBuffer = s_arrayPool.Rent( sizeToRent );
+            _fallbackSequenceSegment = new( newBuffer );
+
+            _nextEndIndex = newBuffer.Length - _currentBuffer.Length;
+            _currentBuffer.CopyTo( newBuffer.AsSpan()[_nextEndIndex..] );
+            _currentBuffer = newBuffer;
+
+            startIndex = _nextEndIndex - span.Length;
+            span.CopyTo( _currentBuffer[startIndex..] );
+            _nextEndIndex = startIndex;
+        }
+        else
+        {
+            // We can't fit the whole string in the current heap-allocated buffer.
+            // Copy as much as we can to the current buffer, rent a new buffer, and
+            // continue copying the remaining contents.
+            var remainingLength = -startIndex;
+            span[remainingLength..].CopyTo( _currentBuffer );
+            span = span[..remainingLength];
+
+            var sizeToRent = Math.Max( MinimumRentedArraySize, remainingLength * 2 );
+            var newBuffer = s_arrayPool.Rent( sizeToRent );
+            _fallbackSequenceSegment = new( newBuffer, _fallbackSequenceSegment );
+            _currentBuffer = newBuffer;
+
+            startIndex = _currentBuffer.Length - remainingLength;
+            span.CopyTo( _currentBuffer[startIndex..] );
+            _nextEndIndex = startIndex;
+        }
+    }
+
+    public void InsertFront<T>( T value ) where T : ISpanFormattable
+    {
+        // This is large enough for any integer value (10 digits plus the possible sign).
+        // We won't try to optimize for anything larger.
+        Span<char> result = stackalloc char[11];
+
+        if ( value.TryFormat( result, out var charsWritten, format: default, CultureInfo.InvariantCulture ) )
+        {
+            InsertFront( result[..charsWritten] );
+        }
+        else
+        {
+            InsertFront( (IFormattable)value );
+        }
+    }
+
+    public void InsertFront( IFormattable formattable )
+        => InsertFront( formattable.ToString( null, CultureInfo.InvariantCulture ) );
+
+    public override readonly string ToString()
+        => _fallbackSequenceSegment is null
+            ? new( _currentBuffer[_nextEndIndex..] )
+            : _fallbackSequenceSegment.ToString( _nextEndIndex );
+
+    public readonly void Dispose()
+    {
+        _fallbackSequenceSegment?.Dispose();
+    }
+
+    private sealed class SequenceSegment : ReadOnlySequenceSegment<char>, IDisposable
+    {
+        private readonly char[] _array;
+
+        public SequenceSegment( char[] array, SequenceSegment? next = null )
+        {
+            _array = array;
+            Memory = array;
+            Next = next;
+        }
+
+        // For testing.
+        internal int Count()
+        {
+            var count = 0;
+            for ( var current = this; current is not null; current = current.Next as SequenceSegment )
+            {
+                count++;
+            }
+            return count;
+        }
+
+        public string ToString( int startIndex )
+        {
+            RunningIndex = 0;
+
+            var tail = this;
+            while ( tail.Next is SequenceSegment next )
+            {
+                next.RunningIndex = tail.RunningIndex + tail.Memory.Length;
+                tail = next;
+            }
+
+            var sequence = new ReadOnlySequence<char>( this, startIndex, tail, tail.Memory.Length );
+            return sequence.ToString();
+        }
+
+        public void Dispose()
+        {
+            for ( var current = this; current is not null; current = current.Next as SequenceSegment )
+            {
+                s_arrayPool.Return( current._array );
+            }
+        }
+    }
+}

--- a/Source/Blazorise/Utilities/Expressions/ExpressionFormatter.cs
+++ b/Source/Blazorise/Utilities/Expressions/ExpressionFormatter.cs
@@ -1,0 +1,333 @@
+﻿#region Using directives
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Runtime.Serialization;
+#endregion
+
+namespace Blazorise.Utilities;
+
+/// <summary>
+/// Provides methods for formatting lambda expressions.
+/// </summary>
+/// <remarks>
+/// Copy from https://github.com/dotnet/aspnetcore/blob/ee4a0e9801c4e1e673d0373e1c51a6790de174cc/src/Components/Shared/src/ExpressionFormatting/ExpressionFormatter.cs
+/// </remarks>
+public static class ExpressionFormatter
+{
+    /// <summary>
+    /// The size of the buffer used for stack allocation.
+    /// </summary>
+    internal const int StackAllocBufferSize = 128;
+
+    private delegate void CapturedValueFormatter( object closure, ref ReverseStringBuilder builder );
+
+    private static readonly ConcurrentDictionary<MemberInfo, CapturedValueFormatter> s_capturedValueFormatterCache = new();
+    private static readonly ConcurrentDictionary<MethodInfo, MethodInfoData> s_methodInfoDataCache = new();
+
+    /// <summary>
+    /// Clears the cached formatters.
+    /// </summary>
+    public static void ClearCache()
+    {
+        s_capturedValueFormatterCache.Clear();
+        s_methodInfoDataCache.Clear();
+    }
+
+    /// <summary>
+    /// Formats the given lambda expression into a string.
+    /// </summary>
+    /// <param name="expression">The lambda expression to format.</param>
+    /// <returns>The formatted string representation of the lambda expression.</returns>
+    public static string FormatLambda( LambdaExpression expression )
+    {
+        return FormatLambda( expression, prefix: null );
+    }
+
+    /// <summary>
+    /// Formats the given lambda expression into a string with an optional prefix.
+    /// </summary>
+    /// <param name="expression">The lambda expression to format.</param>
+    /// <param name="prefix">The prefix to prepend to the formatted string.</param>
+    /// <returns>The formatted string representation of the lambda expression with the prefix.</returns>
+    public static string FormatLambda( LambdaExpression expression, string? prefix = null )
+    {
+        var builder = new ReverseStringBuilder( stackalloc char[StackAllocBufferSize] );
+        var node = expression.Body;
+        var wasLastExpressionMemberAccess = false;
+        var wasLastExpressionIndexer = false;
+
+        while ( node is not null )
+        {
+            switch ( node.NodeType )
+            {
+                case ExpressionType.Constant:
+                    var constantExpression = (ConstantExpression)node;
+                    node = null;
+                    break;
+                case ExpressionType.Call:
+                    var methodCallExpression = (MethodCallExpression)node;
+
+                    if ( !IsSingleArgumentIndexer( methodCallExpression ) )
+                    {
+                        throw new InvalidOperationException( "Method calls cannot be formatted." );
+                    }
+
+                    node = methodCallExpression.Object;
+                    if ( prefix != null && node is ConstantExpression )
+                    {
+                        break;
+                    }
+
+                    if ( wasLastExpressionMemberAccess )
+                    {
+                        wasLastExpressionMemberAccess = false;
+                        builder.InsertFront( "." );
+                    }
+                    wasLastExpressionIndexer = true;
+
+                    builder.InsertFront( "]" );
+                    FormatIndexArgument( methodCallExpression.Arguments[0], ref builder );
+                    builder.InsertFront( "[" );
+
+                    break;
+
+                case ExpressionType.ArrayIndex:
+                    var binaryExpression = (BinaryExpression)node;
+                    node = binaryExpression.Left;
+                    if ( prefix != null && node is ConstantExpression )
+                    {
+                        break;
+                    }
+
+                    if ( wasLastExpressionMemberAccess )
+                    {
+                        wasLastExpressionMemberAccess = false;
+                        builder.InsertFront( "." );
+                    }
+
+                    builder.InsertFront( "]" );
+                    FormatIndexArgument( binaryExpression.Right, ref builder );
+                    builder.InsertFront( "[" );
+                    wasLastExpressionIndexer = true;
+                    break;
+
+                case ExpressionType.MemberAccess:
+                    var memberExpression = (MemberExpression)node;
+                    node = memberExpression.Expression;
+                    if ( prefix != null && node is ConstantExpression )
+                    {
+                        break;
+                    }
+
+                    if ( wasLastExpressionMemberAccess )
+                    {
+                        builder.InsertFront( "." );
+                    }
+                    wasLastExpressionMemberAccess = true;
+                    wasLastExpressionIndexer = false;
+
+                    var name = memberExpression.Member.GetCustomAttribute<DataMemberAttribute>()?.Name ?? memberExpression.Member.Name;
+                    builder.InsertFront( name );
+
+                    break;
+
+                default:
+                    // Unsupported expression type.
+                    node = null;
+                    break;
+            }
+        }
+
+        if ( prefix != null )
+        {
+            if ( !builder.Empty && !wasLastExpressionIndexer )
+            {
+                builder.InsertFront( "." );
+            }
+            builder.InsertFront( prefix );
+        }
+
+        var result = builder.ToString();
+
+        builder.Dispose();
+
+        return result;
+    }
+
+    internal static bool IsSingleArgumentIndexer( Expression expression )
+    {
+        if ( expression is not MethodCallExpression methodExpression || methodExpression.Arguments.Count != 1 )
+        {
+            return false;
+        }
+
+        var methodInfoData = GetOrCreateMethodInfoData( methodExpression.Method );
+        return methodInfoData.IsSingleArgumentIndexer;
+    }
+
+    private static MethodInfoData GetOrCreateMethodInfoData( MethodInfo methodInfo )
+    {
+        if ( !s_methodInfoDataCache.TryGetValue( methodInfo, out var methodInfoData ) )
+        {
+            methodInfoData = GetMethodInfoData( methodInfo );
+            s_methodInfoDataCache[methodInfo] = methodInfoData;
+        }
+
+        return methodInfoData;
+
+        [UnconditionalSuppressMessage( "Trimming", "IL2072", Justification = "The relevant members should be preserved since they were referenced in a LINQ expression" )]
+        static MethodInfoData GetMethodInfoData( MethodInfo methodInfo )
+        {
+            var declaringType = methodInfo.DeclaringType;
+            if ( declaringType is null )
+            {
+                return new( isSingleArgumentIndexer: false );
+            }
+
+            // Check whether GetDefaultMembers() (if present in CoreCLR) would return a member of this type. Compiler
+            // names the indexer property, if any, in a generated [DefaultMember] attribute for the containing type.
+            var defaultMember = declaringType.GetCustomAttribute<DefaultMemberAttribute>( inherit: true );
+            if ( defaultMember is null )
+            {
+                return new( isSingleArgumentIndexer: false );
+            }
+
+            // Find default property (the indexer) and confirm its getter is the method in this expression.
+            var runtimeProperties = declaringType.GetRuntimeProperties();
+            if ( runtimeProperties is null )
+            {
+                return new( isSingleArgumentIndexer: false );
+            }
+
+            foreach ( var property in runtimeProperties )
+            {
+                if ( string.Equals( defaultMember.MemberName, property.Name, StringComparison.Ordinal ) &&
+                    property.GetMethod == methodInfo )
+                {
+                    return new( isSingleArgumentIndexer: true );
+                }
+            }
+
+            return new( isSingleArgumentIndexer: false );
+        }
+    }
+
+    private static void FormatIndexArgument(
+        Expression indexExpression,
+        ref ReverseStringBuilder builder )
+    {
+        switch ( indexExpression )
+        {
+            case MemberExpression memberExpression when memberExpression.Expression is ConstantExpression constantExpression:
+                FormatCapturedValue( memberExpression, constantExpression, ref builder );
+                break;
+            case ConstantExpression constantExpression:
+                FormatConstantValue( constantExpression, ref builder );
+                break;
+            default:
+                throw new InvalidOperationException( $"Unable to evaluate index expressions of type '{indexExpression.GetType().Name}'." );
+        }
+    }
+
+    internal static string FormatIndexArgument(
+        Expression indexExpression )
+    {
+        var builder = new ReverseStringBuilder( stackalloc char[StackAllocBufferSize] );
+        try
+        {
+            FormatIndexArgument( indexExpression, ref builder );
+            var result = builder.ToString();
+            return result;
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+    }
+
+    private static void FormatCapturedValue( MemberExpression memberExpression, ConstantExpression constantExpression, ref ReverseStringBuilder builder )
+    {
+        var member = memberExpression.Member;
+        if ( !s_capturedValueFormatterCache.TryGetValue( member, out var format ) )
+        {
+            format = CreateCapturedValueFormatter( memberExpression );
+            s_capturedValueFormatterCache[member] = format;
+        }
+
+        format( constantExpression.Value!, ref builder );
+    }
+
+    private static CapturedValueFormatter CreateCapturedValueFormatter( MemberExpression memberExpression )
+    {
+        var memberType = memberExpression.Type;
+
+        if ( memberType == typeof( int ) )
+        {
+            var func = CompileMemberEvaluator<int>( memberExpression );
+            return ( object closure, ref ReverseStringBuilder builder ) => builder.InsertFront( func.Invoke( closure ) );
+        }
+        else if ( memberType == typeof( string ) )
+        {
+            var func = CompileMemberEvaluator<string>( memberExpression );
+            return ( object closure, ref ReverseStringBuilder builder ) => builder.InsertFront( func.Invoke( closure ) );
+        }
+        else if ( typeof( ISpanFormattable ).IsAssignableFrom( memberType ) )
+        {
+            var func = CompileMemberEvaluator<ISpanFormattable>( memberExpression );
+            return ( object closure, ref ReverseStringBuilder builder ) => builder.InsertFront( func.Invoke( closure ) );
+        }
+        else if ( typeof( IFormattable ).IsAssignableFrom( memberType ) )
+        {
+            var func = CompileMemberEvaluator<IFormattable>( memberExpression );
+            return ( object closure, ref ReverseStringBuilder builder ) => builder.InsertFront( func.Invoke( closure ) );
+        }
+        else
+        {
+            throw new InvalidOperationException( $"Cannot format an index argument of type '{memberType}'." );
+        }
+
+        static Func<object, TResult> CompileMemberEvaluator<TResult>( MemberExpression memberExpression )
+        {
+            var parameterExpression = Expression.Parameter( typeof( object ) );
+            var convertExpression = Expression.Convert( parameterExpression, memberExpression.Member.DeclaringType! );
+            var replacedMemberExpression = memberExpression.Update( convertExpression );
+            var replacedExpression = Expression.Lambda<Func<object, TResult>>( replacedMemberExpression, parameterExpression );
+            return replacedExpression.Compile();
+        }
+    }
+
+    private static void FormatConstantValue( ConstantExpression constantExpression, ref ReverseStringBuilder builder )
+    {
+        switch ( constantExpression.Value )
+        {
+            case string s:
+                builder.InsertFront( s );
+                break;
+            case ISpanFormattable spanFormattable:
+                // This is better than the formattable case because we don't allocate an extra string.
+                builder.InsertFront( spanFormattable );
+                break;
+            case IFormattable formattable:
+                builder.InsertFront( formattable );
+                break;
+            case null:
+                builder.InsertFront( "null" );
+                break;
+            case var x:
+                throw new InvalidOperationException( $"Unable to format constant values of type '{x.GetType()}'." );
+        }
+    }
+
+    private readonly struct MethodInfoData
+    {
+        public bool IsSingleArgumentIndexer { get; }
+
+        public MethodInfoData( bool isSingleArgumentIndexer )
+        {
+            IsSingleArgumentIndexer = isSingleArgumentIndexer;
+        }
+    }
+}

--- a/Source/Blazorise/Utilities/Formatters/HtmlFieldPrefix.cs
+++ b/Source/Blazorise/Utilities/Formatters/HtmlFieldPrefix.cs
@@ -1,0 +1,95 @@
+﻿#region Using directives
+using System;
+using System.Linq.Expressions;
+#endregion
+
+namespace Blazorise.Utilities;
+
+/// <summary>
+/// Represents a prefix for HTML field names.
+/// </summary>
+/// <remarks>
+/// Copy from https://github.com/dotnet/aspnetcore/blob/ee4a0e9801c4e1e673d0373e1c51a6790de174cc/src/Components/Web/src/Forms/HtmlFieldPrefix.cs
+/// </remarks>
+public class HtmlFieldPrefix
+{
+    #region Members
+
+    private readonly LambdaExpression[] rest = Array.Empty<LambdaExpression>();
+
+    #endregion
+
+    #region Constructors
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HtmlFieldPrefix"/> class with the initial lambda expression.
+    /// </summary>
+    /// <param name="initial">The initial lambda expression.</param>
+    public HtmlFieldPrefix( LambdaExpression initial )
+    {
+        Initial = initial;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HtmlFieldPrefix"/> class with the specified lambda expressions.
+    /// </summary>
+    /// <param name="expression">The initial lambda expression.</param>
+    /// <param name="rest">The additional lambda expressions.</param>
+    public HtmlFieldPrefix( LambdaExpression expression, params LambdaExpression[] rest )
+        : this( expression )
+    {
+        this.rest = rest;
+    }
+
+    #endregion
+
+    #region Methods
+
+    /// <summary>
+    /// Combines the current HTML field prefix with another lambda expression.
+    /// </summary>
+    /// <param name="other">The lambda expression to combine with.</param>
+    /// <returns>A new <see cref="HtmlFieldPrefix"/> that includes the combined lambda expressions.</returns>
+    public HtmlFieldPrefix Combine( LambdaExpression other )
+    {
+        var restLength = rest?.Length ?? 0;
+        var length = restLength + 1;
+        var expressions = new LambdaExpression[length];
+        for ( var i = 0; i < restLength - 1; i++ )
+        {
+            expressions[i] = rest![i];
+        }
+
+        expressions[length - 1] = other;
+
+        return new HtmlFieldPrefix( Initial, expressions );
+    }
+
+    /// <summary>
+    /// Gets the field name for the given lambda expression.
+    /// </summary>
+    /// <param name="expression">The lambda expression to get the field name for.</param>
+    /// <returns>The field name as a string.</returns>
+    public string GetFieldName( LambdaExpression expression )
+    {
+        var prefix = ExpressionFormatter.FormatLambda( Initial );
+        var restLength = rest?.Length ?? 0;
+        for ( var i = 0; i < restLength; i++ )
+        {
+            prefix = ExpressionFormatter.FormatLambda( rest![i], prefix );
+        }
+
+        return ExpressionFormatter.FormatLambda( expression, prefix );
+    }
+
+    #endregion
+
+    #region Properties
+
+    /// <summary>
+    /// Gets the initial lambda expression.
+    /// </summary>
+    public LambdaExpression Initial { get; }
+
+    #endregion
+}


### PR DESCRIPTION
Closes #5592 

At first, I tried using `FieldIdentifier`, but we had several problems.

1. FieldIdentifier is only available on Validations. I tried to bring it down to input level, but it was too complex and it broke the validation. We can reconsider this for 2.0 as I have realized we had to break some APIs also.
2. The FieldIdentifier was generating invalid names, eg. `FieldName` instead of `Model.FieldName`.

So, I went and saw how they do it in .NET core. I have copied their helpers, who are internal only and brought them to Blazorise. Then, I used some of the code to generate the name attribute. simplified it, and made it to work with our components. It works as expected.

One problem, though. On our `Radio` component, we already have the `Name` parameter. I still need to see what to do with it.

I still want to see if there is only room for improvement. This is only a first run.

---

@mrpmorris Any chance you could test it?