### PR TITLE
BlazoriseLicenseChecker: Null checks and apply defaults for unlicensed limits

### DIFF
--- a/Source/Blazorise/Licensing/BlazoriseLicenseChecker.cs
+++ b/Source/Blazorise/Licensing/BlazoriseLicenseChecker.cs
@@ -87,7 +87,7 @@ public sealed class BlazoriseLicenseChecker
     /// Null if no limit is set.
     /// </summary>
     /// <returns></returns>
-    public int? GetAutoCompleteRowsLimit()
+    public int? GetAutocompleteRowsLimit()
     {
         return blazoriseLicenseProvider.GetAutocompleteRowsLimit();
     }

--- a/Source/Blazorise/Licensing/BlazoriseLicenseLimitsHelper.cs
+++ b/Source/Blazorise/Licensing/BlazoriseLicenseLimitsHelper.cs
@@ -1,0 +1,57 @@
+﻿namespace Blazorise.Licensing;
+
+/// <summary>
+/// Ultimately provides sane defaults for Blazorise licensing, in case required scoped services are not provided
+/// </summary>
+public static class BlazoriseLicenseLimitsHelper
+{
+    /// <summary>
+    /// Returns the maximum number of rows that can be displayed.
+    /// Null if no limit is set.
+    /// </summary>
+    /// <returns></returns>
+    public static int? GetDataGridRowsLimit( BlazoriseLicenseChecker blazoriseLicenseChecker )
+    {
+        return blazoriseLicenseChecker is null ? BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_DATAGRID_MAX_ROWS : blazoriseLicenseChecker.GetDataGridRowsLimit();
+    }
+
+    /// <summary>
+    /// Returns the maximum number of rows that can be displayed.
+    /// Null if no limit is set.
+    /// </summary>
+    /// <returns></returns>
+    public static int? GetAutocompleteRowsLimit( BlazoriseLicenseChecker blazoriseLicenseChecker )
+    {
+        return blazoriseLicenseChecker is null ? BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_AUTOCOMPLETE_MAX_ROWS : blazoriseLicenseChecker.GetAutocompleteRowsLimit();
+    }
+
+    /// <summary>
+    /// Returns the maximum number of rows that can be displayed.
+    /// Null if no limit is set.
+    /// </summary>
+    /// <returns></returns>
+    public static int? GetChartsRowsLimit( BlazoriseLicenseChecker blazoriseLicenseChecker )
+    {
+        return blazoriseLicenseChecker is null ? BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_CHARTS_MAX_ROWS : blazoriseLicenseChecker.GetChartsRowsLimit();
+    }
+
+    /// <summary>
+    /// Returns the maximum number of rows that can be displayed.
+    /// Null if no limit is set.
+    /// </summary>
+    /// <returns></returns>
+    public static int? GetListViewRowsLimit( BlazoriseLicenseChecker blazoriseLicenseChecker )
+    {
+        return blazoriseLicenseChecker is null ? BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_LISTVIEW_MAX_ROWS : blazoriseLicenseChecker.GetListViewRowsLimit();
+    }
+
+    /// <summary>
+    /// Returns the maximum number of rows that can be displayed.
+    /// Null if no limit is set.
+    /// </summary>
+    /// <returns></returns>
+    public static int? GetTreeViewRowsLimit( BlazoriseLicenseChecker blazoriseLicenseChecker )
+    {
+        return blazoriseLicenseChecker is null ? BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_TREEVIEW_MAX_ROWS : blazoriseLicenseChecker.GetTreeViewRowsLimit();
+    }
+}

