### PR TITLE
Flex utilities: improve breakpoint rules

### DIFF
--- a/Documentation/Blazorise.Docs/Pages/News/2024-10-15-release-notes-170.razor
+++ b/Documentation/Blazorise.Docs/Pages/News/2024-10-15-release-notes-170.razor
@@ -295,4 +295,12 @@
     For more information on how to use the Skeleton component and customize loading placeholders, refer to the <Anchor To="docs/components/skeleton">Skeleton documentation</Anchor>.
 </Paragraph>
 
+<Heading Size="HeadingSize.Is3">
+    Improved Flex Utilities
+</Heading>
+
+<Paragraph>
+    We have improved the way how our Fluent Flex utilities work. Previously it was not possible to define a breakpoint on per-flex rule, which made it hard to define different flex rules for different breakpoints. Now you can define the flex rules for each breakpoint separately, and you can also define the order of the flex rules.
+</Paragraph>
+
 <NewsPagePostInfo UserName="Mladen Macanović" ImageName="mladen" PostedOn="October 15th, 2024" Read="7 min" />

--- a/Source/Blazorise.AntDesign/Providers/AntDesignClassProvider.cs
+++ b/Source/Blazorise.AntDesign/Providers/AntDesignClassProvider.cs
@@ -1460,14 +1460,21 @@ public class AntDesignClassProvider : ClassProvider
         return sb.ToString();
     }
 
-    public override string Flex( FlexType flexType, IEnumerable<FlexDefinition> flexDefinitions )
+    public override string Flex( FlexRule flexRule )
     {
         var sb = new StringBuilder();
 
-        if ( flexType != FlexType.Default )
-            sb.Append( $"ant-display-{ToFlexType( flexType )}" ).Append( ' ' );
+        if ( flexRule.FlexType != FlexType.Default )
+        {
+            if ( flexRule.Breakpoint > Breakpoint.Mobile )
+                sb.Append( $"ant-display-{ToBreakpoint( flexRule.Breakpoint )}-{ToFlexType( flexRule.FlexType )}" );
+            else
+                sb.Append( $"ant-display-{ToFlexType( flexRule.FlexType )}" );
 
-        sb.Append( string.Join( ' ', flexDefinitions.Select( x => Flex( x ) ) ) );
+            sb.Append( ' ' );
+        }
+
+        sb.Append( string.Join( ' ', flexRule.Definitions.Where( x => x.Condition ?? true ).Select( x => Flex( x ) ) ) );
 
         return sb.ToString();
     }

--- a/Source/Blazorise.Bootstrap/Providers/BootstrapClassProvider.cs
+++ b/Source/Blazorise.Bootstrap/Providers/BootstrapClassProvider.cs
@@ -1458,7 +1458,24 @@ public class BootstrapClassProvider : ClassProvider
         var sb = new StringBuilder();
 
         if ( flexType != FlexType.Default )
-            sb.Append( $"d-{ToFlexType( flexType )}" ).Append( ' ' );
+        {
+            var dist = flexDefinitions
+                .Where( x => x.Breakpoint != Breakpoint.None && x.Breakpoint != Breakpoint.Mobile && !x.RulesDefined )
+                .Select( x => x.Breakpoint )
+                .Distinct()
+                .ToList();
+
+            if ( dist.Count > 0 )
+            {
+                sb.Append( string.Join( ' ', dist.Select( x => $"d-{ToBreakpoint( x )}-{ToFlexType( flexType )}" ) ) );
+            }
+            else
+            {
+                sb.Append( $"d-{ToFlexType( flexType )}" );
+            }
+
+            sb.Append( ' ' );
+        }
 
         sb.Append( string.Join( ' ', flexDefinitions.Select( x => Flex( x ) ) ) );
 

