### PR TITLE
Refactor input components initialization

### DIFF
--- a/Source/Blazorise/Base/BaseComponent.cs
+++ b/Source/Blazorise/Base/BaseComponent.cs
@@ -88,8 +88,22 @@ public abstract class BaseComponent : BaseAfterRenderComponent
 
     #region Methods
 
+    /// <summary>
+    /// Method called before setting the parameters.
+    /// </summary>
+    /// <param name="parameters">The parameters that will be passed to the component.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    protected virtual Task OnBeforeSetParametersAsync( ParameterView parameters ) => Task.CompletedTask;
+
+    /// <summary>
+    /// Method called after the parameters are set.
+    /// </summary>
+    /// <param name="parameters">The parameters that have been set on the component.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    protected virtual Task OnAfterSetParametersAsync( ParameterView parameters ) => Task.CompletedTask;
+
     /// <inheritdoc/>
-    public override Task SetParametersAsync( ParameterView parameters )
+    public override async Task SetParametersAsync( ParameterView parameters )
     {
         object heightAttribute = null;
 
@@ -117,10 +131,22 @@ public abstract class BaseComponent : BaseAfterRenderComponent
                 Attributes.Add( "height", heightAttribute );
             }
 
-            return base.SetParametersAsync( ParameterView.FromDictionary( parametersDictionary ) );
+            var newParameters = ParameterView.FromDictionary( parametersDictionary );
+
+            await OnBeforeSetParametersAsync( newParameters );
+
+            await base.SetParametersAsync( newParameters );
+
+            await OnAfterSetParametersAsync( newParameters );
+
+            return;
         }
 
-        return base.SetParametersAsync( parameters );
+        await OnBeforeSetParametersAsync( parameters );
+
+        await base.SetParametersAsync( parameters );
+
+        await OnAfterSetParametersAsync( parameters );
     }
 
     /// <inheritdoc/>

--- a/Source/Blazorise/Base/BaseComponent.cs
+++ b/Source/Blazorise/Base/BaseComponent.cs
@@ -88,22 +88,8 @@ public abstract class BaseComponent : BaseAfterRenderComponent
 
     #region Methods
 
-    /// <summary>
-    /// Method called before setting the parameters.
-    /// </summary>
-    /// <param name="parameters">The parameters that will be passed to the component.</param>
-    /// <returns>A task that represents the asynchronous operation.</returns>
-    protected virtual Task OnBeforeSetParametersAsync( ParameterView parameters ) => Task.CompletedTask;
-
-    /// <summary>
-    /// Method called after the parameters are set.
-    /// </summary>
-    /// <param name="parameters">The parameters that have been set on the component.</param>
-    /// <returns>A task that represents the asynchronous operation.</returns>
-    protected virtual Task OnAfterSetParametersAsync( ParameterView parameters ) => Task.CompletedTask;
-
     /// <inheritdoc/>
-    public override async Task SetParametersAsync( ParameterView parameters )
+    public override Task SetParametersAsync( ParameterView parameters )
     {
         object heightAttribute = null;
 
@@ -131,22 +117,10 @@ public abstract class BaseComponent : BaseAfterRenderComponent
                 Attributes.Add( "height", heightAttribute );
             }
 
-            var newParameters = ParameterView.FromDictionary( parametersDictionary );
-
-            await OnBeforeSetParametersAsync( newParameters );
-
-            await base.SetParametersAsync( newParameters );
-
-            await OnAfterSetParametersAsync( newParameters );
-
-            return;
+            return base.SetParametersAsync( ParameterView.FromDictionary( parametersDictionary ) );
         }
 
-        await OnBeforeSetParametersAsync( parameters );
-
-        await base.SetParametersAsync( parameters );
-
-        await OnAfterSetParametersAsync( parameters );
+        return base.SetParametersAsync( parameters );
     }
 
     /// <inheritdoc/>

--- a/Source/Blazorise/Base/BaseInputComponent.razor.cs
+++ b/Source/Blazorise/Base/BaseInputComponent.razor.cs
@@ -126,6 +126,16 @@ public abstract class BaseInputComponent<TValue> : BaseComponent, IValidationInp
     }
 
     /// <inheritdoc/>
+    public override async Task SetParametersAsync( ParameterView parameters )
+    {
+        await OnBeforeSetParametersAsync( parameters );
+
+        await base.SetParametersAsync( parameters );
+
+        await OnAfterSetParametersAsync( parameters );
+    }
+
+    /// <inheritdoc/>
     protected override void OnInitialized()
     {
         if ( Theme is not null )

--- a/Source/Blazorise/Base/BaseInputComponent.razor.cs
+++ b/Source/Blazorise/Base/BaseInputComponent.razor.cs
@@ -72,10 +72,8 @@ public abstract class BaseInputComponent<TValue> : BaseComponent, IValidationInp
     /// </summary>
     /// <param name="parameters">The parameters that will be passed to the component.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
-    protected override async Task OnBeforeSetParametersAsync( ParameterView parameters )
+    protected virtual Task OnBeforeSetParametersAsync( ParameterView parameters )
     {
-        await base.OnBeforeSetParametersAsync( parameters );
-
         InitializeParameters();
 
         if ( Rendered )
@@ -85,6 +83,8 @@ public abstract class BaseInputComponent<TValue> : BaseComponent, IValidationInp
                 ExecuteAfterRender( Revalidate );
             }
         }
