### PR TITLE
Chart: add callbacks to tooltip options

### DIFF
--- a/Demos/Blazorise.Demo/Pages/Tests/ChartsPage.razor.cs
+++ b/Demos/Blazorise.Demo/Pages/Tests/ChartsPage.razor.cs
@@ -20,7 +20,20 @@ public partial class ChartsPage
 
     ChartOptions chartOptions = new()
     {
-        AspectRatio = 1.5
+        AspectRatio = 1.5,
+        Plugins = new ChartPlugins()
+        {
+            Tooltip = new ChartTooltip()
+            {
+                Enabled = true,
+                UsePointStyle = true,
+                Callbacks = new ChartTooltipCallbacks
+                {
+                    Title = ( items ) => "Custom title: " + items[0].Parsed,
+                    Label = ( item ) => "Custom label: " + item.Parsed,
+                }
+            }
+        }
     };
 
     LineChartOptions lineChartOptions = new()

--- a/Documentation/Blazorise.Docs/Pages/News/2024-10-15-release-notes-170.razor
+++ b/Documentation/Blazorise.Docs/Pages/News/2024-10-15-release-notes-170.razor
@@ -46,6 +46,11 @@
             <Strong>RichTextEdit:</Strong> Table support
         </Paragraph>
     </UnorderedListItem>
+    <UnorderedListItem>
+        <Paragraph>
+            <Strong>Chart:</Strong> Tooltip callbacks
+        </Paragraph>
+    </UnorderedListItem>
 </UnorderedList>
 
 <Paragraph>
@@ -227,6 +232,18 @@
 
 <Paragraph>
     However, since this module is not officially supported, we are marking this feature as experimental. This designation will remain until an official table module is released by the Quill.js team.
+</Paragraph>
+
+<Heading Size="HeadingSize.Is3">
+    Tooltip Callbacks
+</Heading>
+
+<Paragraph>
+    Added <Code>Callbacks</Code> parameter to the <Code>ChartTooltip</Code> options. This allows you to define custom callbacks for the tooltip, and can be useful if you want to customize the tooltip content or appearance based on the data point.
+</Paragraph>
+
+<Paragraph>
+    Please be aware that this feature is still experimental. The way how the callbacks works is that we convert C# lambda into JS function and then pass it to the Chart.js. This can be a bit tricky since the JS function can't access the C# context, so you need to be careful when using this feature.
 </Paragraph>
 
 <NewsPagePostInfo UserName="Mladen Macanović" ImageName="mladen" PostedOn="October 15th, 2024" Read="7 min" />