--- a/Source/Blazorise/Licensing/BlazoriseLicenseProvider.cs
+++ b/Source/Blazorise/Licensing/BlazoriseLicenseProvider.cs
@@ -14,6 +14,11 @@ namespace Blazorise.Licensing;
 public sealed class BlazoriseLicenseProvider
 {
     #region Members
+    internal const int DEFAULT_UNLICENSED_LIMIT_DATAGRID_MAX_ROWS = 1000;
+    internal const int DEFAULT_UNLICENSED_LIMIT_AUTOCOMPLETE_MAX_ROWS = 1000;
+    internal const int DEFAULT_UNLICENSED_LIMIT_CHARTS_MAX_ROWS = 10;
+    internal const int DEFAULT_UNLICENSED_LIMIT_LISTVIEW_MAX_ROWS = 1000;
+    internal const int DEFAULT_UNLICENSED_LIMIT_TREEVIEW_MAX_ROWS = 100;
 
     private static readonly Assembly CurrentAssembly = typeof( BlazoriseLicenseProvider ).Assembly;
 
@@ -205,7 +210,7 @@ public sealed class BlazoriseLicenseProvider
         }
         else if ( Result == BlazoriseLicenseResult.Unlicensed )
         {
-            limitsDataGridMaxRows = 1000;
+            limitsDataGridMaxRows = DEFAULT_UNLICENSED_LIMIT_DATAGRID_MAX_ROWS;
         }
 
         return limitsDataGridMaxRows;
@@ -233,7 +238,7 @@ public sealed class BlazoriseLicenseProvider
         }
         else if ( Result == BlazoriseLicenseResult.Unlicensed )
         {
-            limitsAutocompleteMaxRows = 1000;
+            limitsAutocompleteMaxRows = DEFAULT_UNLICENSED_LIMIT_AUTOCOMPLETE_MAX_ROWS;
         }
 
         return limitsAutocompleteMaxRows;
@@ -261,7 +266,7 @@ public sealed class BlazoriseLicenseProvider
         }
         else if ( Result == BlazoriseLicenseResult.Unlicensed )
         {
-            limitsChartsMaxRows = 10;
+            limitsChartsMaxRows = DEFAULT_UNLICENSED_LIMIT_CHARTS_MAX_ROWS;
         }
 
         return limitsChartsMaxRows;
@@ -289,7 +294,7 @@ public sealed class BlazoriseLicenseProvider
         }
         else if ( Result == BlazoriseLicenseResult.Unlicensed )
         {
-            limitsListViewMaxRows = 1000;
+            limitsListViewMaxRows = DEFAULT_UNLICENSED_LIMIT_LISTVIEW_MAX_ROWS;
         }
 
         return limitsListViewMaxRows;
@@ -317,7 +322,7 @@ public sealed class BlazoriseLicenseProvider
         }
         else if ( Result == BlazoriseLicenseResult.Unlicensed )
         {
-            limitsTreeViewMaxRows = 100;
+            limitsTreeViewMaxRows = DEFAULT_UNLICENSED_LIMIT_TREEVIEW_MAX_ROWS;
         }
 
         return limitsTreeViewMaxRows;

--- a/Source/Extensions/Blazorise.Charts/BaseChart.cs
+++ b/Source/Extensions/Blazorise.Charts/BaseChart.cs
@@ -79,7 +79,7 @@ public class BaseChart<TDataSet, TItem, TOptions, TModel> : BaseChart<TItem>, IB
         if ( datasets.IsNullOrEmpty() )
             return;
 
-        var chartsRowLimit = LicenseChecker.GetChartsRowsLimit();
+        var chartsRowLimit = BlazoriseLicenseLimitsHelper.GetChartsRowsLimit( LicenseChecker );
 
         if ( !chartsRowLimit.HasValue )
             return;
@@ -92,7 +92,7 @@ public class BaseChart<TDataSet, TItem, TOptions, TModel> : BaseChart<TItem>, IB
 
     private List<TItem> LimitData( List<TItem> data )
     {
-        var chartsRowLimit = LicenseChecker.GetChartsRowsLimit();
+        var chartsRowLimit = BlazoriseLicenseLimitsHelper.GetChartsRowsLimit( LicenseChecker );
 
         if ( !chartsRowLimit.HasValue )
             return data;

--- a/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
+++ b/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
@@ -862,7 +862,7 @@ public partial class Autocomplete<TItem, TValue> : BaseAfterRenderComponent, IAs
             }
         }
 