--- a/Source/Blazorise.Bootstrap/Providers/BootstrapClassProvider.cs
+++ b/Source/Blazorise.Bootstrap/Providers/BootstrapClassProvider.cs
@@ -1453,31 +1453,21 @@ public class BootstrapClassProvider : ClassProvider
         return sb.ToString();
     }
 
-    public override string Flex( FlexType flexType, IEnumerable<FlexDefinition> flexDefinitions )
+    public override string Flex( FlexRule flexRule )
     {
         var sb = new StringBuilder();
 
-        if ( flexType != FlexType.Default )
+        if ( flexRule.FlexType != FlexType.Default )
         {
-            var dist = flexDefinitions
-                .Where( x => x.Breakpoint != Breakpoint.None && x.Breakpoint != Breakpoint.Mobile && !x.RulesDefined )
-                .Select( x => x.Breakpoint )
-                .Distinct()
-                .ToList();
-
-            if ( dist.Count > 0 )
-            {
-                sb.Append( string.Join( ' ', dist.Select( x => $"d-{ToBreakpoint( x )}-{ToFlexType( flexType )}" ) ) );
-            }
+            if ( flexRule.Breakpoint > Breakpoint.Mobile )
+                sb.Append( $"d-{ToBreakpoint( flexRule.Breakpoint )}-{ToFlexType( flexRule.FlexType )}" );
             else
-            {
-                sb.Append( $"d-{ToFlexType( flexType )}" );
-            }
+                sb.Append( $"d-{ToFlexType( flexRule.FlexType )}" );
 
             sb.Append( ' ' );
         }
 
-        sb.Append( string.Join( ' ', flexDefinitions.Select( x => Flex( x ) ) ) );
+        sb.Append( string.Join( ' ', flexRule.Definitions.Where( x => x.Condition ?? true ).Select( x => Flex( x ) ) ) );
 
         return sb.ToString();
     }

--- a/Source/Blazorise.Bootstrap5/Providers/Bootstrap5ClassProvider.cs
+++ b/Source/Blazorise.Bootstrap5/Providers/Bootstrap5ClassProvider.cs
@@ -1451,31 +1451,25 @@ public class Bootstrap5ClassProvider : ClassProvider
         return sb.ToString();
     }
 
-    public override string Flex( FlexType flexType, IEnumerable<FlexDefinition> flexDefinitions )
+    public override string Flex( FlexRule flexRule )
     {
         var sb = new StringBuilder();
 
-        if ( flexType != FlexType.Default )
+        if ( flexRule.FlexType != FlexType.Default )
         {
-            var dist = flexDefinitions
-                .Where( x => x.Breakpoint != Breakpoint.None && x.Breakpoint != Breakpoint.Mobile )
-                .Select( x => x.Breakpoint )
-                .Distinct()
-                .ToList();
-
-            if ( dist.Count > 0 )
+            if ( flexRule.Breakpoint > Breakpoint.Mobile )
             {
-                sb.Append( string.Join( ' ', dist.Select( x => $"d-{ToBreakpoint( x )}-{ToFlexType( flexType )}" ) ) );
+                sb.Append( $"d-{ToBreakpoint( flexRule.Breakpoint )}-{ToFlexType( flexRule.FlexType )}" );
             }
             else
             {
-                sb.Append( $"d-{ToFlexType( flexType )}" );
+                sb.Append( $"d-{ToFlexType( flexRule.FlexType )}" );
             }
 
             sb.Append( ' ' );
         }
 
-        sb.Append( string.Join( ' ', flexDefinitions.Select( x => Flex( x ) ) ) );
+        sb.Append( string.Join( ' ', flexRule.Definitions.Where( x => x.Condition ?? true ).Select( x => Flex( x ) ) ) );
 
         return sb.ToString();
     }

--- a/Source/Blazorise.Bootstrap5/Providers/Bootstrap5ClassProvider.cs
+++ b/Source/Blazorise.Bootstrap5/Providers/Bootstrap5ClassProvider.cs
@@ -1456,7 +1456,24 @@ public class Bootstrap5ClassProvider : ClassProvider
         var sb = new StringBuilder();
 
         if ( flexType != FlexType.Default )
