### PR TITLE
DatePicker: add EnabledDates parameter

### DIFF
--- a/Documentation/Blazorise.Docs/Models/Snippets.generated.cs
+++ b/Documentation/Blazorise.Docs/Models/Snippets.generated.cs
@@ -1893,7 +1893,7 @@ public partial class CaptchaInput : BaseInputComponent<bool>
 
 @code {
 
-    DateTime?[]? enabledDates = new DateTime?[]{
+    DateTime?[] enabledDates = new DateTime?[]{
         DateTime.Now.AddDays(-1),
         DateTime.Now.AddDays(2),
     };

--- a/Documentation/Blazorise.Docs/Models/Snippets.generated.cs
+++ b/Documentation/Blazorise.Docs/Models/Snippets.generated.cs
@@ -1888,6 +1888,17 @@ public partial class CaptchaInput : BaseInputComponent<bool>
     };
 }";
 
+        public const string DatePickerEnabledDatesExample = @"<DatePicker TValue=""DateTime?"" EnabledDates=""@enabledDates"" />
+
+
+@code {
+
+    DateTime?[]? enabledDates = new DateTime?[]{
+        DateTime.Now.AddDays(-1),
+        DateTime.Now.AddDays(2),
+    };
+}";
+
         public const string DatePickerFormatBestPracticeExample = @"<Field>
     <FieldLabel>Start date</FieldLabel>
     <FieldBody>

--- a/Documentation/Blazorise.Docs/Models/Snippets.generated.cs
+++ b/Documentation/Blazorise.Docs/Models/Snippets.generated.cs
@@ -1890,9 +1890,7 @@ public partial class CaptchaInput : BaseInputComponent<bool>
 
         public const string DatePickerEnabledDatesExample = @"<DatePicker TValue=""DateTime?"" EnabledDates=""@enabledDates"" />
 
