### PR TITLE
ChartStreamingOptions: Change delay from int? to long?

### DIFF
--- a/Source/Extensions/Blazorise.Charts.Streaming/ChartStreamingOptions.cs
+++ b/Source/Extensions/Blazorise.Charts.Streaming/ChartStreamingOptions.cs
@@ -32,7 +32,7 @@ public class ChartStreamingOptions
     /// </summary>
     [JsonPropertyName( "delay" )]
     [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-    public int? Delay { get; set; } = 0;
+    public long? Delay { get; set; } = 0;
 
     /// <summary>
     /// Frequency at which the chart is drawn on a display (frames per second). This option can be set at chart level but not at axis level. Decrease this value to save CPU power (https://github.com/nagix/chartjs-plugin-streaming#lowering-cpu-usage).


### PR DESCRIPTION
## Changed the type of the Delay property of ChartStreamingOptions from int? to long?

Closes #5615

## How Has This Been Tested?

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] The PR is submitted to the correct branch (`master` for dev, `rel-1.x` for maintenance).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
