### PR TITLE
Autocomplete: Allow repeated texts

### DIFF
--- a/Documentation/Blazorise.Docs/Pages/News/2024-10-15-release-notes-170.razor
+++ b/Documentation/Blazorise.Docs/Pages/News/2024-10-15-release-notes-170.razor
@@ -58,6 +58,14 @@
 </NewsPageSubtitle>
 
 <Heading Size="HeadingSize.Is3">
+    Autocomplete
+</Heading>
+
+<Paragraph>
+    There was a limitation where the Autocomplete would not handle Texts that were repeated correctly. The Autocomplete should now allow you to have repeated Texts, it is of note that the values should still be unique and it should work as expected.
+</Paragraph>
+
+<Heading Size="HeadingSize.Is3">
     Optimizations
 </Heading>
 

--- a/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
+++ b/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
@@ -496,7 +496,8 @@ public partial class Autocomplete<TItem, TValue> : BaseAfterRenderComponent, IAs
         }
         else
         {
-            if ( !IsSelectedvalue( GetItemValue( Search ) ) )
+            var itemValues = GetItemValues( Search );
+            if ( itemValues.IsNullOrEmpty() || !itemValues.Any( IsSelectedvalue ) )
             {
                 if ( !FreeTyping )
                 {
@@ -1060,6 +1061,11 @@ public partial class Autocomplete<TItem, TValue> : BaseAfterRenderComponent, IAs
         return FreeTyping ? Search?.ToString() : SelectedValue?.ToString();
     }
 
+    /// <summary>
+    /// Gets the text of the <typeparamref name="TValue"/>.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <returns></returns>
     private string GetItemText( TValue value )
     {
         var item = GetItemByValue( value );
@@ -1069,6 +1075,11 @@ public partial class Autocomplete<TItem, TValue> : BaseAfterRenderComponent, IAs
             : GetItemText( item );
     }
 
+    /// <summary>
+    /// Gets the text of the <typeparamref name="TItem"/>.
+    /// </summary>
+    /// <param name="item"></param>
+    /// <returns></returns>
     private string GetItemText( TItem item )
     {
         if ( item is null )
@@ -1077,6 +1088,27 @@ public partial class Autocomplete<TItem, TValue> : BaseAfterRenderComponent, IAs
         return TextField?.Invoke( item ) ?? string.Empty;
     }
 
+
+
+    /// <summary>
+    /// Gets multiple values from <see cref="Data"/> by using the provided <see cref="TextField"/> and <see cref="ValueField"/>.
+    /// </summary>
+    /// <param name="text"></param>
+    /// <returns></returns>
+    private IEnumerable<TValue> GetItemValues( string text )
+    {
+        var items = GetItemsByText( text );
+
+        return items.IsNullOrEmpty()
+            ? Array.Empty<TValue>()
+            : items.Select( GetItemValue );
+    }
+
+    /// <summary>
+    /// Gets a <typeparamref name="TValue"/> from <see cref="Data"/> by using the provided <see cref="TextField"/>.
+    /// </summary>
+    /// <param name="text"></param>
+    /// <returns></returns>
     private TValue GetItemValue( string text )
     {
         var item = GetItemByText( text );
@@ -1086,6 +1118,11 @@ public partial class Autocomplete<TItem, TValue> : BaseAfterRenderComponent, IAs
             : GetItemValue( item );
     }
 
+    /// <summary>
+    /// Gets a <typeparamref name="TValue"/> from <see cref="Data"/> by using the provided <see cref="ValueField"/>.
+    /// </summary>
+    /// <param name="item"></param>
+    /// <returns></returns>
     private TValue GetItemValue( TItem item )
     {
         if ( item is null || ValueField == null )
@@ -1113,6 +1150,16 @@ public partial class Autocomplete<TItem, TValue> : BaseAfterRenderComponent, IAs
         => Data is not null
                ? Data.FirstOrDefault( x => TextField( x ).IsEqual( text ) )
                : default;
+
+    /// <summary>
+    /// Gets multiple items from <see cref="Data"/> by using the provided <see cref="TextField"/>.
+    /// </summary>
+    /// <param name="text"></param>
+    /// <returns></returns>
+    public IEnumerable<TItem> GetItemsByText( string text )
+        => Data is not null
+               ? Data.Where( x => TextField( x ).IsEqual( text ) )
+               : Array.Empty<TItem>();
 
     /// <summary>
     /// Gets a <typeparamref name="TValue"/> from <see cref="SelectedValues"/> by using the provided <see cref="TextField"/> and <see cref="ValueField"/>.


### PR DESCRIPTION
This should make it so that when the field is left or committed our internal check does not reset the value because it does not find a matching value.

So basically now we have a `GetItemValues` and `GetItemsByText` so we can get multiple items / values out of a single text.

**Testing Code:**
```

<Row>
    <Column ColumnSize="ColumnSize.IsFull.OnMobile.IsHalf.OnTablet">
        <Card Margin="Margin.Is4.OnY">
            <CardHeader>
                <CardTitle>Autocomplete</CardTitle>
            </CardHeader>
            <CardBody>
                <Field Horizontal JustifyContent="JustifyContent.End">
                    <FieldLabel ColumnSize="ColumnSize.Is2">Select Value</FieldLabel>
                    <FieldBody ColumnSize="ColumnSize.Is10">
                        <Autocomplete TItem="Country"
                                      TValue="string"
                                      Data="@Countries"
                                      TextField="@(( item ) => item.Name)"
                                      ValueField="@((item) => item.Iso)"
                                      @bind-SelectedValue="selectedAutoCompleteSearchValue"
                                      @bind-SelectedText="selectedAutoCompleteText"
                                      Placeholder="Search..."
                                      Filter="AutocompleteFilter.StartsWith">
                            <NotFoundContent> Sorry... @context was not found! :( </NotFoundContent>
                            <ItemContent>
                                <Div Flex="Flex.InlineFlex.JustifyContent.Between" Width="Width.Is100">
                                    <Heading Margin="Margin.Is2.FromBottom">@context.Value</Heading>
                                    <Small>@context.Item.Capital</Small>
                                </Div>
                                <Paragraph Margin="Margin.Is2.FromBottom">@context.Text</Paragraph>
                            </ItemContent>
                        </Autocomplete>
                    </FieldBody>
                </Field>
                <Field Horizontal JustifyContent="JustifyContent.End">
                    <FieldBody ColumnSize="ColumnSize.Is10.Is2.WithOffset">
                        Selected value: @selectedAutoCompleteSearchValue
                    </FieldBody>
                    <FieldBody ColumnSize="ColumnSize.Is10.Is2.WithOffset">
                        Selected text value: @selectedAutoCompleteText
                    </FieldBody>
                </Field>
            </CardBody>
        </Card>
    </Column>
</Row>

@code{
    private List<Country> Countries { get; set; } = new List<Country>() { new( "Portugal1", "PT", "Lisbon" ), new( "Portugal", "PT", "Lisbon" ), new( "Portugal", "PT-BR", "Lisbon" ), new( "Portugal", "PT-PT", "Lisbon" ), new( "France", "fr", "Paris" ), new( "Poland", "pl", "Warsaw" ) };

    private string selectedAutoCompleteSearchValue { get; set; }
    private string selectedAutoCompleteText { get; set; }

}

```