--- a/Source/Extensions/Blazorise.Charts/Options/ChartPlugins.cs
+++ b/Source/Extensions/Blazorise.Charts/Options/ChartPlugins.cs
@@ -19,7 +19,7 @@ public class ChartPlugins
     /// Configuration for the chart tooltips.
     /// </summary>
     [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-    public ChartTooltips Tooltips { get; set; }
+    public ChartTooltip Tooltip { get; set; }
 
     /// <summary>
     /// Configuration for the chart title.

--- a/Source/Extensions/Blazorise.Charts/Options/ChartPointStyle.cs
+++ b/Source/Extensions/Blazorise.Charts/Options/ChartPointStyle.cs
@@ -1,0 +1,74 @@
+﻿#region Using directives
+using System.Text.Json.Serialization;
+#endregion
+
+namespace Blazorise.Charts;
+
+/// <summary>
+/// Defines the point style.
+/// </summary>
+public class ChartPointStyle
+{
+    /// <summary>
+    /// Point radius.
+    /// </summary>
+    [JsonPropertyName( "radius" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public double? Radius { get; set; }
+
+    /// <summary>
+    /// Point style.
+    /// </summary>
+    [JsonPropertyName( "pointStyle" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public string PointStyle { get; set; }
+
+    /// <summary>
+    /// Point rotation (in degrees).
+    /// </summary>
+    [JsonPropertyName( "rotation" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public double? Rotation { get; set; }
+
+    /// <summary>
+    /// Point fill color.
+    /// </summary>
+    [JsonPropertyName( "backgroundColor" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public string BackgroundColor { get; set; }
+
+    /// <summary>
+    /// Point stroke width.
+    /// </summary>
+    [JsonPropertyName( "borderWidth" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public double? BorderWidth { get; set; }
+
+    /// <summary>
+    /// Point stroke color.
+    /// </summary>
+    [JsonPropertyName( "borderColor" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public string BorderColor { get; set; }
+
+    /// <summary>
+    /// Extra radius added to point radius for hit detection.
+    /// </summary>
+    [JsonPropertyName( "hitRadius" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public double? HitRadius { get; set; }
+
+    /// <summary>
+    /// Point radius when hovered.
+    /// </summary>
+    [JsonPropertyName( "hoverRadius" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public double? HoverRadius { get; set; }
+
+    /// <summary>
+    /// Stroke width when hovered.
+    /// </summary>
+    [JsonPropertyName( "hoverBorderWidth" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public double? HoverBorderWidth { get; set; }
+}

--- a/Source/Extensions/Blazorise.Charts/Options/ChartTooltip.cs
+++ b/Source/Extensions/Blazorise.Charts/Options/ChartTooltip.cs
@@ -7,7 +7,7 @@ namespace Blazorise.Charts;
 /// <summary>
 /// Tooltip Configuration
 /// </summary>
-public class ChartTooltips
+public class ChartTooltip
 {
     /// <summary>
     /// Are on-canvas tooltips enabled.
@@ -32,6 +32,13 @@ public class ChartTooltips
     /// </summary>
     [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
     public string Position { get; set; }
+
+    /// <summary>
+    /// Tooltip callbacks.
+    /// </summary>
+    [JsonPropertyName( "callbacks" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public ChartTooltipCallbacks Callbacks { get; set; }
 
     /// <summary>
     /// Background color of the tooltip.

--- a/Source/Extensions/Blazorise.Charts/Options/ChartTooltipCallbacks.cs
+++ b/Source/Extensions/Blazorise.Charts/Options/ChartTooltipCallbacks.cs
@@ -1,0 +1,125 @@
+﻿#region Using directives
+using System;
+using System.Linq.Expressions;
+using System.Text.Json.Serialization;
+#endregion
+
+namespace Blazorise.Charts;
+
+/// <summary>
+/// Tooltip callbacks.
+/// </summary>
+public class ChartTooltipCallbacks
+{
+    /// <summary>
+    /// Returns the text to render before the title.
+    /// </summary>
+    [JsonPropertyName( "beforeTitle" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    [JsonConverter( typeof( LambdaConverter<Func<ChartTooltipItemContext[], string>> ) )]
+    public Expression<Func<ChartTooltipItemContext[], string>> BeforeTitle { get; set; }
+
+    /// <summary>
+    /// Returns text to render as the title of the tooltip.
+    /// </summary>
+    [JsonPropertyName( "title" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    [JsonConverter( typeof( LambdaConverter<Func<ChartTooltipItemContext[], string>> ) )]
+    public Expression<Func<ChartTooltipItemContext[], string>> Title { get; set; }
+
+    /// <summary>
+    /// Returns text to render after the title.
+    /// </summary>
+    [JsonPropertyName( "afterTitle" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    [JsonConverter( typeof( LambdaConverter<Func<ChartTooltipItemContext[], string>> ) )]
+    public Expression<Func<ChartTooltipItemContext[], string>> AfterTitle { get; set; }
+
+    /// <summary>
+    /// Returns text to render before the body section.
+    /// </summary>
+    [JsonPropertyName( "beforeBody" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    [JsonConverter( typeof( LambdaConverter<Func<ChartTooltipItemContext[], string>> ) )]
+    public Expression<Func<ChartTooltipItemContext[], string>> BeforeBody { get; set; }
+
+    /// <summary>
+    /// Returns text to render before an individual label. This will be called for each item in the tooltip.
+    /// </summary>
+    [JsonPropertyName( "beforeLabel" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    [JsonConverter( typeof( LambdaConverter<Func<ChartTooltipItemContext, string>> ) )]
+    public Expression<Func<ChartTooltipItemContext, string>> BeforeLabel { get; set; }
+
+    /// <summary>
+    /// Returns text to render for an individual item in the tooltip. <see href="https://www.chartjs.org/docs/3.7.1/configuration/tooltip.html#label-callback">more...</see>
+    /// </summary>
+    [JsonPropertyName( "label" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    [JsonConverter( typeof( LambdaConverter<Func<ChartTooltipItemContext, string>> ) )]
+    public Expression<Func<ChartTooltipItemContext, string>> Label { get; set; }
+
+    /// <summary>
+    /// Returns the colors for the text of the label for the tooltip item. <see href="https://www.chartjs.org/docs/3.7.1/configuration/tooltip.html#label-color-callback">more...</see>
+    /// </summary>
+    [JsonPropertyName( "labelColor" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    [JsonConverter( typeof( LambdaConverter<Func<ChartTooltipItemContext, string>> ) )]
+    public Expression<Func<ChartTooltipItemContext, string>> LabelColor { get; set; }
+
+    /// <summary>
+    /// Returns the colors for the text of the label for the tooltip item.
+    /// </summary>
+    [JsonPropertyName( "labelTextColor" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    [JsonConverter( typeof( LambdaConverter<Func<ChartTooltipItemContext, string>> ) )]
+    public Expression<Func<ChartTooltipItemContext, string>> LabelTextColor { get; set; }
+
+    /// <summary>
+    /// eturns the point style to use instead of color boxes if usePointStyle is true (object with values pointStyle and rotation). Default implementation uses the point style from the dataset points. <see href="https://www.chartjs.org/docs/3.7.1/configuration/tooltip.html#label-point-style-callback">more..</see>
+    /// </summary>
+    [JsonPropertyName( "labelPointStyle" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    [JsonConverter( typeof( LambdaConverter<Func<ChartTooltipItemContext, ChartPointStyle>> ) )]
+    public Expression<Func<ChartTooltipItemContext, ChartPointStyle>> LabelPointStyle { get; set; }
+
+    /// <summary>
+    /// Returns text to render after an individual label.
+    /// </summary>
+    [JsonPropertyName( "afterLabel" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    [JsonConverter( typeof( LambdaConverter<Func<ChartTooltipItemContext, string>> ) )]
+    public Expression<Func<ChartTooltipItemContext, string>> AfterLabel { get; set; }
+
+    /// <summary>
+    /// Returns text to render after the body section.
+    /// </summary>
+    [JsonPropertyName( "afterBody" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    [JsonConverter( typeof( LambdaConverter<Func<ChartTooltipItemContext[], string>> ) )]
+    public Expression<Func<ChartTooltipItemContext[], string>> AfterBody { get; set; }
+
+    /// <summary>
+    /// Returns text to render before the footer section.
+    /// </summary>
+    [JsonPropertyName( "beforeFooter" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    [JsonConverter( typeof( LambdaConverter<Func<ChartTooltipItemContext[], string>> ) )]
+    public Expression<Func<ChartTooltipItemContext[], string>> BeforeFooter { get; set; }
+
+    /// <summary>
+    /// Returns text to render as the footer of the tooltip.
+    /// </summary>
+    [JsonPropertyName( "footer" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    [JsonConverter( typeof( LambdaConverter<Func<ChartTooltipItemContext[], string>> ) )]
+    public Expression<Func<ChartTooltipItemContext[], string>> Footer { get; set; }
+
+    /// <summary>
+    /// Text to render after the footer section.
+    /// </summary>
+    [JsonPropertyName( "afterFooter" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    [JsonConverter( typeof( LambdaConverter<Func<ChartTooltipItemContext[], string>> ) )]
+    public Expression<Func<ChartTooltipItemContext[], string>> AfterFooter { get; set; }
+}

--- a/Source/Extensions/Blazorise.Charts/Options/ChartTooltipItemContext.cs
+++ b/Source/Extensions/Blazorise.Charts/Options/ChartTooltipItemContext.cs
@@ -1,0 +1,76 @@
+﻿#region Using directives
+using System.Text.Json.Serialization;
+using Lambda2Js;
+#endregion
+
+namespace Blazorise.Charts;
+
+/// <summary>
+/// The tooltip items passed to the tooltip callbacks implement the following interface.
+/// </summary>
+public class ChartTooltipItemContext
+{
+    /// <summary>
+    /// Label for the tooltip.
+    /// </summary>
+    [JsonPropertyName( "index" )]
+    [JavascriptMember( MemberName = "index" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public string Label { get; set; }
+
+    /// <summary>
+    /// Parsed data values for the given `dataIndex` and `datasetIndex`.
+    /// </summary>
+    [JsonPropertyName( "parsed" )]
+    [JavascriptMember( MemberName = "parsed" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public object Parsed { get; set; }
+
+    /// <summary>
+    /// Raw data values for the given `dataIndex` and `datasetIndex`.
+    /// </summary>
+    [JsonPropertyName( "raw" )]
+    [JavascriptMember( MemberName = "raw" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public object Raw { get; set; }
+
+    /// <summary>
+    /// Formatted value for the tooltip.
+    /// </summary>
+    [JsonPropertyName( "formattedValue" )]
+    [JavascriptMember( MemberName = "formattedValue" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public string FormattedValue { get; set; }
+
+    /// <summary>
+    /// The dataset the item comes from.
+    /// </summary>
+    [JsonPropertyName( "dataset" )]
+    [JavascriptMember( MemberName = "dataset" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public object Dataset { get; set; }
+
+    /// <summary>
+    /// Index of the dataset the item comes from.
+    /// </summary>
+    [JsonPropertyName( "datasetIndex" )]
+    [JavascriptMember( MemberName = "datasetIndex" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public int DatasetIndex { get; set; }
+
+    /// <summary>
+    /// Index of this data item in the dataset.
+    /// </summary>
+    [JsonPropertyName( "dataIndex" )]
+    [JavascriptMember( MemberName = "dataIndex" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public int DataIndex { get; set; }
+
+    /// <summary>
+    /// The chart element (point, arc, bar, etc.) for this tooltip item.
+    /// </summary>
+    [JsonPropertyName( "element" )]
+    [JavascriptMember( MemberName = "element" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public object Element { get; set; }
+}

--- a/Source/Extensions/Blazorise.Charts/wwwroot/charts.js
+++ b/Source/Extensions/Blazorise.Charts/wwwroot/charts.js
@@ -45,6 +45,22 @@ export function initialize(dotnetAdapter, eventOptions, canvas, canvasId, type, 
         options = optionsObject;
     }
 
+    function processTooltipCallbacks(callbacks) {
+        if (callbacks && typeof callbacks === 'object') {
+            const newCallbacks = {};
+
+            Object.keys(callbacks).forEach(key => {
+                if (typeof callbacks[key] === 'string') {
+                    newCallbacks[key] = eval(`(${callbacks[key]})`);
+                } else {
+                    newCallbacks[key] = callbacks[key];
+                }
+            });
+
+            Object.assign(callbacks, newCallbacks);
+        }
+    }
+
     function processTicksCallback(scales, axis) {
         if (scales && Array.isArray(scales[axis])) {
             scales[axis].forEach(a => {
@@ -63,6 +79,10 @@ export function initialize(dotnetAdapter, eventOptions, canvas, canvasId, type, 
     if (options && options.scales) {
         processTicksCallback(options.scales, 'x');
         processTicksCallback(options.scales, 'y');
+    }
+
+    if (options && options.plugins && options.plugins.tooltip && options.plugins.tooltip.callbacks) {
+        processTooltipCallbacks(options.plugins.tooltip.callbacks);
     }
 
     // search for canvas element


### PR DESCRIPTION
Closes #5741

Added all callbacks from https://www.chartjs.org/docs/3.7.1/configuration/tooltip.html#tooltip-callbacks

As in other parts of the code I have used `LambdaConverter` that converts C# to JS code. For simple tasks it seems to work as expected. 

```cs
ChartOptions chartOptions = new()
{
    AspectRatio = 1.5,
    Plugins = new ChartPlugins()
    {
        Tooltip = new ChartTooltip()
        {
            Enabled = true,
            UsePointStyle = true,
            Callbacks = new ChartTooltipCallbacks
            {
                Title = ( items ) => "Custom title: " + items[0].Parsed,
                Label = ( item ) => "Custom label: " + item.Parsed,
            }
        }
    }
};
```

The only problem is that the `Parsed` of the `ChartTooltipItemContext` can only be defined as `object` type. We cannot do something like `Title = ( items ) => "Custom title: " + items[0].Parsed.x,` because `object` is unknown in C#. I tried the `dynamic` type, but C# complained that it could not be used in lambda expression.

I could introduce a known type for the `Parsed` field, but I don't know how many different objects can be there. Some charts have it as a simple number. Some are `{ x, y }`. 

So I think I will leave it as `object` for now.