### PR TITLE
TransferList: Do not mutate the Items collection

### DIFF
--- a/Source/Extensions/Blazorise.Components/TransferList.razor.cs
+++ b/Source/Extensions/Blazorise.Components/TransferList.razor.cs
@@ -39,8 +39,8 @@ public partial class TransferList<TItem> : ComponentBase
         if ( bothListsEmpty )
         {
             // If both lists are empty, then we just start with the items in the start list.
-            ItemsStart = Items;
-            ItemsStartChanged.InvokeAsync( Items );
+            ItemsStart = Items.ToList();
+            ItemsStartChanged.InvokeAsync( ItemsStart );
         }
         else if ( startNotEmptyButEndEmpty )
         {


### PR DESCRIPTION
- Fixes an issue where if the user provides `Items` and both **start** and **end** lists are **empty**. Then the Items was assigned by reference to `ItemsStart` causing it to mutate on internal changes.