-        var maxRowsLimit = LicenseChecker.GetAutoCompleteRowsLimit();
+        var maxRowsLimit = BlazoriseLicenseLimitsHelper.GetAutocompleteRowsLimit( LicenseChecker );
 
         if ( maxRowsLimit.HasValue )
         {

--- a/Source/Extensions/Blazorise.Components/ListView.razor.cs
+++ b/Source/Extensions/Blazorise.Components/ListView.razor.cs
@@ -21,7 +21,7 @@ public partial class ListView<TItem> : ComponentBase
 
     private IEnumerable<TItem> GetData()
     {
-        var maxRowsLimit = LicenseChecker.GetListViewRowsLimit();
+        var maxRowsLimit = BlazoriseLicenseLimitsHelper.GetListViewRowsLimit( LicenseChecker );
 
         if ( maxRowsLimit.HasValue )
         {

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -2357,7 +2357,7 @@ public partial class DataGrid<TItem> : BaseDataGridComponent
             }
         }
 
-        var maxRowsLimit = LicenseChecker.GetDataGridRowsLimit();
+        var maxRowsLimit = BlazoriseLicenseLimitsHelper.GetDataGridRowsLimit( LicenseChecker );
 
         if ( maxRowsLimit.HasValue )
         {

--- a/Source/Extensions/Blazorise.TreeView/TreeView.razor.cs
+++ b/Source/Extensions/Blazorise.TreeView/TreeView.razor.cs
@@ -10,7 +10,6 @@ using Blazorise.TreeView.Extensions;
 using Blazorise.TreeView.Internal;
 using Blazorise.Utilities;
 using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Web;
 #endregion
 
 namespace Blazorise.TreeView;
@@ -131,8 +130,6 @@ public partial class TreeView<TNode> : BaseComponent, IDisposable
     /// <returns>Returns the awaitable task.</returns>
     public async Task Reload()
     {
-        var maxRowsLimit = LicenseChecker.GetTreeViewRowsLimit();
-
         treeViewNodeStates = new();
 
         await foreach ( var nodeState in Nodes.ToNodeStates( HasChildNodesAsync, DetermineHasChildNodes, ( node ) => ExpandedNodes?.Contains( node ) == true, DetermineIsDisabled ) )
@@ -145,7 +142,7 @@ public partial class TreeView<TNode> : BaseComponent, IDisposable
 
     private void AddTreeViewNodeState( TreeViewNodeState<TNode> treeViewNodeState )
     {
-        var maxRowsLimit = LicenseChecker.GetTreeViewRowsLimit();
+        var maxRowsLimit = BlazoriseLicenseLimitsHelper.GetTreeViewRowsLimit( LicenseChecker );
 
         if ( maxRowsLimit.HasValue )
         {


### PR DESCRIPTION
Well it is not the first time we hear about someone complaining about a null in `BlazoriseLicenseChecker`.
Although typically this should not be null as per our standard **Blazorise** registration.

This should make sure that users can't try to game the system by removing the service from the DI Container, by assuming the user as unlicensed if `BlazoriseLicenseChecker` is null.
Also gives the flexibility for users to initialize the services themselves, and if they happen to not initialize the `BlazoriseLicenseChecker`, then we still don't throw an exception, but still apply our limits.

The naming of the class can change if you wish, I went back and forth with a few but ultimately, stating that the purpose of it is related to `BlazoriseLicenseLimits` seems fine, the suffix can change if you prefer something like `Manager`, `Utils`, or whatever else.

**PS:** Also it could probably be extensions in the `LicenseChecker` that check whether it is null itself? But I think this is clearer? Let me know your thoughts.

closes #5647