-            sb.Append( $"d-{ToFlexType( flexType )}" ).Append( ' ' );
+        {
+            var dist = flexDefinitions
+                .Where( x => x.Breakpoint != Breakpoint.None && x.Breakpoint != Breakpoint.Mobile )
+                .Select( x => x.Breakpoint )
+                .Distinct()
+                .ToList();
+
+            if ( dist.Count > 0 )
+            {
+                sb.Append( string.Join( ' ', dist.Select( x => $"d-{ToBreakpoint( x )}-{ToFlexType( flexType )}" ) ) );
+            }
+            else
+            {
+                sb.Append( $"d-{ToFlexType( flexType )}" );
+            }
+
+            sb.Append( ' ' );
+        }
 
         sb.Append( string.Join( ' ', flexDefinitions.Select( x => Flex( x ) ) ) );
 

--- a/Source/Blazorise.Bulma/Providers/BulmaClassProvider.cs
+++ b/Source/Blazorise.Bulma/Providers/BulmaClassProvider.cs
@@ -1460,14 +1460,21 @@ public class BulmaClassProvider : ClassProvider
         return sb.ToString();
     }
 
-    public override string Flex( FlexType flexType, IEnumerable<FlexDefinition> flexDefinitions )
+    public override string Flex( FlexRule flexRule )
     {
         var sb = new StringBuilder();
 
-        if ( flexType != FlexType.Default )
-            sb.Append( $"is-{ToFlexType( flexType )}" ).Append( ' ' );
+        if ( flexRule.FlexType != FlexType.Default )
+        {
+            if ( flexRule.Breakpoint > Breakpoint.Mobile )
+                sb.Append( $"is-{ToFlexType( flexRule.FlexType )}-{ToBreakpoint( flexRule.Breakpoint )}" );
+            else
+                sb.Append( $"is-{ToFlexType( flexRule.FlexType )}" );
 
-        sb.Append( string.Join( ' ', flexDefinitions.Select( x => Flex( x ) ) ) );
+            sb.Append( ' ' );
+        }
+
+        sb.Append( string.Join( ' ', flexRule.Definitions.Where( x => x.Condition ?? true ).Select( x => Flex( x ) ) ) );
 
         return sb.ToString();
     }

--- a/Source/Blazorise.FluentUI2/Providers/FluentUI2ClassProvider.cs
+++ b/Source/Blazorise.FluentUI2/Providers/FluentUI2ClassProvider.cs
@@ -1595,14 +1595,21 @@ public class FluentUI2ClassProvider : ClassProvider
         return sb.ToString();
     }
 
-    public override string Flex( FlexType flexType, IEnumerable<FlexDefinition> flexDefinitions )
+    public override string Flex( FlexRule flexRule )
     {
         var sb = new StringBuilder();
 
-        if ( flexType != FlexType.Default )
-            sb.Append( $"fui-{ToFlexType( flexType )}" ).Append( ' ' );
+        if ( flexRule.FlexType != FlexType.Default )
+        {
+            if ( flexRule.Breakpoint > Breakpoint.Mobile )
+                sb.Append( $"fui-{ToBreakpoint( flexRule.Breakpoint )}-{ToFlexType( flexRule.FlexType )}" );
+            else
+                sb.Append( $"fui-{ToFlexType( flexRule.FlexType )}" );
 
-        sb.Append( string.Join( ' ', flexDefinitions.Select( x => Flex( x ) ) ) );
+            sb.Append( ' ' );
+        }
+
+        sb.Append( string.Join( ' ', flexRule.Definitions.Where( x => x.Condition ?? true ).Select( x => Flex( x ) ) ) );
 
         return sb.ToString();
     }