+
+        return Task.CompletedTask;
     }
 
     /// <summary>
@@ -92,7 +92,7 @@ public abstract class BaseInputComponent<TValue> : BaseComponent, IValidationInp
     /// </summary>
     /// <param name="parameters">The parameters that have been set on the component.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
-    protected override async Task OnAfterSetParametersAsync( ParameterView parameters )
+    protected virtual async Task OnAfterSetParametersAsync( ParameterView parameters )
     {
         if ( ParentValidation is not null )
         {
@@ -123,8 +123,6 @@ public abstract class BaseInputComponent<TValue> : BaseComponent, IValidationInp
                 ParentFocusableContainer?.NotifyFocusableComponentRemoved( this );
             }
         }
-
-        await base.OnAfterSetParametersAsync( parameters );
     }
 
     /// <inheritdoc/>

--- a/Source/Blazorise/Base/BaseInputComponent.razor.cs
+++ b/Source/Blazorise/Base/BaseInputComponent.razor.cs
@@ -78,7 +78,7 @@ public abstract class BaseInputComponent<TValue> : BaseComponent, IValidationInp
 
         if ( Rendered )
         {
-            if ( parameters.TryGetParameter( nameof( Value ), Value, out paramValue ) && paramValue.Changed )
+            if ( parameters.TryGetParameter( nameof( Value ), Value, IsSameAsInternalValue, out paramValue ) && paramValue.Changed )
             {
                 ExecuteAfterRender( Revalidate );
             }

--- a/Source/Blazorise/Base/BaseTextInput.razor.cs
+++ b/Source/Blazorise/Base/BaseTextInput.razor.cs
@@ -1,5 +1,6 @@
 ﻿#region Using directives
 using System;
+using System.Linq.Expressions;
 using System.Threading.Tasks;
 using Blazorise.Utilities;
 using Microsoft.AspNetCore.Components;
@@ -23,6 +24,25 @@ public abstract class BaseTextInput<TValue> : BaseInputComponent<TValue>, ISelec
     #endregion
 
     #region Methods
+
+    /// <inheritdoc/>
+    protected override async Task OnAfterSetParametersAsync( ParameterView parameters )
+    {
+        if ( ParentValidation is not null )
+        {
+            if ( parameters.TryGetValue<string>( nameof( Pattern ), out var paramPattern ) )
+            {
+                // make sure we get the newest value
+                var newValue = paramValue.Defined
+                    ? paramValue.Value
+                    : Value;
+
+                await ParentValidation.InitializeInputPattern( paramPattern, newValue );
+            }
+        }
+
+        await base.OnAfterSetParametersAsync( parameters );
+    }
 
     /// <inheritdoc/>
     protected override void OnInitialized()

--- a/Source/Blazorise/Components/Check/Check.razor.cs
+++ b/Source/Blazorise/Components/Check/Check.razor.cs
@@ -26,23 +26,7 @@ public partial class Check<TValue> : BaseCheckComponent<TValue>
     /// <inheritdoc/>
     public override async Task SetParametersAsync( ParameterView parameters )
     {
-        if ( Rendered )
-        {
-            if ( parameters.TryGetValue<TValue>( nameof( Value ), out var paramValue ) && !paramValue.IsEqual( Value ) )
-            {
-                ExecuteAfterRender( Revalidate );
-            }
-        }
-
         await base.SetParametersAsync( parameters );
-
-        if ( ParentValidation is not null )
-        {
-            if ( parameters.TryGetValue<Expression<Func<TValue>>>( nameof( ValueExpression ), out var expression ) )
-                await ParentValidation.InitializeInputExpression( expression );
-
-            await InitializeValidation();
-        }
 
         if ( parameters.TryGetValue<bool?>( nameof( Indeterminate ), out var indeterminate ) && this.indeterminate != indeterminate )
         {

--- a/Source/Blazorise/Components/ColorEdit/ColorEdit.razor.cs
+++ b/Source/Blazorise/Components/ColorEdit/ColorEdit.razor.cs
@@ -17,28 +17,6 @@ public partial class ColorEdit : BaseInputComponent<string>, ISelectableComponen
     #region Methods
 
     /// <inheritdoc/>
-    public override async Task SetParametersAsync( ParameterView parameters )
-    {
-        if ( Rendered )
-        {
-            if ( parameters.TryGetValue<string>( nameof( Value ), out var paramValue ) && !paramValue.IsEqual( Value ) )
-            {
-                ExecuteAfterRender( Revalidate );
-            }
-        }
-
-        await base.SetParametersAsync( parameters );
-
-        if ( ParentValidation is not null )
-        {
-            if ( parameters.TryGetValue<Expression<Func<string>>>( nameof( ValueExpression ), out var expression ) )
-                await ParentValidation.InitializeInputExpression( expression );
-
-            await InitializeValidation();
-        }
-    }
-
-    /// <inheritdoc/>
     protected override void BuildClasses( ClassBuilder builder )
     {
         builder.Append( ClassProvider.ColorEdit() );

--- a/Source/Blazorise/Components/ColorPicker/ColorPicker.razor.cs
+++ b/Source/Blazorise/Components/ColorPicker/ColorPicker.razor.cs
@@ -29,18 +29,19 @@ public partial class ColorPicker : BaseInputComponent<string>, ISelectableCompon
     #region Methods
 
     /// <inheritdoc/>
-    public override async Task SetParametersAsync( ParameterView parameters )
+    protected override async Task OnBeforeSetParametersAsync( ParameterView parameters )
     {
-        var valueChanged = parameters.TryGetValue<string>( nameof( Value ), out var paramValue ) && !Value.IsEqual( paramValue );
+        await base.OnBeforeSetParametersAsync( parameters );
+
         var paletteChanged = parameters.TryGetValue( nameof( Palette ), out string[] paramPalette ) && !Palette.AreEqual( paramPalette );
         var showPaletteChanged = parameters.TryGetValue( nameof( ShowPalette ), out bool paramShowPalette ) && ShowPalette != paramShowPalette;
         var hideAfterPaletteSelectChanged = parameters.TryGetValue( nameof( HideAfterPaletteSelect ), out bool paramHideAfterPaletteSelect ) && HideAfterPaletteSelect != paramHideAfterPaletteSelect;
         var disabledChanged = parameters.TryGetValue( nameof( Disabled ), out bool paramDisabled ) && Disabled != paramDisabled;
         var readOnlyChanged = parameters.TryGetValue( nameof( ReadOnly ), out bool paramReadOnly ) && ReadOnly != paramReadOnly;
 
-        if ( valueChanged )
+        if ( paramValue.Changed )
         {
-            await CurrentValueHandler( paramValue );
+            await CurrentValueHandler( paramValue.Value );
 
             if ( Rendered )
             {
@@ -62,16 +63,6 @@ public partial class ColorPicker : BaseInputComponent<string>, ISelectableCompon
                 Disabled = new { Changed = disabledChanged, Value = paramDisabled },
                 ReadOnly = new { Changed = readOnlyChanged, Value = paramReadOnly },
             } ) );
-        }
-
-        await base.SetParametersAsync( parameters );
-
-        if ( ParentValidation is not null )
-        {
-            if ( parameters.TryGetValue<Expression<Func<string>>>( nameof( ValueExpression ), out var expression ) )
-                await ParentValidation.InitializeInputExpression( expression );
-
-            await InitializeValidation();
         }
     }
 

--- a/Source/Blazorise/Components/DateEdit/DateEdit.razor.cs
+++ b/Source/Blazorise/Components/DateEdit/DateEdit.razor.cs
@@ -19,38 +19,6 @@ public partial class DateEdit<TValue> : BaseTextInput<TValue>
     #region Methods
 
     /// <inheritdoc/>
-    public override async Task SetParametersAsync( ParameterView parameters )
-    {
-        if ( Rendered )
-        {
-            if ( parameters.TryGetValue<TValue>( nameof( Value ), out var paramValue ) && !paramValue.IsEqual( Value ) )
-            {
-                ExecuteAfterRender( Revalidate );
-            }
-        }
-
-        await base.SetParametersAsync( parameters );
-
-        if ( ParentValidation is not null )
-        {
-            if ( parameters.TryGetValue<Expression<Func<TValue>>>( nameof( ValueExpression ), out var expression ) )
-                await ParentValidation.InitializeInputExpression( expression );
-
-            if ( parameters.TryGetValue<string>( nameof( Pattern ), out var paramPattern ) )
-            {
-                // make sure we get the newest value
-                var newValue = parameters.TryGetValue<TValue>( nameof( Value ), out var paramValue )
-                    ? paramValue
-                    : Value;
-
-                await ParentValidation.InitializeInputPattern( paramPattern, newValue );
-            }
-
-            await InitializeValidation();
-        }
-    }
-
-    /// <inheritdoc/>
     protected override void BuildClasses( ClassBuilder builder )
     {
         builder.Append( ClassProvider.DateEdit( Plaintext ) );

--- a/Source/Blazorise/Components/DatePicker/DatePicker.razor.cs
+++ b/Source/Blazorise/Components/DatePicker/DatePicker.razor.cs
@@ -37,13 +37,12 @@ public partial class DatePicker<TValue> : BaseTextInput<TValue>, IAsyncDisposabl
     #region Methods
 
     /// <inheritdoc/>
-    public override async Task SetParametersAsync( ParameterView parameters )
+    protected override async Task OnBeforeSetParametersAsync( ParameterView parameters )
     {
-        var valueDefined = parameters.TryGetValue( nameof( Value ), out TValue paramValue );
+        await base.OnBeforeSetParametersAsync( parameters );
 
         if ( Rendered )
         {
-            var valueChanged = !IsSameAsInternalValue( paramValue );
             var minChanged = parameters.TryGetValue( nameof( Min ), out DateTimeOffset? paramMin ) && !Min.IsEqual( paramMin );
             var maxChanged = parameters.TryGetValue( nameof( Max ), out DateTimeOffset? paramMax ) && !Max.IsEqual( paramMax );
             var firstDayOfWeekChanged = parameters.TryGetValue( nameof( FirstDayOfWeek ), out DayOfWeek paramFirstDayOfWeek ) && !FirstDayOfWeek.IsEqual( paramFirstDayOfWeek );
@@ -60,9 +59,9 @@ public partial class DatePicker<TValue> : BaseTextInput<TValue>, IAsyncDisposabl
             var placeholderChanged = parameters.TryGetValue( nameof( Placeholder ), out string paramPlaceholder ) && Placeholder != paramPlaceholder;
             var staticPickerChanged = parameters.TryGetValue( nameof( StaticPicker ), out bool paramSaticPicker ) && StaticPicker != paramSaticPicker;
 
-            if ( valueChanged )
+            if ( paramValue.Changed )
             {
-                var formatedDateString = FormatValueAsString( paramValue );
+                var formatedDateString = FormatValueAsString( paramValue.Value );
 
                 await CurrentValueHandler( formatedDateString );
 
@@ -107,26 +106,6 @@ public partial class DatePicker<TValue> : BaseTextInput<TValue>, IAsyncDisposabl
                     StaticPicker = new { Changed = staticPickerChanged, Value = paramSaticPicker },
                 } ) );
             }
-        }
-
-        // Let blazor do its thing!
-        await base.SetParametersAsync( parameters );
-
-        if ( ParentValidation is not null )
-        {
-            if ( parameters.TryGetValue<Expression<Func<TValue>>>( nameof( ValueExpression ), out var expression ) )
-                await ParentValidation.InitializeInputExpression( expression );
-
-            if ( parameters.TryGetValue<string>( nameof( Pattern ), out var paramPattern ) )
-            {
-                var newValue = valueDefined
-                    ? paramValue
-                    : Value;
-
-                await ParentValidation.InitializeInputPattern( paramPattern, newValue );
-            }
-
-            await InitializeValidation();
         }
     }
 

