### PR TITLE
[Fix] Cropper crashing on source change.

### DIFF
--- a/Source/Extensions/Blazorise.Cropper/Cropper.razor.cs
+++ b/Source/Extensions/Blazorise.Cropper/Cropper.razor.cs
@@ -34,7 +34,6 @@ public partial class Cropper : BaseComponent, IAsyncDisposable
             var selectionOptionsChanged = parameters.TryGetValue<CropperSelectionOptions>( nameof( SelectionOptions ), out var paramSelectionOptions ) && paramSelectionOptions != SelectionOptions;
             var gridOptionsChanged = parameters.TryGetValue<CropperGridOptions>( nameof( GridOptions ), out var paramGridOptions ) && paramGridOptions != GridOptions;
             var enabledChanged = parameters.TryGetValue<bool>( nameof( Enabled ), out var paramEnabled ) && paramEnabled != Enabled;
-
             if ( sourceChanged
                 || altChanged
                 || crossoriginChanged
@@ -43,16 +42,20 @@ public partial class Cropper : BaseComponent, IAsyncDisposable
                 || gridOptionsChanged
                 || enabledChanged )
             {
+                Console.WriteLine( $"Source changed {sourceChanged}. JsModel is null {JSModule ==null}. ElementRef {ElementRef}, ElemeId {ElementId==null} " );
+
                 ExecuteAfterRender( async () => await JSModule.UpdateOptions( ElementRef, ElementId, new
                 {
-                    Source = new { Changed = sourceChanged, Value = paramSource },
+                    
+
+                Source = new { Changed = sourceChanged, Value = paramSource },
                     Alt = new { Changed = altChanged, Value = paramAlt },
                     CrossOrigin = new { Changed = crossoriginChanged, Value = paramCrossOrigin },
                     Image = new
                     {
                         Changed = imageOptionsChanged,
                         Value = new
-                        {
+                        {   
                             Rotatable = paramImageOptions?.Rotatable ?? true,
                             Scalable = paramImageOptions?.Scalable ?? true,
                             Skewable = paramImageOptions?.Skewable ?? true,
@@ -66,7 +69,7 @@ public partial class Cropper : BaseComponent, IAsyncDisposable
                         {
                             AspectRatio = paramSelectionOptions?.AspectRatio.Value,
                             InitialAspectRatio = paramSelectionOptions?.InitialAspectRatio.Value,
-                            InitialCoverage = paramSelectionOptions.InitialCoverage,
+                            InitialCoverage = paramSelectionOptions?.InitialCoverage.Value,
                             Movable = paramSelectionOptions?.Movable ?? false,
                             Resizable = paramSelectionOptions?.Resizable ?? false,
                             Zoomable = paramSelectionOptions?.Zoomable ?? false,

--- a/Source/Extensions/Blazorise.Cropper/Cropper.razor.cs
+++ b/Source/Extensions/Blazorise.Cropper/Cropper.razor.cs
@@ -42,20 +42,16 @@ public partial class Cropper : BaseComponent, IAsyncDisposable
                 || gridOptionsChanged
                 || enabledChanged )
             {
-                Console.WriteLine( $"Source changed {sourceChanged}. JsModel is null {JSModule ==null}. ElementRef {ElementRef}, ElemeId {ElementId==null} " );
-
                 ExecuteAfterRender( async () => await JSModule.UpdateOptions( ElementRef, ElementId, new
                 {
-                    
-
-                Source = new { Changed = sourceChanged, Value = paramSource },
+                    Source = new { Changed = sourceChanged, Value = paramSource },
                     Alt = new { Changed = altChanged, Value = paramAlt },
                     CrossOrigin = new { Changed = crossoriginChanged, Value = paramCrossOrigin },
                     Image = new
                     {
                         Changed = imageOptionsChanged,
                         Value = new
-                        {   
+                        {
                             Rotatable = paramImageOptions?.Rotatable ?? true,
                             Scalable = paramImageOptions?.Scalable ?? true,
                             Skewable = paramImageOptions?.Skewable ?? true,


### PR DESCRIPTION
## Description

Closes #5809

The stuff that was null was actually null was the paramSelectionOptions. The bug appears only if you don't set the `paramSelectionOptions` (that's why it pass the tests).

 The `InitialConverage` is null anyway if you don't set it. So I think the omitting of the null check was just an oversight. 

## How Has This Been Tested?

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] The PR is submitted to the correct branch (`master` for dev, `rel-1.x` for maintenance).
- [ ] My code follows the code style of this project.
- [ ] I've added relevant tests.