--- a/Source/Blazorise.Tailwind/Providers/TailwindClassProvider.cs
+++ b/Source/Blazorise.Tailwind/Providers/TailwindClassProvider.cs
@@ -2109,14 +2109,21 @@ public class TailwindClassProvider : ClassProvider
         return sb.ToString();
     }
 
-    public override string Flex( FlexType flexType, IEnumerable<FlexDefinition> flexDefinitions )
+    public override string Flex( FlexRule flexRule )
     {
         var sb = new StringBuilder();
 
-        if ( flexType != FlexType.Default )
-            sb.Append( $"{ToFlexType( flexType )}" ).Append( ' ' );
+        if ( flexRule.FlexType != FlexType.Default )
+        {
+            if ( flexRule.Breakpoint > Breakpoint.None )
+                sb.Append( $"{ToBreakpoint( flexRule.Breakpoint )}:{ToFlexType( flexRule.FlexType )}" );
+            else
+                sb.Append( $"{ToFlexType( flexRule.FlexType )}" );
 
-        sb.Append( string.Join( ' ', flexDefinitions.Select( x => Flex( x ) ) ) );
+            sb.Append( ' ' );
+        }
+
+        sb.Append( string.Join( ' ', flexRule.Definitions.Where( x => x.Condition ?? true ).Select( x => Flex( x ) ) ) );
 
         return sb.ToString();
     }

--- a/Source/Blazorise/Fluent/FluentFlex.cs
+++ b/Source/Blazorise/Fluent/FluentFlex.cs
@@ -27,6 +27,7 @@ public interface IFluentFlex
 public interface IFluentFlexAll :
     IFluentFlex,
     IFluentFlexBreakpoint,
+    IFluentFlexType,
     IFluentFlexDirection,
     IFluentFlexJustifyContent,
     IFluentFlexAlignItems,
@@ -78,21 +79,28 @@ public interface IFluentFlexBreakpoint :
 }
 
 /// <summary>
+/// Allowed rules for flex type.
+/// </summary>
+public interface IFluentFlexType :
+    IFluentFlex
+{
+    /// <summary>
+    /// Displays an element as a block-level flex container.
+    /// </summary>
+    IFluentFlexAll Flex { get; }
+
+    /// <summary>
+    /// Displays an element as an inline-level flex container.
+    /// </summary>
+    IFluentFlexAll InlineFlex { get; }
+}
+
+/// <summary>
 /// Allowed rules for flex direction.
 /// </summary>
 public interface IFluentFlexDirection :
     IFluentFlex
 {
-    /// <summary>
-    /// Default value. The flexible items are displayed horizontally, as a row.
-    /// </summary>
-    IFluentFlexAll Flex { get; }
-
-    /// <summary>
-    ///  
-    /// </summary>
-    IFluentFlexAll InlineFlex { get; }
-
     /// <summary>
     /// Default value. The flexible items are displayed horizontally, as a row.
     /// </summary>
@@ -611,6 +619,7 @@ public record FlexDefinition
 public class FluentFlex :
     IFluentFlex,
     IFluentFlexBreakpoint,
+    IFluentFlexType,
     IFluentFlexDirection,
     IFluentFlexJustifyContent,
     IFluentFlexJustifyContentPositions,

--- a/Source/Blazorise/Fluent/FluentFlex.cs
+++ b/Source/Blazorise/Fluent/FluentFlex.cs
@@ -524,6 +524,11 @@ public record FlexRule
     public FlexType FlexType { get; set; }
 
     /// <summary>
+    /// Defines the flex breakpoint rule.
+    /// </summary>
+    public Breakpoint Breakpoint { get; set; }
+
+    /// <summary>
     /// Gets or sets the flex definition.
     /// </summary>
     public List<FlexDefinition> Definitions { get; set; }
@@ -598,21 +603,6 @@ public record FlexDefinition
     /// If condition is true the rule will will be applied.
     /// </summary>
     public bool? Condition { get; set; }
-
-    /// <summary>
-    /// Indicates if any of the definition rules are defined(except for Breakpoint).
-    /// </summary>
-    public bool RulesDefined =>
-        Direction != FlexDirection.Default ||
-        JustifyContent != FlexJustifyContent.Default ||
-        AlignItems != FlexAlignItems.Default ||
-        AlignSelf != FlexAlignSelf.Default ||
-        AlignContent != FlexAlignContent.Default ||
-        GrowShrink != FlexGrowShrink.Default ||
-        GrowShrinkSize != FlexGrowShrinkSize.Default ||
-        Wrap != FlexWrap.Default ||
-        Order != FlexOrder.Default ||
-        Fill;
 }
 
 /// <summary>