--- a/Source/Blazorise/Components/InputMask/InputMask.razor.cs
+++ b/Source/Blazorise/Components/InputMask/InputMask.razor.cs
@@ -28,38 +28,6 @@ public partial class InputMask : BaseTextInput<string>, IAsyncDisposable
     #region Methods
 
     /// <inheritdoc/>
-    public override async Task SetParametersAsync( ParameterView parameters )
-    {
-        if ( Rendered )
-        {
-            if ( parameters.TryGetValue<string>( nameof( Value ), out var paramValue ) && !paramValue.IsEqual( Value ) )
-            {
-                ExecuteAfterRender( Revalidate );
-            }
-        }
-
-        await base.SetParametersAsync( parameters );
-
-        if ( ParentValidation is not null )
-        {
-            if ( parameters.TryGetValue<Expression<Func<string>>>( nameof( ValueExpression ), out var expression ) )
-                await ParentValidation.InitializeInputExpression( expression );
-
-            if ( parameters.TryGetValue<string>( nameof( Pattern ), out var paramPattern ) )
-            {
-                // make sure we get the newest value
-                var newValue = parameters.TryGetValue<string>( nameof( Value ), out var paramValue )
-                    ? paramValue
-                    : Value;
-
-                await ParentValidation.InitializeInputPattern( paramPattern, newValue );
-            }
-
-            await InitializeValidation();
-        }
-    }
-
-    /// <inheritdoc/>
     protected override async Task OnFirstAfterRenderAsync()
     {
         dotNetObjectRef ??= CreateDotNetObjectRef( this );

--- a/Source/Blazorise/Components/MemoEdit/MemoEdit.razor.cs
+++ b/Source/Blazorise/Components/MemoEdit/MemoEdit.razor.cs
@@ -25,8 +25,10 @@ public partial class MemoEdit : BaseInputComponent<string>, ISelectableComponent
     #region Methods
 
     /// <inheritdoc/>
-    public override async Task SetParametersAsync( ParameterView parameters )
+    protected override async Task OnBeforeSetParametersAsync( ParameterView parameters )
     {
+        await base.OnBeforeSetParametersAsync( parameters );
+
         var replaceTabChanged = parameters.TryGetValue( nameof( ReplaceTab ), out bool paramReplaceTab ) && ReplaceTab != paramReplaceTab;
         var tabSizeChanged = parameters.TryGetValue( nameof( TabSize ), out int paramTabSize ) && TabSize != paramTabSize;
         var softTabsChanged = parameters.TryGetValue( nameof( SoftTabs ), out bool paramSoftTabs ) && SoftTabs != paramSoftTabs;
@@ -60,26 +62,6 @@ public partial class MemoEdit : BaseInputComponent<string>, ISelectableComponent
                     }
                 } );
             }