-
 @code {
-
     DateTime?[] enabledDates = new DateTime?[]{
         DateTime.Now.AddDays(-1),
         DateTime.Now.AddDays(2),

--- a/Documentation/Blazorise.Docs/NewFilesToBuild.txt
+++ b/Documentation/Blazorise.Docs/NewFilesToBuild.txt
@@ -1,1 +1,0 @@
-D:\Projects\Megabit\Blazorise\Documentation\Blazorise.Docs\Pages\Docs\Components\Dates\Code\DatePickerEnabledDatesExampleCode.html

--- a/Documentation/Blazorise.Docs/NewFilesToBuild.txt
+++ b/Documentation/Blazorise.Docs/NewFilesToBuild.txt
@@ -1,0 +1,1 @@
+D:\Projects\Megabit\Blazorise\Documentation\Blazorise.Docs\Pages\Docs\Components\Dates\Code\DatePickerEnabledDatesExampleCode.html

--- a/Documentation/Blazorise.Docs/Pages/Docs/Components/Dates/Code/DatePickerEnabledDatesExampleCode.html
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Components/Dates/Code/DatePickerEnabledDatesExampleCode.html
@@ -1,0 +1,14 @@
+<div class="blazorise-codeblock">
+<div class="html"><pre>
+<span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">DatePicker</span> <span class="htmlAttributeName">TValue</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">DateTime?</span><span class="quot">&quot;</span> <span class="htmlAttributeName">EnabledDates</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="sharpVariable"><span class="atSign">&#64;</span>enabledDates</span><span class="quot">&quot;</span> <span class="htmlTagDelimiter">/&gt;</span>
+</pre></div>
+<div class="csharp"><pre>
+<span class="atSign">&#64;</span>code {
+
+    DateTime?[] enabledDates = <span class="keyword">new</span> DateTime?[]{
+        DateTime.Now.AddDays(-<span class="number">1</span>),
+        DateTime.Now.AddDays(<span class="number">2</span>),
+    };
+}
+</pre></div>
+</div>

--- a/Documentation/Blazorise.Docs/Pages/Docs/Components/Dates/Code/DatePickerEnabledDatesExampleCode.html
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Components/Dates/Code/DatePickerEnabledDatesExampleCode.html
@@ -4,7 +4,6 @@
 </pre></div>
 <div class="csharp"><pre>
 <span class="atSign">&#64;</span>code {
-
     DateTime?[] enabledDates = <span class="keyword">new</span> DateTime?[]{
         DateTime.Now.AddDays(-<span class="number">1</span>),
         DateTime.Now.AddDays(<span class="number">2</span>),

--- a/Documentation/Blazorise.Docs/Pages/Docs/Components/Dates/DatePickerPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Components/Dates/DatePickerPage.razor
@@ -60,7 +60,6 @@
     <DocsPageSectionSource Code="DatePickerEnabledDatesExample" />
 </DocsPageSection>
 
-
 <DocsPageSection>
     <DocsPageSectionHeader Title="Disable days">
         If you’d like to make only certain days in a week unavailable for selection you can assign the <Code>DisabledDays</Code> parameter.

--- a/Documentation/Blazorise.Docs/Pages/Docs/Components/Dates/DatePickerPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Components/Dates/DatePickerPage.razor
@@ -51,6 +51,17 @@
 </DocsPageSection>
 
 <DocsPageSection>
+    <DocsPageSectionHeader Title="Enable dates">
+        If you’d like to make only certain dates available for selection, you can assign the <Code>EnabledDates</Code> parameter.
+    </DocsPageSectionHeader>
+    <DocsPageSectionContent Outlined FullWidth>
+        <DatePickerEnabledDatesExample />
+    </DocsPageSectionContent>
+    <DocsPageSectionSource Code="DatePickerEnabledDatesExample" />
+</DocsPageSection>
+
+
+<DocsPageSection>
     <DocsPageSectionHeader Title="Disable days">
         If you’d like to make only certain days in a week unavailable for selection you can assign the <Code>DisabledDays</Code> parameter.
     </DocsPageSectionHeader>

--- a/Documentation/Blazorise.Docs/Pages/Docs/Components/Dates/DatePickerPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Components/Dates/DatePickerPage.razor
@@ -470,6 +470,9 @@
     <DocsAttributesItem Name="DisabledDates" Type="IEnumerable<TValue>" Default="null">
         List of disabled dates that the user should not be able to pick.
     </DocsAttributesItem>
+    <DocsAttributesItem Name="EnabledDates" Type="IEnumerable<TValue>" Default="null">
+        List of enabled dates that the user should be able to pick.
+    </DocsAttributesItem>
     <DocsAttributesItem Name="DisabledDays" Type="IEnumerable<DayOfWeek>" Default="null">
         List of disabled days in a week that the user should not be able to pick.
     </DocsAttributesItem>

--- a/Documentation/Blazorise.Docs/Pages/Docs/Components/Dates/Examples/DatePickerEnabledDatesExample.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Components/Dates/Examples/DatePickerEnabledDatesExample.razor
@@ -1,0 +1,12 @@
+﻿@namespace Blazorise.Docs.Docs.Examples
+
+<DatePicker TValue="DateTime?" EnabledDates="@enabledDates" />
+
+
+@code {
+
+    DateTime?[]? enabledDates = new DateTime?[]{
+        DateTime.Now.AddDays(-1),
+        DateTime.Now.AddDays(2),
+    };
+}

--- a/Documentation/Blazorise.Docs/Pages/Docs/Components/Dates/Examples/DatePickerEnabledDatesExample.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Components/Dates/Examples/DatePickerEnabledDatesExample.razor
@@ -5,7 +5,7 @@
 
 @code {
 
-    DateTime?[]? enabledDates = new DateTime?[]{
+    DateTime?[] enabledDates = new DateTime?[]{
         DateTime.Now.AddDays(-1),
         DateTime.Now.AddDays(2),
     };

--- a/Documentation/Blazorise.Docs/Pages/Docs/Components/Dates/Examples/DatePickerEnabledDatesExample.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Components/Dates/Examples/DatePickerEnabledDatesExample.razor
@@ -2,9 +2,7 @@
 
 <DatePicker TValue="DateTime?" EnabledDates="@enabledDates" />
 
-
 @code {
-
     DateTime?[] enabledDates = new DateTime?[]{
         DateTime.Now.AddDays(-1),
         DateTime.Now.AddDays(2),

--- a/Documentation/Blazorise.Docs/Pages/News/2024-10-15-release-notes-170.razor
+++ b/Documentation/Blazorise.Docs/Pages/News/2024-10-15-release-notes-170.razor
@@ -372,7 +372,7 @@
     Find out more in the oficial docs: <Anchor To="docs/extensions/routertabs" Title="RouterTabs Docs">RouterTabs Docs</Anchor>
 </Paragraph>
 
-<Heading Size="HeadingSize.Is4">
+<Heading Size="HeadingSize.Is3">
     <Code Tag>BarItem</Code> no longer has the <Code>cursor: pointer</Code> default behavior.
 </Heading>
 

--- a/Documentation/Blazorise.Docs/Pages/News/2024-10-15-release-notes-170.razor
+++ b/Documentation/Blazorise.Docs/Pages/News/2024-10-15-release-notes-170.razor
@@ -111,12 +111,12 @@
                     </UnorderedListItem>
                 </UnorderedList>
             </Paragraph>
-            
+
         </OrderedListItem>
         <OrderedListItem>
-             <Paragraph>
-                    <Code Tag>BarItem</Code> no longer has the <Code>cursor: pointer</Code> default behavior.
-          </Paragraph>
+            <Paragraph>
+                <Code Tag>BarItem</Code> no longer has the <Code>cursor: pointer</Code> default behavior.
+            </Paragraph>
         </OrderedListItem>
     </OrderedList>
 </Paragraph>
@@ -363,12 +363,12 @@
 </Paragraph>
 
 <Heading Size="HeadingSize.Is3">
-    New RouterTabs component 
+    New RouterTabs component
 </Heading>
 
 <Paragraph>
     We are excited to introduce the new RouterTabs component.
-    After properly setting it up, this component automatically creates tabs per each page the user navigates to.  
+    After properly setting it up, this component automatically creates tabs per each page the user navigates to.
     Find out more in the oficial docs: <Anchor To="docs/extensions/routertabs" Title="RouterTabs Docs">RouterTabs Docs</Anchor>
 </Paragraph>
 
@@ -384,7 +384,6 @@
     If you have a <Code Tag>div</Code> inside a <Code Tag>BarItem</Code>, the default cursor behavior has been updated to reflect these UX improvements.
 </Paragraph>
 
-
 <Heading Size="HeadingSize.Is3">
     <Code>EnabledDates</Code> Property in the <Code Tag>DatePicker</Code> component
 </Heading>
@@ -392,6 +391,5 @@
 <Paragraph>
     The <Code>EnabledDates</Code> property in the <Code Tag>DatePicker</Code> component allows you to specify specific dates that users can select from. This feature is useful when you want to restrict the date selection to a predefined set of enabled dates.
 </Paragraph>
-
 
 <NewsPagePostInfo UserName="Mladen Macanović" ImageName="mladen" PostedOn="October 15th, 2024" Read="7 min" />

--- a/Documentation/Blazorise.Docs/Pages/News/2024-10-15-release-notes-170.razor
+++ b/Documentation/Blazorise.Docs/Pages/News/2024-10-15-release-notes-170.razor
@@ -384,4 +384,14 @@
     If you have a <Code Tag>div</Code> inside a <Code Tag>BarItem</Code>, the default cursor behavior has been updated to reflect these UX improvements.
 </Paragraph>
 
+
+<Heading Size="HeadingSize.Is3">
+    <Code>EnabledDates</Code> Property in the <Code Tag>DatePicker</Code> component
+</Heading>
+
+<Paragraph>
+    The <Code>EnabledDates</Code> property in the <Code Tag>DatePicker</Code> component allows you to specify specific dates that users can select from. This feature is useful when you want to restrict the date selection to a predefined set of enabled dates.
+</Paragraph>
+
+
 <NewsPagePostInfo UserName="Mladen Macanović" ImageName="mladen" PostedOn="October 15th, 2024" Read="7 min" />

--- a/Source/Blazorise/Components/DatePicker/DatePicker.razor.cs
+++ b/Source/Blazorise/Components/DatePicker/DatePicker.razor.cs
@@ -637,7 +637,7 @@ public partial class DatePicker<TValue> : BaseTextInput<IReadOnlyList<TValue>>, 
     [Parameter] public IEnumerable<TValue> DisabledDates { get; set; }
 
     /// <summary>
-    /// List of enabled dates - user can pick only these.
+    /// List of enabled dates that the user should be able to pick.
     /// </summary>
     [Parameter] public IEnumerable<TValue> EnabledDates { get; set; }
     /// <summary>

--- a/Source/Blazorise/Components/DatePicker/DatePicker.razor.cs
+++ b/Source/Blazorise/Components/DatePicker/DatePicker.razor.cs
@@ -71,7 +71,6 @@ public partial class DatePicker<TValue> : BaseTextInput<IReadOnlyList<TValue>>, 
                     ExecuteAfterRender( async () => await JSModule.UpdateValue( ElementRef, ElementId, formatedDateString ) );
                 }
             }
-            Console.WriteLine( $"Params called enbaled date changesd {enabledDatesChanged}" );
 
             if ( minChanged
                  || maxChanged
@@ -637,12 +636,10 @@ public partial class DatePicker<TValue> : BaseTextInput<IReadOnlyList<TValue>>, 
     /// </summary>
     [Parameter] public IEnumerable<TValue> DisabledDates { get; set; }
 
-    #nullable enable
     /// <summary>
     /// List of enabled dates - user can pick only these.
     /// </summary>
-    [Parameter] public IEnumerable<TValue>? EnabledDates { get; set; }
-    #nullable disable
+    [Parameter] public IEnumerable<TValue> EnabledDates { get; set; }
     /// <summary>
     /// List of disabled days in a week that the user should not be able to pick.
     /// </summary>

--- a/Source/Blazorise/Components/DatePicker/DatePicker.razor.cs
+++ b/Source/Blazorise/Components/DatePicker/DatePicker.razor.cs
@@ -50,6 +50,7 @@ public partial class DatePicker<TValue> : BaseTextInput<IReadOnlyList<TValue>>, 
             var disabledChanged = parameters.TryGetValue( nameof( Disabled ), out bool paramDisabled ) && Disabled != paramDisabled;
             var readOnlyChanged = parameters.TryGetValue( nameof( ReadOnly ), out bool paramReadOnly ) && ReadOnly != paramReadOnly;
             var disabledDatesChanged = parameters.TryGetValue( nameof( DisabledDates ), out IEnumerable<TValue> paramDisabledDates ) && !DisabledDates.AreEqual( paramDisabledDates );
+            var enabledDatesChanged = parameters.TryGetValue( nameof( EnabledDates ), out IEnumerable<TValue>? paramEnabledDates ) && !EnabledDates.AreEqual( paramEnabledDates );
             var disabledDaysChanged = parameters.TryGetValue( nameof( DisabledDays ), out IEnumerable<DayOfWeek> paramDisabledDays ) && !DisabledDays.AreEqual( paramDisabledDays );
             var selectionModeChanged = parameters.TryGetValue( nameof( SelectionMode ), out DateInputSelectionMode paramSelectionMode ) && !SelectionMode.IsEqual( paramSelectionMode );
             var inlineChanged = parameters.TryGetValue( nameof( Inline ), out bool paramInline ) && Inline != paramInline;
@@ -70,6 +71,7 @@ public partial class DatePicker<TValue> : BaseTextInput<IReadOnlyList<TValue>>, 
                     ExecuteAfterRender( async () => await JSModule.UpdateValue( ElementRef, ElementId, formatedDateString ) );
                 }
             }
+            Console.WriteLine( $"Params called enbaled date changesd {enabledDatesChanged}" );
 
             if ( minChanged
                  || maxChanged
@@ -80,6 +82,7 @@ public partial class DatePicker<TValue> : BaseTextInput<IReadOnlyList<TValue>>, 
                  || disabledChanged
                  || readOnlyChanged
                  || disabledDatesChanged
+                 || enabledDatesChanged
                  || disabledDaysChanged
                  || selectionModeChanged
                  || inlineChanged
@@ -98,6 +101,7 @@ public partial class DatePicker<TValue> : BaseTextInput<IReadOnlyList<TValue>>, 
                     Disabled = new { Changed = disabledChanged, Value = paramDisabled },
                     ReadOnly = new { Changed = readOnlyChanged, Value = paramReadOnly },
                     DisabledDates = new { Changed = disabledDatesChanged, Value = paramDisabledDates?.Select( x => FormatValueAsString( new TValue[] { x } ) ) },
+                    EnabledDates = new { Changed = enabledDatesChanged, Value = paramEnabledDates?.Select( x => FormatValueAsString( new TValue[] { x } ) ) },
                     DisabledDays = new { Changed = disabledDaysChanged, Value = paramDisabledDays?.Select( x => (int)x ) },
                     SelectionMode = new { Changed = selectionModeChanged, Value = paramSelectionMode },
                     Inline = new { Changed = inlineChanged, Value = paramInline },
@@ -176,6 +180,7 @@ public partial class DatePicker<TValue> : BaseTextInput<IReadOnlyList<TValue>>, 
             Disabled,
             ReadOnly,
             DisabledDates = DisabledDates?.Select( x => FormatValueAsString( new TValue[] { x } ) ),
+            EnabledDates = EnabledDates?.Select( x => FormatValueAsString( new TValue[] { x } ) ),
             DisabledDays = DisabledDays?.Select( x => (int)x ),
             Localization = GetLocalizationObject(),
             Inline,
@@ -632,6 +637,12 @@ public partial class DatePicker<TValue> : BaseTextInput<IReadOnlyList<TValue>>, 
     /// </summary>
     [Parameter] public IEnumerable<TValue> DisabledDates { get; set; }
 
+    #nullable enable
+    /// <summary>
+    /// List of enabled dates - user can pick only these.
+    /// </summary>
+    [Parameter] public IEnumerable<TValue>? EnabledDates { get; set; }
+    #nullable disable
     /// <summary>
     /// List of disabled days in a week that the user should not be able to pick.
     /// </summary>

--- a/Source/Blazorise/wwwroot/datePicker.js
+++ b/Source/Blazorise/wwwroot/datePicker.js
@@ -309,7 +309,7 @@ export function updateOptions(element, elementId, options) {
 
         if (options.enabledDates.changed) {
             if (options.enabledDates.value == null) {
-                picker.set("_enable", undefined);
+                picker.set("enable", [() => true]);
             } else {
                 picker.set("enable", options.enabledDates.value);
             }

--- a/Source/Blazorise/wwwroot/datePicker.js
+++ b/Source/Blazorise/wwwroot/datePicker.js
@@ -81,7 +81,7 @@ export function initialize(dotnetAdapter, element, elementId, options) {
                 }
             }
         },
-        
+
     };
 
     if (options.enabledDates)
@@ -308,7 +308,7 @@ export function updateOptions(element, elementId, options) {
         }
 
         if (options.enabledDates.changed) {
-            if (options.enabledDates.value == null) {
+            if (utilities.isNullOrUndefined(options.enabledDates.value)) {
                 picker.set("enable", [() => true]);
             } else {
                 picker.set("enable", options.enabledDates.value);

--- a/Source/Blazorise/wwwroot/datePicker.js
+++ b/Source/Blazorise/wwwroot/datePicker.js
@@ -43,6 +43,8 @@ export function initialize(dotnetAdapter, element, elementId, options) {
     mutationObserver.observe(document.getElementById(elementId), { attributes: true });
 
     const disableDatesOptions = options.disabledDates || [];
+    const enableDatesOptions = options.enabledDates || [];
+
     const disableDaysOptions = options.disabledDays ? [function (date) {
         return options.disabledDays && options.disabledDays.length > 0 && options.disabledDays.includes(date.getDay());
     }] : [];
@@ -78,8 +80,12 @@ export function initialize(dotnetAdapter, element, elementId, options) {
                     input.id = id;
                 }
             }
-        }
+        },
+        
     };
+
+    if (options.enabledDates)
+        defaultOptions.enable = options.enabledDates;
 
     if (options.selectionMode)
         defaultOptions.mode = options.selectionMode;
@@ -299,6 +305,14 @@ export function updateOptions(element, elementId, options) {
             }] : [];
 
             picker.set("disable", disableDatesOptions.concat(disableDaysOptions));
+        }
+
+        if (options.enabledDates.changed) {
+            if (options.enabledDates.value === null) {
+                picker.set("_enable", undefined);
+            } else {
+                picker.set("enable", options.enabledDates.value);
+            }
         }
 
         if (options.selectionMode.changed) {

--- a/Source/Blazorise/wwwroot/datePicker.js
+++ b/Source/Blazorise/wwwroot/datePicker.js
@@ -308,7 +308,7 @@ export function updateOptions(element, elementId, options) {
         }
 
         if (options.enabledDates.changed) {
-            if (options.enabledDates.value === null) {
+            if (options.enabledDates.value == null) {
                 picker.set("_enable", undefined);
             } else {
                 picker.set("enable", options.enabledDates.value);

--- a/Source/Blazorise/wwwroot/utilities.js
+++ b/Source/Blazorise/wwwroot/utilities.js
@@ -341,6 +341,10 @@ export function createEvent(name) {
     return e;
 }
 
+export function isNullOrUndefined(value) {
+    return value === null || value === undefined;
+}
+
 export function coalesce(value, defaultValue) {
     return value === null || value === undefined ? defaultValue : value;
 }


### PR DESCRIPTION
## Description
Enabled dates in DatePicker.

Few consideration:
- Empty array means "no dates are enabled". For changing from "some enabled dates" to "enable all dates" we need to set the EnabledDates param to null (there are workarounds).. Which will eventually run this code 

```js
//datepicker.js
 picker.set("_enable", undefined);
```
which sets the internal property to undefined. Which is kind of hackie solution (others didn't work), but I didn't noticed any side effects.. Other option is to make all the dates enabled, but this will mess up the dotnet-js synchronization. Note that this code will only run when you set the EnabledDates to null and they were previously set to non-null array. 

- In release notes I fixed heading for my previous PR. Doesn't belong here, but is just a small update. 

Closes #5754

## How Has This Been Tested?

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] The PR is submitted to the correct branch (`master` for dev, `rel-1.x` for maintenance).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