@@ -686,7 +676,7 @@ public class FluentFlex :
                 {
                     foreach ( var rule in rules.Where( x => x.Definitions?.Count > 0 ) )
                     {
-                        builder.Append( classProvider.Flex( rule.FlexType, rule.Definitions.Where( x => x.Condition ?? true ).Select( v => v ) ) );
+                        builder.Append( classProvider.Flex( rule ) );
                     }
                 }
                 else if ( currentFlexDefinition is not null && currentFlexDefinition != FlexDefinition.Empty && ( currentFlexDefinition.Condition ?? true ) )
@@ -802,6 +792,13 @@ public class FluentFlex :
     /// <returns>Next rule reference.</returns>
     public IFluentFlexAll WithBreakpoint( Breakpoint breakpoint )
     {
+        if ( currentFlexDefinition is null )
+        {
+            // If there is still no definition then we need to apply breakpoint to the flex rule.
+            currentFlexRule = GetRule();
+            currentFlexRule.Breakpoint = breakpoint;
+        }
+
         currentFlexDefinition = GetDefinition();
         currentFlexDefinition.Breakpoint = breakpoint;
         Dirty();

--- a/Source/Blazorise/Interfaces/IClassProvider.cs
+++ b/Source/Blazorise/Interfaces/IClassProvider.cs
@@ -1234,7 +1234,7 @@ public interface IClassProvider
 
     string Flex( FlexDefinition flexDefinition );
 
-    string Flex( FlexType flexType, IEnumerable<FlexDefinition> flexDefinitions );
+    string Flex( FlexRule flexRule );
 
     #endregion
 

--- a/Source/Blazorise/Providers/ClassProvider.cs
+++ b/Source/Blazorise/Providers/ClassProvider.cs
@@ -1237,7 +1237,7 @@ public abstract class ClassProvider : IClassProvider
 
     public abstract string Flex( FlexDefinition flexDefinition );
 
-    public abstract string Flex( FlexType flexType, IEnumerable<FlexDefinition> flexDefinitions );
+    public abstract string Flex( FlexRule flexRule );
 
     #endregion
 

--- a/Source/Blazorise/Providers/EmptyClassProvider.cs
+++ b/Source/Blazorise/Providers/EmptyClassProvider.cs
@@ -1239,7 +1239,7 @@ class EmptyClassProvider : IClassProvider
 
     public string Flex( FlexDefinition flexDefinition ) => null;
 
-    public string Flex( FlexType flexType, IEnumerable<FlexDefinition> flexDefinitions ) => null;
+    public string Flex( FlexRule flexRule ) => null;
 
     #endregion
 


### PR DESCRIPTION
I wanted to define some special flex rules while trying to improve our docs, but I realized it wasn't working.

**Example:**

`<Div Flex="Flex.Default.OnDesktop.Flex.ReverseRow.OnDesktop.JustifyContent.Between.AlignItems.Center">`

 After some investigation, I found the problem. The breakpoint was defined on a flex definition level. Not on a flex rule itself. This made it very hard to do work with. So I went and refactor internals of flex utilities to allow.

- Multiple flex types
- Breakpoint for each flex type
- New `IFluentFlexAll Default` alias for default flex type