-        }
-
-        await base.SetParametersAsync( parameters );
-
-        if ( ParentValidation is not null )
-        {
-            if ( parameters.TryGetValue<Expression<Func<string>>>( nameof( ValueExpression ), out var expression ) )
-                await ParentValidation.InitializeInputExpression( expression );
-
-            if ( parameters.TryGetValue<string>( nameof( Pattern ), out var paramPattern ) )
-            {
-                // make sure we get the newest value
-                var newValue = parameters.TryGetValue<string>( nameof( Value ), out var paramValue )
-                    ? paramValue
-                    : Value;
-
-                await ParentValidation.InitializeInputPattern( paramPattern, newValue );
-            }
-
-            await InitializeValidation();
         }
     }
 

--- a/Source/Blazorise/Components/NumericEdit/NumericEdit.razor.cs
+++ b/Source/Blazorise/Components/NumericEdit/NumericEdit.razor.cs
@@ -57,14 +57,14 @@ public partial class NumericEdit<TValue> : BaseTextInput<TValue>, IAsyncDisposab
     #region Methods
 
     /// <inheritdoc/>
-    public override Task SetParametersAsync( ParameterView parameters )
+    protected override async Task OnBeforeSetParametersAsync( ParameterView parameters )
     {
+        await base.OnBeforeSetParametersAsync( parameters );
+
         // This make sure we know that Min or Max parameters are defined and can be checked against the current value.
         // Without we cannot determine if Min or Max has a default value when TValue is non-nullable type.
         minDefined = parameters.TryGetValue<TValue>( nameof( Min ), out var min );
         maxDefined = parameters.TryGetValue<TValue>( nameof( Max ), out var max );
-
-        return base.SetParametersAsync( parameters );
     }
 
     /// <inheritdoc/>

--- a/Source/Blazorise/Components/NumericEdit/NumericEdit.razor.cs
+++ b/Source/Blazorise/Components/NumericEdit/NumericEdit.razor.cs
@@ -57,40 +57,14 @@ public partial class NumericEdit<TValue> : BaseTextInput<TValue>, IAsyncDisposab
     #region Methods
 
     /// <inheritdoc/>
-    public override async Task SetParametersAsync( ParameterView parameters )
+    public override Task SetParametersAsync( ParameterView parameters )
     {
-        if ( Rendered )
-        {
-            if ( parameters.TryGetValue<TValue>( nameof( Value ), out var paramValue ) && !paramValue.IsEqual( Value ) )
-            {
-                ExecuteAfterRender( Revalidate );
-            }
-        }
-
         // This make sure we know that Min or Max parameters are defined and can be checked against the current value.
         // Without we cannot determine if Min or Max has a default value when TValue is non-nullable type.
         minDefined = parameters.TryGetValue<TValue>( nameof( Min ), out var min );
         maxDefined = parameters.TryGetValue<TValue>( nameof( Max ), out var max );
 
-        await base.SetParametersAsync( parameters );
-
-        if ( ParentValidation is not null )
-        {
-            if ( parameters.TryGetValue<Expression<Func<TValue>>>( nameof( ValueExpression ), out var expression ) )
-                await ParentValidation.InitializeInputExpression( expression );
-
-            if ( parameters.TryGetValue<string>( nameof( Pattern ), out var paramPattern ) )
-            {
-                // make sure we get the newest value
-                var newValue = parameters.TryGetValue<TValue>( nameof( Value ), out var paramValue )
-                    ? paramValue
-                    : Value;
-
-                await ParentValidation.InitializeInputPattern( paramPattern, newValue );
-            }
-
-            await InitializeValidation();
-        }
+        return base.SetParametersAsync( parameters );
     }
 
     /// <inheritdoc/>

--- a/Source/Blazorise/Components/Radio/RadioGroup.razor.cs
+++ b/Source/Blazorise/Components/Radio/RadioGroup.razor.cs
@@ -41,25 +41,6 @@ public partial class RadioGroup<TValue> : BaseInputComponent<TValue>
     #region Methods
 
     /// <inheritdoc/>
-    public override async Task SetParametersAsync( ParameterView parameters )
-    {
-        if ( parameters.TryGetValue<TValue>( nameof( Value ), out var paramValue ) && !paramValue.IsEqual( Value ) )
-        {
-            await CurrentValueHandler( paramValue?.ToString() );
-        }
-
-        await base.SetParametersAsync( parameters );
-
-        if ( ParentValidation is not null )
-        {
-            if ( parameters.TryGetValue<Expression<Func<TValue>>>( nameof( ValueExpression ), out var expression ) )
-                await ParentValidation.InitializeInputExpression( expression );
-
-            await InitializeValidation();
-        }
-    }
-
-    /// <inheritdoc/>
     protected override void BuildClasses( ClassBuilder builder )
     {
         builder.Append( ClassProvider.RadioGroup( Buttons, Orientation ) );

--- a/Source/Blazorise/Components/Select/Select.razor.cs
+++ b/Source/Blazorise/Components/Select/Select.razor.cs
@@ -37,28 +37,6 @@ public partial class Select<TValue> : BaseInputComponent<TValue>, ISelect
     #region Methods
 
     /// <inheritdoc/>
-    public override async Task SetParametersAsync( ParameterView parameters )
-    {
-        if ( Rendered )
-        {
-            if ( parameters.TryGetValue<TValue>( nameof( Value ), out var paramValue ) && !IsSameAsInternalValue( paramValue ) )
-            {
-                ExecuteAfterRender( Revalidate );
-            }
-        }
-
-        await base.SetParametersAsync( parameters );
-
-        if ( ParentValidation is not null )
-        {
-            if ( parameters.TryGetValue<Expression<Func<TValue>>>( nameof( ValueExpression ), out var expression ) )
-                await ParentValidation.InitializeInputExpression( expression );
-
-            await InitializeValidation();
-        }
-    }
-
-    /// <inheritdoc/>
     protected override void BuildClasses( ClassBuilder builder )
     {
         builder.Append( ClassProvider.Select() );

--- a/Source/Blazorise/Components/Slider/Slider.razor.cs
+++ b/Source/Blazorise/Components/Slider/Slider.razor.cs
@@ -33,30 +33,14 @@ public partial class Slider<TValue> : BaseInputComponent<TValue>
     #region Methods
 
     /// <inheritdoc/>
-    public override async Task SetParametersAsync( ParameterView parameters )
+    protected override async Task OnBeforeSetParametersAsync( ParameterView parameters )
     {
-        if ( Rendered )
-        {
-            if ( parameters.TryGetValue<TValue>( nameof( Value ), out var paramValue ) && !paramValue.IsEqual( Value ) )
-            {
-                ExecuteAfterRender( Revalidate );
-            }
-        }
+        await base.OnBeforeSetParametersAsync( parameters );
 
         // This make sure we know that Min or Max parameters are defined and can be checked against the current value.
         // Without we cannot determine if Min or Max has a default value when TValue is non-nullable type.
         minDefined = parameters.TryGetValue<TValue>( nameof( Min ), out var min );
         maxDefined = parameters.TryGetValue<TValue>( nameof( Max ), out var max );
-
-        await base.SetParametersAsync( parameters );
-
-        if ( ParentValidation is not null )
-        {
-            if ( parameters.TryGetValue<Expression<Func<TValue>>>( nameof( ValueExpression ), out var expression ) )
-                await ParentValidation.InitializeInputExpression( expression );
-
-            await InitializeValidation();
-        }
     }
 
     /// <inheritdoc/>

--- a/Source/Blazorise/Components/Switch/Switch.razor.cs
+++ b/Source/Blazorise/Components/Switch/Switch.razor.cs
@@ -24,31 +24,21 @@ public partial class Switch<TValue> : BaseCheckComponent<TValue>
     #region Methods
 
     /// <inheritdoc/>
-    public override async Task SetParametersAsync( ParameterView parameters )
+    protected override async Task OnBeforeSetParametersAsync( ParameterView parameters )
     {
+        await base.OnBeforeSetParametersAsync( parameters );
+
         if ( Rendered )
         {
-            if ( parameters.TryGetValue<TValue>( nameof( Value ), out var paramValue ) && !paramValue.IsEqual( Value ) )
+            if ( paramValue.Changed )
             {
                 ExecuteAfterRender( async () =>
                 {
-                    await Revalidate();
-
                     // Some providers may require that we define classname based on a switch state so we need to reset classes.
                     DirtyClasses();
                     await InvokeAsync( StateHasChanged );
                 } );
             }
-        }
-
-        await base.SetParametersAsync( parameters );
-
-        if ( ParentValidation is not null )
-        {
-            if ( parameters.TryGetValue<Expression<Func<TValue>>>( nameof( ValueExpression ), out var expression ) )
-                await ParentValidation.InitializeInputExpression( expression );
-
-            await InitializeValidation();
         }
     }
 

--- a/Source/Blazorise/Components/TextEdit/TextEdit.razor.cs
+++ b/Source/Blazorise/Components/TextEdit/TextEdit.razor.cs
@@ -1,6 +1,5 @@
 ﻿#region Using directives
 using System;
-using System.Linq.Expressions;
 using System.Threading.Tasks;
 using Blazorise.Extensions;
 using Blazorise.Modules;
@@ -16,38 +15,6 @@ namespace Blazorise;
 public partial class TextEdit : BaseTextInput<string>, IAsyncDisposable
 {
     #region Methods
-
-    /// <inheritdoc/>
-    public override async Task SetParametersAsync( ParameterView parameters )
-    {
-        if ( Rendered )
-        {
-            if ( parameters.TryGetValue<string>( nameof( Value ), out var paramValue ) && !paramValue.IsEqual( Value ) )
-            {
-                ExecuteAfterRender( Revalidate );
-            }
-        }
-
-        await base.SetParametersAsync( parameters );
-
-        if ( ParentValidation is not null )
-        {
-            if ( parameters.TryGetValue<Expression<Func<string>>>( nameof( ValueExpression ), out var expression ) )
-                await ParentValidation.InitializeInputExpression( expression );
-
-            if ( parameters.TryGetValue<string>( nameof( Pattern ), out var paramPattern ) )
-            {
-                // make sure we get the newest value
-                var newValue = parameters.TryGetValue<string>( nameof( Value ), out var paramValue )
-                    ? paramValue
-                    : Value;
-
-                await ParentValidation.InitializeInputPattern( paramPattern, newValue );
-            }
-
-            await InitializeValidation();
-        }
-    }
 
     /// <inheritdoc/>
     protected async override Task OnFirstAfterRenderAsync()

--- a/Source/Blazorise/Components/TimeEdit/TimeEdit.razor.cs
+++ b/Source/Blazorise/Components/TimeEdit/TimeEdit.razor.cs
@@ -19,38 +19,6 @@ public partial class TimeEdit<TValue> : BaseTextInput<TValue>
     #region Methods
 
     /// <inheritdoc/>
-    public override async Task SetParametersAsync( ParameterView parameters )
-    {
-        if ( Rendered )
-        {
-            if ( parameters.TryGetValue<TValue>( nameof( Value ), out var paramValue ) && !paramValue.IsEqual( Value ) )
-            {
-                ExecuteAfterRender( Revalidate );
-            }
-        }
-
-        await base.SetParametersAsync( parameters );
-
-        if ( ParentValidation is not null )
-        {
-            if ( parameters.TryGetValue<Expression<Func<TValue>>>( nameof( ValueExpression ), out var expression ) )
-                await ParentValidation.InitializeInputExpression( expression );
-
-            if ( parameters.TryGetValue<string>( nameof( Pattern ), out var paramPattern ) )
-            {
-                // make sure we get the newest value
-                var newValue = parameters.TryGetValue<TValue>( nameof( Value ), out var paramValue )
-                    ? paramValue
-                    : Value;
-
-                await ParentValidation.InitializeInputPattern( paramPattern, newValue );
-            }
-
-            await InitializeValidation();
-        }
-    }
-
-    /// <inheritdoc/>
     protected override void BuildClasses( ClassBuilder builder )
     {
         builder.Append( ClassProvider.TimeEdit( Plaintext ) );

--- a/Source/Blazorise/Extensions/ParameterExtensions.cs
+++ b/Source/Blazorise/Extensions/ParameterExtensions.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+using Microsoft.AspNetCore.Components;
+
+namespace Blazorise.Extensions;
+
+/// <summary>
+/// Helper methods for component parameters.
+/// </summary>
+public static class ParameterViewExtensions
+{
+    /// <summary>
+    /// Gets the value of the parameter with the specified name.
+    /// </summary>
+    /// <typeparam name="T">The type of the value.</typeparam>
+    /// <param name="parameters">Dictionary of all component paremeters.</param>
+    /// <param name="parameterName">The name of the parameter.</param>
+    /// <param name="currentValue">Last known parameter value.</param>
+    /// <param name="result">Receives the result, if any.</param>
+    public static bool TryGetParameter<T>( this ParameterView parameters, string parameterName, T currentValue, out ComponentParameterInfo<T> result )
+    {
+        if ( parameters.TryGetValue<T>( parameterName, out var paramNewValue ) )
+        {
+            var changed = currentValue is IEnumerable<T> array && paramNewValue is IEnumerable<T> array2
+                ? !array.AreEqual( array2 )
+                : !paramNewValue.IsEqual( currentValue );
+
+            result = new ComponentParameterInfo<T>( paramNewValue, true, changed );
+        }
+        else
+            result = new ComponentParameterInfo<T>( default );
+
+        return result.Defined;
+    }
+}

--- a/Source/Blazorise/Extensions/ParameterExtensions.cs
+++ b/Source/Blazorise/Extensions/ParameterExtensions.cs
@@ -1,5 +1,8 @@
-﻿using System.Collections.Generic;
+﻿#region Using directives
+using System;
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Components;
+#endregion
 
 namespace Blazorise.Extensions;
 
@@ -8,6 +11,8 @@ namespace Blazorise.Extensions;
 /// </summary>
 public static class ParameterViewExtensions
 {
+    #region Methods
+
     /// <summary>
     /// Gets the value of the parameter with the specified name.
     /// </summary>
@@ -31,4 +36,29 @@ public static class ParameterViewExtensions
 
         return result.Defined;
     }
+
+    /// <summary>
+    /// Gets the value of the parameter with the specified name.
+    /// </summary>
+    /// <typeparam name="T">The type of the value.</typeparam>
+    /// <param name="parameters">Dictionary of all component paremeters.</param>
+    /// <param name="parameterName">The name of the parameter.</param>
+    /// <param name="comparer">The custom comparer function.</param>
+    /// <param name="currentValue">Last known parameter value.</param>
+    /// <param name="result">Receives the result, if any.</param>
+    public static bool TryGetParameter<T>( this ParameterView parameters, string parameterName, T currentValue, Func<T, bool> comparer, out ComponentParameterInfo<T> result )
+    {
+        if ( parameters.TryGetValue<T>( parameterName, out var paramNewValue ) )
+        {
+            var changed = comparer( paramNewValue );
+
+            result = new ComponentParameterInfo<T>( paramNewValue, true, changed );
+        }
+        else
+            result = new ComponentParameterInfo<T>( default );
+
+        return result.Defined;
+    }
+
+    #endregion
 }

--- a/Source/Blazorise/Models/ComponentParameterInfo.cs
+++ b/Source/Blazorise/Models/ComponentParameterInfo.cs
@@ -1,0 +1,85 @@
+﻿namespace Blazorise;
+
+/// <summary>
+/// Represents a component parameter that can containe the last received value.
+/// </summary>
+/// <typeparam name="T"></typeparam>
+public record struct ComponentParameterInfo<T>
+{
+    #region Members
+
+    private readonly bool defined;
+
+    private readonly bool changed;
+
+    #endregion
+
+    #region Constructors
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ComponentParameterInfo{T}"/> structure to the specified value.
+    /// </summary>
+    /// <param name="value">A value type.</param>
+    public ComponentParameterInfo( T value )
+    {
+        Value = value;
+
+        defined = false;
+        changed = false;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ComponentParameterInfo{T}"/> structure to the specified value and received information.
+    /// </summary>
+    /// <param name="value">A value type.</param>
+    /// <param name="defined">True if the parameter has being received through the parameters.</param>
+    /// <param name="changed">True if the parameter has being changes since the last time.</param>
+    public ComponentParameterInfo( T value, bool defined, bool changed )
+    {
+        Value = value;
+
+        this.defined = defined;
+        this.changed = changed;
+    }
+
+    #endregion
+
+    #region Methods
+
+    /// <summary>
+    /// Retrieves the value of the current <see cref="ComponentParameterInfo{T}"/> object, or a default value.
+    /// </summary>
+    /// <param name="defaultValue">A value to return if the <see cref="Defined"/> property is false.</param>
+    /// <returns>The value of the <see cref="Value"/> property if the <see cref="Defined"/> property is true; otherwise, the <paramref name="defaultValue"/> parameter.</returns>
+    /// <remarks>
+    /// The <see cref="GetValueOrDefault"/> method returns a value even if the <see cref="Defined"/> property is false.
+    /// </remarks>
+    public T GetValueOrDefault( T defaultValue )
+    {
+        if ( !defined )
+            return defaultValue;
+
+        return Value;
+    }
+
+    #endregion
+
+    #region Properties
+
+    /// <summary>
+    /// Gets the actual value that was received through the supplied parameters.
+    /// </summary>
+    public T Value { get; }
+
+    /// <summary>
+    /// Indicates if the parameter was being defined and received through the component parameters or attributes.
+    /// </summary>
+    public bool Defined => defined;
+
+    /// <summary>
+    /// Indicates if the received parameter has being changed since the last rendering. 
+    /// </summary>
+    public bool Changed => changed;
+
+    #endregion
+}

--- a/Source/Blazorise/Models/ComponentParameterInfo.cs
+++ b/Source/Blazorise/Models/ComponentParameterInfo.cs
@@ -1,9 +1,9 @@
 ﻿namespace Blazorise;
 
 /// <summary>
-/// Represents a component parameter that can containe the last received value.
+/// Represents a component parameter that can contain the last received value, as well as information about whether it was defined or changed.
 /// </summary>
-/// <typeparam name="T"></typeparam>
+/// <typeparam name="T">The type of the component parameter's value.</typeparam>
 public record struct ComponentParameterInfo<T>
 {
     #region Members
@@ -17,27 +17,25 @@ public record struct ComponentParameterInfo<T>
     #region Constructors
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="ComponentParameterInfo{T}"/> structure to the specified value.
+    /// Initializes a new instance of the <see cref="ComponentParameterInfo{T}"/> structure with the specified value.
     /// </summary>
-    /// <param name="value">A value type.</param>
+    /// <param name="value">The value of the component parameter.</param>
     public ComponentParameterInfo( T value )
     {
         Value = value;
-
         defined = false;
         changed = false;
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="ComponentParameterInfo{T}"/> structure to the specified value and received information.
+    /// Initializes a new instance of the <see cref="ComponentParameterInfo{T}"/> structure with the specified value and received information.
     /// </summary>
-    /// <param name="value">A value type.</param>
-    /// <param name="defined">True if the parameter has being received through the parameters.</param>
-    /// <param name="changed">True if the parameter has being changes since the last time.</param>
+    /// <param name="value">The value of the component parameter.</param>
+    /// <param name="defined">A value indicating whether the parameter was received through the component parameters or attributes.</param>
+    /// <param name="changed">A value indicating whether the parameter has changed since it was last rendered.</param>
     public ComponentParameterInfo( T value, bool defined, bool changed )
     {
         Value = value;
-
         this.defined = defined;
         this.changed = changed;
     }
@@ -47,13 +45,10 @@ public record struct ComponentParameterInfo<T>
     #region Methods
 
     /// <summary>
-    /// Retrieves the value of the current <see cref="ComponentParameterInfo{T}"/> object, or a default value.
+    /// Retrieves the value of the current <see cref="ComponentParameterInfo{T}"/> object, or a default value if the parameter was not defined.
     /// </summary>
     /// <param name="defaultValue">A value to return if the <see cref="Defined"/> property is false.</param>
-    /// <returns>The value of the <see cref="Value"/> property if the <see cref="Defined"/> property is true; otherwise, the <paramref name="defaultValue"/> parameter.</returns>
-    /// <remarks>
-    /// The <see cref="GetValueOrDefault"/> method returns a value even if the <see cref="Defined"/> property is false.
-    /// </remarks>
+    /// <returns>The value of the <see cref="Value"/> property if <see cref="Defined"/> is true; otherwise, the <paramref name="defaultValue"/> parameter.</returns>
     public T GetValueOrDefault( T defaultValue )
     {
         if ( !defined )
@@ -67,17 +62,17 @@ public record struct ComponentParameterInfo<T>
     #region Properties
 
     /// <summary>
-    /// Gets the actual value that was received through the supplied parameters.
+    /// Gets the actual value that was received through the component parameters or attributes.
     /// </summary>
     public T Value { get; }
 
     /// <summary>
-    /// Indicates if the parameter was being defined and received through the component parameters or attributes.
+    /// Indicates whether the parameter was defined and received through the component parameters or attributes.
     /// </summary>
     public bool Defined => defined;
 
     /// <summary>
-    /// Indicates if the received parameter has being changed since the last rendering. 
+    /// Indicates whether the received parameter has changed since the last rendering.
     /// </summary>
     public bool Changed => changed;
 


### PR DESCRIPTION
A refactor of the input component lifecycle was used during the initialization process. I have made use of the prototype from https://github.com/Megabit/Blazorise/pull/4308 that was meant to keep track of parameters. 

So far all tests are passing and there are no issues as far as see. If all goes as planned, I will merge it into the larger API refactor branch.