### PR TITLE
Docs: Components which require a Blazorise license

### DIFF
--- a/Documentation/Blazorise.Docs/Components/Commercial/PlansComparer.razor
+++ b/Documentation/Blazorise.Docs/Components/Commercial/PlansComparer.razor
@@ -1,4 +1,5 @@
 ﻿@using System.Globalization
+@using Blazorise.Licensing
 <Paragraph TextSize="TextSize.Heading1" TextAlignment="TextAlignment.Center" Margin="Margin.Is5.FromTop.Is4.FromBottom">
     Compare Plan Features
 </Paragraph>
@@ -302,7 +303,7 @@
             <TableRowHeader Flex="Flex.JustifyContent.Between">
                 DataGrid
             </TableRowHeader>
-            <TableRowCell>10000 rows</TableRowCell>
+            <TableRowCell>@BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_DATAGRID_MAX_ROWS rows</TableRowCell>
             <TableRowCell><Icon Name="IconName.Infinity" TextColor="TextColor.Primary" /></TableRowCell>
             <TableRowCell><Icon Name="IconName.Infinity" TextColor="TextColor.Primary" /></TableRowCell>
             <TableRowCell><Icon Name="IconName.Infinity" TextColor="TextColor.Primary" /></TableRowCell>
@@ -311,7 +312,7 @@
             <TableRowHeader Flex="Flex.JustifyContent.Between">
                 Autocomplete
             </TableRowHeader>
-            <TableRowCell>10000 items</TableRowCell>
+            <TableRowCell>@BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_AUTOCOMPLETE_MAX_ROWS items</TableRowCell>
             <TableRowCell><Icon Name="IconName.Infinity" TextColor="TextColor.Primary" /></TableRowCell>
             <TableRowCell><Icon Name="IconName.Infinity" TextColor="TextColor.Primary" /></TableRowCell>
             <TableRowCell><Icon Name="IconName.Infinity" TextColor="TextColor.Primary" /></TableRowCell>
@@ -320,7 +321,7 @@
             <TableRowHeader Flex="Flex.JustifyContent.Between">
                 Charts
             </TableRowHeader>
-            <TableRowCell>100 points</TableRowCell>
+            <TableRowCell>@BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_CHARTS_MAX_ROWS points</TableRowCell>
             <TableRowCell><Icon Name="IconName.Infinity" TextColor="TextColor.Primary" /></TableRowCell>
             <TableRowCell><Icon Name="IconName.Infinity" TextColor="TextColor.Primary" /></TableRowCell>
             <TableRowCell><Icon Name="IconName.Infinity" TextColor="TextColor.Primary" /></TableRowCell>
@@ -329,7 +330,7 @@
             <TableRowHeader Flex="Flex.JustifyContent.Between">
                 ListView
             </TableRowHeader>
-            <TableRowCell>10000 items</TableRowCell>
+            <TableRowCell>@BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_LISTVIEW_MAX_ROWS items</TableRowCell>
             <TableRowCell><Icon Name="IconName.Infinity" TextColor="TextColor.Primary" /></TableRowCell>
             <TableRowCell><Icon Name="IconName.Infinity" TextColor="TextColor.Primary" /></TableRowCell>
             <TableRowCell><Icon Name="IconName.Infinity" TextColor="TextColor.Primary" /></TableRowCell>
@@ -347,7 +348,7 @@
             <TableRowHeader Flex="Flex.JustifyContent.Between">
                 TreeView
             </TableRowHeader>
-            <TableRowCell>1000 nodes</TableRowCell>
+            <TableRowCell>@BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_TREEVIEW_MAX_ROWS nodes</TableRowCell>
             <TableRowCell><Icon Name="IconName.Infinity" TextColor="TextColor.Primary" /></TableRowCell>
             <TableRowCell><Icon Name="IconName.Infinity" TextColor="TextColor.Primary" /></TableRowCell>
             <TableRowCell><Icon Name="IconName.Infinity" TextColor="TextColor.Primary" /></TableRowCell>

--- a/Documentation/Blazorise.Docs/Components/Commercial/PlansComparer.razor
+++ b/Documentation/Blazorise.Docs/Components/Commercial/PlansComparer.razor
@@ -31,7 +31,7 @@
             <TableHeaderCell style="width: 15%;">
                 <Div Flex="Flex.InlineFlex.Column.JustifyContent.Center.AlignItems.Center">
                     <Div>
-                    Enterprise
+                        Enterprise
                     </Div>
                     <Div Padding="Padding.Is2.OnY">
                         <Span>@($"${( EnterprisePrices[Plan].Price * Quantity ).ToString( CultureInfo.InvariantCulture )}")</Span><Small TextColor="TextColor.Muted" TextWeight="TextWeight.Light">/@ProfessionalPrices[Plan].Unit</Small>
@@ -47,7 +47,7 @@
                         <Small TextColor="TextColor.Muted" TextWeight="TextWeight.Light">On Request</Small>
                     </Div>
                 </Div>
-                </TableHeaderCell>
+            </TableHeaderCell>
         </TableRow>
     </TableHeader>
     <TableBody>

--- a/Documentation/Blazorise.Docs/Components/LicenseLimitationAlert.razor
+++ b/Documentation/Blazorise.Docs/Components/LicenseLimitationAlert.razor
@@ -5,7 +5,6 @@
     </Anchor>
 </Alert>
 
-
 @code {
     [Parameter, EditorRequired] public string LimitText { get; set; } = "";
 }

--- a/Documentation/Blazorise.Docs/Components/LicenseLimitationAlert.razor
+++ b/Documentation/Blazorise.Docs/Components/LicenseLimitationAlert.razor
@@ -1,6 +1,6 @@
 ﻿<Alert Color="Color.Warning" Visible>
-    📊 The Community License has a limitation of @LimitText. Unlock full access to all features with 
-    <Anchor To="pricing" Target="Target.Blank" Class="text-decoration-none" >
+    📊 The Community License has a limitation of @LimitText. Unlock full access to all features with
+    <Anchor To="pricing" Target="Target.Blank" Title="Link to premium plans" Class="text-decoration-none">
         our premium plans.
     </Anchor>
 </Alert>

--- a/Documentation/Blazorise.Docs/Components/LicenseLimitationAlert.razor
+++ b/Documentation/Blazorise.Docs/Components/LicenseLimitationAlert.razor
@@ -1,8 +1,7 @@
-﻿
-<Alert Color="Color.Warning" Visible>
-    📊 Community license has a limitation of @LimitText.
+﻿<Alert Color="Color.Warning" Visible>
+    📊 The Community License has a limitation of @LimitText. Unlock full access to all features with 
     <Anchor To="pricing" Target="Target.Blank" Class="text-decoration-none" >
-        See pricing.
+        our premium plans.
     </Anchor>
 </Alert>
 

--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/Autocomplete/AutocompletePage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/Autocomplete/AutocompletePage.razor
@@ -11,7 +11,7 @@
 </DocsPageLead>
 
 <DocsPageParagraph>
-    <LicenseLimitation LimitText="@($"{Licensing.BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_AUTOCOMPLETE_MAX_ROWS}  items")"/>
+    <LicenseLimitationAlert LimitText="@($"{Licensing.BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_AUTOCOMPLETE_MAX_ROWS}  items")"/>
 </DocsPageParagraph>
 
 <DocsPageParagraph>

--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/Autocomplete/AutocompletePage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/Autocomplete/AutocompletePage.razor
@@ -11,6 +11,10 @@
 </DocsPageLead>
 
 <DocsPageParagraph>
+    <LicenseLimitation LimitText="@($"{Licensing.BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_AUTOCOMPLETE_MAX_ROWS}  items")"/>
+</DocsPageParagraph>
+
+<DocsPageParagraph>
     The <Code>Autocomplete</Code> component provides suggestions while you type into the field. The component is in essence
     a text box which, at runtime, filters data in a drop-down by a <Code>Filter</Code> operator when a user captures a value.
     You may also enable <Code>FreeTyping</Code> and <Code>Autocomplete</Code> can be used to just provide suggestions based on user input.

--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/Autocomplete/AutocompletePage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/Autocomplete/AutocompletePage.razor
@@ -11,7 +11,7 @@
 </DocsPageLead>
 
 <DocsPageParagraph>
-    <LicenseLimitationAlert LimitText="@($"{Licensing.BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_AUTOCOMPLETE_MAX_ROWS}  items")" />
+    <LicenseLimitationAlert LimitText="@($"{Licensing.BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_AUTOCOMPLETE_MAX_ROWS} items")" />
 </DocsPageParagraph>
 
 <DocsPageParagraph>

--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/Autocomplete/AutocompletePage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/Autocomplete/AutocompletePage.razor
@@ -11,7 +11,7 @@
 </DocsPageLead>
 
 <DocsPageParagraph>
-    <LicenseLimitationAlert LimitText="@($"{Licensing.BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_AUTOCOMPLETE_MAX_ROWS}  items")"/>
+    <LicenseLimitationAlert LimitText="@($"{Licensing.BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_AUTOCOMPLETE_MAX_ROWS}  items")" />
 </DocsPageParagraph>
 
 <DocsPageParagraph>

--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/Chart/ChartPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/Chart/ChartPage.razor
@@ -11,7 +11,7 @@
 </DocsPageLead>
 
 <DocsPageParagraph>
-    <LicenseLimitationAlert LimitText="@($"{Licensing.BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_CHARTS_MAX_ROWS}  points")" />
+    <LicenseLimitationAlert LimitText="@($"{Licensing.BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_CHARTS_MAX_ROWS} points per chart")" />
 </DocsPageParagraph>
 
 <DocsPageParagraph>

--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/Chart/ChartPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/Chart/ChartPage.razor
@@ -11,7 +11,7 @@
 </DocsPageLead>
 
 <DocsPageParagraph>
-    <LicenseLimitationAlert LimitText="@($"{Licensing.BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_CHARTS_MAX_ROWS}  points")"/> 
+    <LicenseLimitationAlert LimitText="@($"{Licensing.BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_CHARTS_MAX_ROWS}  points")" />
 </DocsPageParagraph>
 
 <DocsPageParagraph>

--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/Chart/ChartPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/Chart/ChartPage.razor
@@ -11,6 +11,10 @@
 </DocsPageLead>
 
 <DocsPageParagraph>
+    <LicenseLimitation LimitText="@($"{Licensing.BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_CHARTS_MAX_ROWS}  points")"/> 
+</DocsPageParagraph>
+
+<DocsPageParagraph>
     The chart extension is defined of several different chart components. Each of the chart type have it’s own dataset and option settings.
 </DocsPageParagraph>
 

--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/Chart/ChartPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/Chart/ChartPage.razor
@@ -11,7 +11,7 @@
 </DocsPageLead>
 
 <DocsPageParagraph>
-    <LicenseLimitation LimitText="@($"{Licensing.BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_CHARTS_MAX_ROWS}  points")"/> 
+    <LicenseLimitationAlert LimitText="@($"{Licensing.BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_CHARTS_MAX_ROWS}  points")"/> 
 </DocsPageParagraph>
 
 <DocsPageParagraph>

--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/ChartDataLabels/ChartDataLabelsPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/ChartDataLabels/ChartDataLabelsPage.razor
@@ -11,7 +11,7 @@
 </DocsPageLead>
 
 <DocsPageParagraph>
-    <LicenseLimitationAlert LimitText="@($"{Licensing.BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_CHARTS_MAX_ROWS}  points")" />
+    <LicenseLimitationAlert LimitText="@($"{Licensing.BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_CHARTS_MAX_ROWS} points per chart")" />
 </DocsPageParagraph>
 
 <DocsPageParagraph>

--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/ChartDataLabels/ChartDataLabelsPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/ChartDataLabels/ChartDataLabelsPage.razor
@@ -11,6 +11,10 @@
 </DocsPageLead>
 
 <DocsPageParagraph>
+    <LicenseLimitationAlert LimitText="@($"{Licensing.BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_CHARTS_MAX_ROWS}  points")" />
+</DocsPageParagraph>
+
+<DocsPageParagraph>
     DataLabels is made possible with the help of <Anchor To="https://chartjs-plugin-datalabels.netlify.app/" Title="Link to chart DataLabels plugin" Target="Target.Blank">chartjs-plugin-datalabels</Anchor>.
 </DocsPageParagraph>
 

--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/ChartStreaming/ChartStreamingPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/ChartStreaming/ChartStreamingPage.razor
@@ -11,7 +11,7 @@
 </DocsPageLead>
 
 <DocsPageParagraph>
-    <LicenseLimitationAlert LimitText="@($"{Licensing.BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_CHARTS_MAX_ROWS}  points")" />
+    <LicenseLimitationAlert LimitText="@($"{Licensing.BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_CHARTS_MAX_ROWS} points per chart")" />
 </DocsPageParagraph>
 
 <DocsPageParagraph>

--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/ChartStreaming/ChartStreamingPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/ChartStreaming/ChartStreamingPage.razor
@@ -11,6 +11,10 @@
 </DocsPageLead>
 
 <DocsPageParagraph>
+    <LicenseLimitationAlert LimitText="@($"{Licensing.BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_CHARTS_MAX_ROWS}  points")" />
+</DocsPageParagraph>
+
+<DocsPageParagraph>
     Live streaming is made possible with the help of <Anchor To="https://nagix.github.io/chartjs-plugin-streaming/latest/" Title="Link to chart streaming plugin" Target="Target.Blank">chartjs-plugin-streaming</Anchor>.
 </DocsPageParagraph>
 

--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/ChartTrendline/ChartTrendlinePage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/ChartTrendline/ChartTrendlinePage.razor
@@ -11,7 +11,7 @@
 </DocsPageLead>
 
 <DocsPageParagraph>
-    <LicenseLimitationAlert LimitText="@($"{Licensing.BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_CHARTS_MAX_ROWS}  points")" />
+    <LicenseLimitationAlert LimitText="@($"{Licensing.BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_CHARTS_MAX_ROWS} points per chart")" />
 </DocsPageParagraph>
 
 <DocsPageParagraph>

--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/ChartTrendline/ChartTrendlinePage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/ChartTrendline/ChartTrendlinePage.razor
@@ -11,6 +11,10 @@
 </DocsPageLead>
 
 <DocsPageParagraph>
+    <LicenseLimitationAlert LimitText="@($"{Licensing.BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_CHARTS_MAX_ROWS}  points")" />
+</DocsPageParagraph>
+
+<DocsPageParagraph>
     Trendline is made possible with the help of <Anchor To="https://github.com/Makanz/chartjs-plugin-trendline" Title="Link to chart trendline plugin" Target="Target.Blank">chartjs-plugin-trendline</Anchor>.
 </DocsPageParagraph>
 

--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/ChartsAnnotation/ChartAnnotationPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/ChartsAnnotation/ChartAnnotationPage.razor
@@ -11,6 +11,10 @@
 </DocsPageLead>
 
 <DocsPageParagraph>
+    <LicenseLimitationAlert LimitText="@($"{Licensing.BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_CHARTS_MAX_ROWS}  points")" />
+</DocsPageParagraph>
+
+<DocsPageParagraph>
     Annotations work with line, bar, scatter and bubble charts that use linear, logarithmic, time, or category scales. Annotations will not work on any chart that does not have two or more axes, including pie, radar, and polar area charts.
 </DocsPageParagraph>
 

--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/ChartsAnnotation/ChartAnnotationPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/ChartsAnnotation/ChartAnnotationPage.razor
@@ -11,7 +11,7 @@
 </DocsPageLead>
 
 <DocsPageParagraph>
-    <LicenseLimitationAlert LimitText="@($"{Licensing.BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_CHARTS_MAX_ROWS}  points")" />
+    <LicenseLimitationAlert LimitText="@($"{Licensing.BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_CHARTS_MAX_ROWS} points per chart")" />
 </DocsPageParagraph>
 
 <DocsPageParagraph>

--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/ChartsZoom/ChartsZoomPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/ChartsZoom/ChartsZoomPage.razor
@@ -11,7 +11,7 @@
 </DocsPageLead>
 
 <DocsPageParagraph>
-    <LicenseLimitationAlert LimitText="@($"{Licensing.BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_CHARTS_MAX_ROWS}  points")" />
+    <LicenseLimitationAlert LimitText="@($"{Licensing.BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_CHARTS_MAX_ROWS} points per chart")" />
 </DocsPageParagraph>
 
 <DocsPageParagraph>

--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/ChartsZoom/ChartsZoomPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/ChartsZoom/ChartsZoomPage.razor
@@ -11,6 +11,10 @@
 </DocsPageLead>
 
 <DocsPageParagraph>
+    <LicenseLimitationAlert LimitText="@($"{Licensing.BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_CHARTS_MAX_ROWS}  points")" />
+</DocsPageParagraph>
+
+<DocsPageParagraph>
     Zoom is made possible with the help of <Anchor To="https://www.chartjs.org/chartjs-plugin-zoom/latest/" Title="Link to chart Zoom plugin" Target="Target.Blank">chartjs-plugin-zoom</Anchor>.
 </DocsPageParagraph>
 

--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/DataGrid/GettingStartedPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/DataGrid/GettingStartedPage.razor
@@ -12,7 +12,7 @@
 </DocsPageLead>
 
 <DocsPageParagraph>
-    <LicenseLimitationAlert LimitText="@($"{Licensing.BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_DATAGRID_MAX_ROWS}  items")"/>
+    <LicenseLimitationAlert LimitText="@($"{Licensing.BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_DATAGRID_MAX_ROWS}  items")" />
 </DocsPageParagraph>
 
 <DocsPageParagraph>

--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/DataGrid/GettingStartedPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/DataGrid/GettingStartedPage.razor
@@ -12,7 +12,7 @@
 </DocsPageLead>
 
 <DocsPageParagraph>
-    <LicenseLimitation LimitText="@($"{Licensing.BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_DATAGRID_MAX_ROWS}  items")"/>
+    <LicenseLimitationAlert LimitText="@($"{Licensing.BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_DATAGRID_MAX_ROWS}  items")"/>
 </DocsPageParagraph>
 
 <DocsPageParagraph>

--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/DataGrid/GettingStartedPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/DataGrid/GettingStartedPage.razor
@@ -12,7 +12,7 @@
 </DocsPageLead>
 
 <DocsPageParagraph>
-    <LicenseLimitationAlert LimitText="@($"{Licensing.BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_DATAGRID_MAX_ROWS}  items")" />
+    <LicenseLimitationAlert LimitText="@($"{Licensing.BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_DATAGRID_MAX_ROWS} items")" />
 </DocsPageParagraph>
 
 <DocsPageParagraph>

--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/DataGrid/GettingStartedPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/DataGrid/GettingStartedPage.razor
@@ -12,6 +12,10 @@
 </DocsPageLead>
 
 <DocsPageParagraph>
+    <LicenseLimitation LimitText="@($"{Licensing.BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_DATAGRID_MAX_ROWS}  items")"/>
+</DocsPageParagraph>
+
+<DocsPageParagraph>
     To create a basic grid in Blazorise you need to set the Column that will define the grid structure and behavior.
 </DocsPageParagraph>
 

--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/Index.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/Index.razor
@@ -1,6 +1,6 @@
 ﻿@page "/docs/extensions"
 
-<Seo Canonical="/docs/extensions" Title="Blazorise extensions" Description="Learn about Blazorise UI extensions and how to properly install and use them to build your Blazor single page application." />
+<Seo Canonical="/docs/extensions" Title="Blazorise extensions" Description="Learn about Blazorise UI extensions and how to properly install and use them to build your Blazor single page application."/>
 
 <DocsPageTitle Path="Extensions">
     Blazorise extensions
@@ -11,13 +11,14 @@
 </DocsPageLead>
 
 <Row RowColumns="RowColumns.Are4.OnTablet.Are2.OnMobile">
-    @foreach ( var info in ( PageEntries ?? Enumerable.Empty<PageEntry>() ).Where( x => x.Url.StartsWith( "docs/extensions" ) && !string.IsNullOrEmpty( x.Description ) ) )
+    @foreach(var info in (PageEntries ?? Enumerable.Empty<PageEntry>()).Where(x => x.Url.StartsWith("docs/extensions") && !string.IsNullOrEmpty(x.Description)))
     {
         <Column Margin="Margin.Is3.FromBottom">
-            <DocsPageComponentInfo @key="@info" Name="@info.Name" Description="@info.Description" To="@info.Url" />
+            <DocsPageComponentInfo @key="@info" Name="@info.Name" Description="@info.Description" To="@info.Url"/>
         </Column>
     }
 </Row>
+
 @code {
     public IEnumerable<PageEntry> PageEntries;
 

--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/Index.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/Index.razor
@@ -1,6 +1,6 @@
 ﻿@page "/docs/extensions"
 
-<Seo Canonical="/docs/extensions" Title="Blazorise extensions" Description="Learn about Blazorise UI extensions and how to properly install and use them to build your Blazor single page application."/>
+<Seo Canonical="/docs/extensions" Title="Blazorise extensions" Description="Learn about Blazorise UI extensions and how to properly install and use them to build your Blazor single page application." />
 
 <DocsPageTitle Path="Extensions">
     Blazorise extensions
@@ -11,10 +11,10 @@
 </DocsPageLead>
 
 <Row RowColumns="RowColumns.Are4.OnTablet.Are2.OnMobile">
-    @foreach(var info in (PageEntries ?? Enumerable.Empty<PageEntry>()).Where(x => x.Url.StartsWith("docs/extensions") && !string.IsNullOrEmpty(x.Description)))
+    @foreach ( var info in ( PageEntries ?? Enumerable.Empty<PageEntry>() ).Where( x => x.Url.StartsWith( "docs/extensions" ) && !string.IsNullOrEmpty( x.Description) ) )
     {
         <Column Margin="Margin.Is3.FromBottom">
-            <DocsPageComponentInfo @key="@info" Name="@info.Name" Description="@info.Description" To="@info.Url"/>
+            <DocsPageComponentInfo @key="@info" Name="@info.Name" Description="@info.Description" To="@info.Url" />
         </Column>
     }
 </Row>

--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/LicenseLimitation.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/LicenseLimitation.razor
@@ -1,0 +1,12 @@
+﻿
+<Alert Color="Color.Warning" Visible>
+    📊 Community license has a limitation of @LimitText.
+    <Anchor To="pricing" Target="Target.Blank" Class="text-decoration-none" >
+        See pricing.
+    </Anchor>
+</Alert>
+
+
+@code {
+    [Parameter, EditorRequired] public string LimitText { get; set; } = "";
+}

--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/ListView/ListViewPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/ListView/ListViewPage.razor
@@ -11,6 +11,10 @@
 </DocsPageLead>
 
 <DocsPageParagraph>
+    <LicenseLimitation LimitText="@($"{Licensing.BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_LISTVIEW_MAX_ROWS}  items")"/>
+</DocsPageParagraph>
+
+<DocsPageParagraph>
     List views use <Code>ListGroup</Code> behind the covers, so you may make use of the <Code>ListGroup</Code> underlying APIs.
 </DocsPageParagraph>
 

--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/ListView/ListViewPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/ListView/ListViewPage.razor
@@ -11,7 +11,7 @@
 </DocsPageLead>
 
 <DocsPageParagraph>
-    <LicenseLimitationAlert LimitText="@($"{Licensing.BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_LISTVIEW_MAX_ROWS}  items")"/>
+    <LicenseLimitationAlert LimitText="@($"{Licensing.BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_LISTVIEW_MAX_ROWS}  items")" />
 </DocsPageParagraph>
 
 <DocsPageParagraph>

--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/ListView/ListViewPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/ListView/ListViewPage.razor
@@ -11,7 +11,7 @@
 </DocsPageLead>
 
 <DocsPageParagraph>
-    <LicenseLimitationAlert LimitText="@($"{Licensing.BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_LISTVIEW_MAX_ROWS}  items")" />
+    <LicenseLimitationAlert LimitText="@($"{Licensing.BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_LISTVIEW_MAX_ROWS} items")" />
 </DocsPageParagraph>
 
 <DocsPageParagraph>

--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/ListView/ListViewPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/ListView/ListViewPage.razor
@@ -11,7 +11,7 @@
 </DocsPageLead>
 
 <DocsPageParagraph>
-    <LicenseLimitation LimitText="@($"{Licensing.BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_LISTVIEW_MAX_ROWS}  items")"/>
+    <LicenseLimitationAlert LimitText="@($"{Licensing.BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_LISTVIEW_MAX_ROWS}  items")"/>
 </DocsPageParagraph>
 
 <DocsPageParagraph>

--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/TreeView/TreeViewPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/TreeView/TreeViewPage.razor
@@ -11,7 +11,7 @@
 </DocsPageLead>
 
 <DocsPageParagraph>
-    <LicenseLimitation LimitText="@($"{Licensing.BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_TREEVIEW_MAX_ROWS}  nodes")"/>
+    <LicenseLimitationAlert LimitText="@($"{Licensing.BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_TREEVIEW_MAX_ROWS}  nodes")"/>
 </DocsPageParagraph>
 
 <DocsPageParagraph>

--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/TreeView/TreeViewPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/TreeView/TreeViewPage.razor
@@ -11,7 +11,7 @@
 </DocsPageLead>
 
 <DocsPageParagraph>
-    <LicenseLimitationAlert LimitText="@($"{Licensing.BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_TREEVIEW_MAX_ROWS}  nodes")" />
+    <LicenseLimitationAlert LimitText="@($"{Licensing.BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_TREEVIEW_MAX_ROWS} nodes")" />
 </DocsPageParagraph>
 
 <DocsPageParagraph>

--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/TreeView/TreeViewPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/TreeView/TreeViewPage.razor
@@ -1,6 +1,6 @@
 ﻿@page "/docs/extensions/treeview"
 
-<Seo Canonical="/docs/extensions/treeview" Title="Blazorise TreeView component" Description="Learn to use and work with the Blazorise TreeView component, a component used to display hierarchical data."/>
+<Seo Canonical="/docs/extensions/treeview" Title="Blazorise TreeView component" Description="Learn to use and work with the Blazorise TreeView component, a component used to display hierarchical data." />
 
 <DocsPageTitle Path="Extensions/TreeView">
     Blazorise TreeView component
@@ -11,7 +11,7 @@
 </DocsPageLead>
 
 <DocsPageParagraph>
-    <LicenseLimitationAlert LimitText="@($"{Licensing.BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_TREEVIEW_MAX_ROWS}  nodes")"/>
+    <LicenseLimitationAlert LimitText="@($"{Licensing.BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_TREEVIEW_MAX_ROWS}  nodes")" />
 </DocsPageParagraph>
 
 <DocsPageParagraph>
@@ -80,7 +80,7 @@
     <DocsPageSectionHeader Title="Static files">
         Include CSS link into your <Code>index.html</Code> or <Code>_Layout.cshtml</Code> / <Code>_Host.cshtml</Code> file, depending if you’re using a Blazor WebAssembly or Blazor Server side project.
     </DocsPageSectionHeader>
-    <DocsPageSectionSource Code="TreeViewResourcesExample"/>
+    <DocsPageSectionSource Code="TreeViewResourcesExample" />
 </DocsPageSection>
 
 <DocsPageSection>
@@ -88,9 +88,9 @@
         A basic TreeView that aims to reproduce standard tree-view behavior.
     </DocsPageSectionHeader>
     <DocsPageSectionContent Outlined FullWidth>
-        <TreeViewExample/>
+        <TreeViewExample />
     </DocsPageSectionContent>
-    <DocsPageSectionSource Code="TreeViewExample"/>
+    <DocsPageSectionSource Code="TreeViewExample" />
 </DocsPageSection>
 
 <DocsPageSection>
@@ -98,9 +98,9 @@
         By default, all nodes are collapsed except for the root node(s). To expand a node, click on the triangle icon next to its label. To collapse a node, click on the triangle icon again. You can also programmatically expand or collapse nodes using the <Code>ExpandAll()</Code> and <Code>CollapseAll()</Code> property of the TreeView class.
     </DocsPageSectionHeader>
     <DocsPageSectionContent Outlined FullWidth>
-        <TreeViewExpandExample/>
+        <TreeViewExpandExample />
     </DocsPageSectionContent>
-    <DocsPageSectionSource Code="TreeViewExpandExample"/>
+    <DocsPageSectionSource Code="TreeViewExpandExample" />
 </DocsPageSection>
 
 <DocsPageSection>
@@ -113,9 +113,9 @@
         </Paragraph>
     </DocsPageSectionHeader>
     <DocsPageSectionContent Outlined FullWidth>
-        <TreeViewMultiSelectExample/>
+        <TreeViewMultiSelectExample />
     </DocsPageSectionContent>
-    <DocsPageSectionSource Code="TreeViewMultiSelectExample"/>
+    <DocsPageSectionSource Code="TreeViewMultiSelectExample" />
 </DocsPageSection>
 
 <DocsPageSection>
@@ -131,9 +131,9 @@
         </Paragraph>
     </DocsPageSectionHeader>
     <DocsPageSectionContent Outlined FullWidth>
-        <TreeViewObservableExample/>
+        <TreeViewObservableExample />
     </DocsPageSectionContent>
-    <DocsPageSectionSource Code="TreeViewObservableExample"/>
+    <DocsPageSectionSource Code="TreeViewObservableExample" />
 </DocsPageSection>
 
 <DocsPageSection>
@@ -158,9 +158,9 @@
         </Paragraph>
     </DocsPageSectionHeader>
     <DocsPageSectionContent Outlined FullWidth>
-        <TreeViewContextMenuExample/>
+        <TreeViewContextMenuExample />
     </DocsPageSectionContent>
-    <DocsPageSectionSource Code="TreeViewContextMenuExample"/>
+    <DocsPageSectionSource Code="TreeViewContextMenuExample" />
 </DocsPageSection>
 
 <DocsPageSection>
@@ -188,9 +188,9 @@
         </Paragraph>
     </DocsPageSectionHeader>
     <DocsPageSectionContent Outlined FullWidth>
-        <TreeViewVirtualizationExample/>
+        <TreeViewVirtualizationExample />
     </DocsPageSectionContent>
-    <DocsPageSectionSource Code="TreeViewVirtualizationExample"/>
+    <DocsPageSectionSource Code="TreeViewVirtualizationExample" />
 </DocsPageSection>
 
 <DocsPageSubtitle>

--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/TreeView/TreeViewPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/TreeView/TreeViewPage.razor
@@ -1,6 +1,6 @@
 ﻿@page "/docs/extensions/treeview"
 
-<Seo Canonical="/docs/extensions/treeview" Title="Blazorise TreeView component" Description="Learn to use and work with the Blazorise TreeView component, a component used to display hierarchical data." />
+<Seo Canonical="/docs/extensions/treeview" Title="Blazorise TreeView component" Description="Learn to use and work with the Blazorise TreeView component, a component used to display hierarchical data."/>
 
 <DocsPageTitle Path="Extensions/TreeView">
     Blazorise TreeView component
@@ -9,6 +9,10 @@
 <DocsPageLead>
     The <Code>TreeView</Code> component is a graphical control element that presents a hierarchical view of information.
 </DocsPageLead>
+
+<DocsPageParagraph>
+    <LicenseLimitation LimitText="@($"{Licensing.BlazoriseLicenseProvider.DEFAULT_UNLICENSED_LIMIT_TREEVIEW_MAX_ROWS}  nodes")"/>
+</DocsPageParagraph>
 
 <DocsPageParagraph>
     The TreeView component is a powerful and flexible way to display hierarchical data in a tree-like structure. It allows users to navigate through the tree and perform actions on the nodes, such as expanding or collapsing them, selecting them, or performing other operations.
@@ -76,7 +80,7 @@
     <DocsPageSectionHeader Title="Static files">
         Include CSS link into your <Code>index.html</Code> or <Code>_Layout.cshtml</Code> / <Code>_Host.cshtml</Code> file, depending if you’re using a Blazor WebAssembly or Blazor Server side project.
     </DocsPageSectionHeader>
-    <DocsPageSectionSource Code="TreeViewResourcesExample" />
+    <DocsPageSectionSource Code="TreeViewResourcesExample"/>
 </DocsPageSection>
 
 <DocsPageSection>
@@ -84,9 +88,9 @@
         A basic TreeView that aims to reproduce standard tree-view behavior.
     </DocsPageSectionHeader>
     <DocsPageSectionContent Outlined FullWidth>
-        <TreeViewExample />
+        <TreeViewExample/>
     </DocsPageSectionContent>
-    <DocsPageSectionSource Code="TreeViewExample" />
+    <DocsPageSectionSource Code="TreeViewExample"/>
 </DocsPageSection>
 
 <DocsPageSection>
@@ -94,9 +98,9 @@
         By default, all nodes are collapsed except for the root node(s). To expand a node, click on the triangle icon next to its label. To collapse a node, click on the triangle icon again. You can also programmatically expand or collapse nodes using the <Code>ExpandAll()</Code> and <Code>CollapseAll()</Code> property of the TreeView class.
     </DocsPageSectionHeader>
     <DocsPageSectionContent Outlined FullWidth>
-        <TreeViewExpandExample />
+        <TreeViewExpandExample/>
     </DocsPageSectionContent>
-    <DocsPageSectionSource Code="TreeViewExpandExample" />
+    <DocsPageSectionSource Code="TreeViewExpandExample"/>
 </DocsPageSection>
 
 <DocsPageSection>
@@ -109,9 +113,9 @@
         </Paragraph>
     </DocsPageSectionHeader>
     <DocsPageSectionContent Outlined FullWidth>
-        <TreeViewMultiSelectExample />
+        <TreeViewMultiSelectExample/>
     </DocsPageSectionContent>
-    <DocsPageSectionSource Code="TreeViewMultiSelectExample" />
+    <DocsPageSectionSource Code="TreeViewMultiSelectExample"/>
 </DocsPageSection>
 
 <DocsPageSection>
@@ -127,9 +131,9 @@
         </Paragraph>
     </DocsPageSectionHeader>
     <DocsPageSectionContent Outlined FullWidth>
-        <TreeViewObservableExample />
+        <TreeViewObservableExample/>
     </DocsPageSectionContent>
-    <DocsPageSectionSource Code="TreeViewObservableExample" />
+    <DocsPageSectionSource Code="TreeViewObservableExample"/>
 </DocsPageSection>
 
 <DocsPageSection>
@@ -154,9 +158,9 @@
         </Paragraph>
     </DocsPageSectionHeader>
     <DocsPageSectionContent Outlined FullWidth>
-        <TreeViewContextMenuExample />
+        <TreeViewContextMenuExample/>
     </DocsPageSectionContent>
-    <DocsPageSectionSource Code="TreeViewContextMenuExample" />
+    <DocsPageSectionSource Code="TreeViewContextMenuExample"/>
 </DocsPageSection>
 
 <DocsPageSection>
@@ -184,9 +188,9 @@
         </Paragraph>
     </DocsPageSectionHeader>
     <DocsPageSectionContent Outlined FullWidth>
-        <TreeViewVirtualizationExample />
+        <TreeViewVirtualizationExample/>
     </DocsPageSectionContent>
-    <DocsPageSectionSource Code="TreeViewVirtualizationExample" />
+    <DocsPageSectionSource Code="TreeViewVirtualizationExample"/>
 </DocsPageSection>
 
 <DocsPageSubtitle>

--- a/Source/Blazorise/Licensing/BlazoriseLicenseProvider.cs
+++ b/Source/Blazorise/Licensing/BlazoriseLicenseProvider.cs
@@ -52,13 +52,13 @@ public sealed class BlazoriseLicenseProvider
     /// <param name="options"></param>
     /// <param name="jsRuntime"></param>
     /// <param name="versionProvider"></param>
-    public BlazoriseLicenseProvider(BlazoriseOptions options, IJSRuntime jsRuntime, IVersionProvider versionProvider)
+    public BlazoriseLicenseProvider( BlazoriseOptions options, IJSRuntime jsRuntime, IVersionProvider versionProvider )
     {
         this.options = options;
         this.jsRuntime = jsRuntime;
         this.versionProvider = versionProvider;
 
-        if (!initialized)
+        if ( !initialized )
         {
             backgroundWorker = new BackgroundWorker();
             backgroundWorker.DoWork += BackgroundWorker_DoWork;
@@ -68,11 +68,11 @@ public sealed class BlazoriseLicenseProvider
     #endregion
 
     #region Methods
-    private async void BackgroundWorker_DoWork(object sender, DoWorkEventArgs e)
+    private async void BackgroundWorker_DoWork( object sender, DoWorkEventArgs e )
     {
-        if (initialized)
+        if ( initialized )
         {
-            if (backgroundWorker is not null)
+            if ( backgroundWorker is not null )
             {
                 backgroundWorker.DoWork -= BackgroundWorker_DoWork;
                 backgroundWorker.Dispose();
@@ -80,7 +80,7 @@ public sealed class BlazoriseLicenseProvider
             return;
         }
 
-        if (string.IsNullOrWhiteSpace(options.ProductToken))
+        if ( string.IsNullOrWhiteSpace( options.ProductToken ) )
         {
             Result = BlazoriseLicenseResult.Unlicensed;
             return;
@@ -88,39 +88,45 @@ public sealed class BlazoriseLicenseProvider
 
         try
         {
-            if (IsWebAssembly)
+            if ( IsWebAssembly )
             {
-                var wasmLicenseVerifier = LicenseVerifier.Create().WithWebAssemblyRsaPublicKey(jsRuntime, versionProvider, options, PublicKey);
-                var license = await wasmLicenseVerifier.Load(options.ProductToken, true);
+                var wasmLicenseVerifier = LicenseVerifier.Create().WithWebAssemblyRsaPublicKey( jsRuntime, versionProvider, options, PublicKey );
+                var license = await wasmLicenseVerifier.Load( options.ProductToken, true );
 
-                if (wasmLicenseVerifier.Verify(license, new Assembly[] { CurrentAssembly }))
+                if ( wasmLicenseVerifier.Verify( license, new Assembly[]
+                {
+                    CurrentAssembly
+                } ) )
                 {
                     License = license;
-                    Result = ResolveBlazoriseLicenseResult(license);
+                    Result = ResolveBlazoriseLicenseResult( license );
                 }
                 else
                 {
                     Result = BlazoriseLicenseResult.Unlicensed;
                 }
 
-                PrintResult = ResolveBlazoriseLicensePrintResult(license);
+                PrintResult = ResolveBlazoriseLicensePrintResult( license );
             }
             else
             {
-                var licenseVerifier = LicenseVerifier.Create().WithRsaPublicKey(PublicKey);
-                var license = await licenseVerifier.Load(options.ProductToken, true);
+                var licenseVerifier = LicenseVerifier.Create().WithRsaPublicKey( PublicKey );
+                var license = await licenseVerifier.Load( options.ProductToken, true );
 
-                if (licenseVerifier.Verify(license, new Assembly[] { CurrentAssembly }))
+                if ( licenseVerifier.Verify( license, new Assembly[]
+                {
+                    CurrentAssembly
+                } ) )
                 {
                     License = license;
-                    Result = ResolveBlazoriseLicenseResult(license);
+                    Result = ResolveBlazoriseLicenseResult( license );
                 }
                 else
                 {
                     Result = BlazoriseLicenseResult.Unlicensed;
                 }
 
-                PrintResult = ResolveBlazoriseLicensePrintResult(license);
+                PrintResult = ResolveBlazoriseLicensePrintResult( license );
             }
         }
         catch
@@ -138,37 +144,37 @@ public sealed class BlazoriseLicenseProvider
     /// </summary>
     /// <param name="license"></param>
     /// <returns></returns>
-    private static BlazoriseLicensePrintResult ResolveBlazoriseLicensePrintResult(License license)
+    private static BlazoriseLicensePrintResult ResolveBlazoriseLicensePrintResult( License license )
     {
-        var licenseResult = ResolveBlazoriseLicenseResult(license);
+        var licenseResult = ResolveBlazoriseLicenseResult( license );
 
-        if (licenseResult == BlazoriseLicenseResult.Unlicensed)
+        if ( licenseResult == BlazoriseLicenseResult.Unlicensed )
             return BlazoriseLicensePrintResult.InvalidProductToken;
 
-        if (licenseResult == BlazoriseLicenseResult.Community)
+        if ( licenseResult == BlazoriseLicenseResult.Community )
         {
             return Result == BlazoriseLicenseResult.Community ? BlazoriseLicensePrintResult.Community : BlazoriseLicensePrintResult.CommunityExpired;
         }
 
-        if (licenseResult == BlazoriseLicenseResult.Licensed)
+        if ( licenseResult == BlazoriseLicenseResult.Licensed )
         {
             return Result == BlazoriseLicenseResult.Licensed ? BlazoriseLicensePrintResult.Licensed : BlazoriseLicensePrintResult.LicensedExpired;
         }
 
-        if (licenseResult == BlazoriseLicenseResult.Trial)
+        if ( licenseResult == BlazoriseLicenseResult.Trial )
             return BlazoriseLicensePrintResult.Trial;
 
         return BlazoriseLicensePrintResult.None;
     }
 
-    private static BlazoriseLicenseResult ResolveBlazoriseLicenseResult(License license)
+    private static BlazoriseLicenseResult ResolveBlazoriseLicenseResult( License license )
     {
-        if (license is null)
+        if ( license is null )
             return BlazoriseLicenseResult.Unlicensed;
 
-        if (license.Properties.TryGetValue(Constants.Properties.LICENSE_TYPE, out var licenseType) && Enum.TryParse<BlazoriseLicenseType>(licenseType, true, out var licenseTypeAsEnum))
+        if ( license.Properties.TryGetValue( Constants.Properties.LICENSE_TYPE, out var licenseType ) && Enum.TryParse<BlazoriseLicenseType>( licenseType, true, out var licenseTypeAsEnum ) )
         {
-            switch (licenseTypeAsEnum)
+            switch ( licenseTypeAsEnum )
             {
                 case BlazoriseLicenseType.Community:
                     return BlazoriseLicenseResult.Community;
@@ -186,25 +192,25 @@ public sealed class BlazoriseLicenseProvider
 
     internal int? GetDataGridRowsLimit()
     {
-        if (limitsDataGridMaxRows.HasValue)
+        if ( limitsDataGridMaxRows.HasValue )
             return limitsDataGridMaxRows;
 
-        if (Result == BlazoriseLicenseResult.Initializing)
+        if ( Result == BlazoriseLicenseResult.Initializing )
             return null;
 
 
-        if (License is not null)
+        if ( License is not null )
         {
-            if (License.Properties.TryGetValue(Constants.Properties.DATAGRID_MAX_ROWS, out var rowsLimitString) && int.TryParse(rowsLimitString, out var rowsLimit))
+            if ( License.Properties.TryGetValue( Constants.Properties.DATAGRID_MAX_ROWS, out var rowsLimitString ) && int.TryParse( rowsLimitString, out var rowsLimit ) )
             {
                 limitsDataGridMaxRows = rowsLimit;
             }
         }
-        else if (Result == BlazoriseLicenseResult.Community)
+        else if ( Result == BlazoriseLicenseResult.Community )
         {
             limitsDataGridMaxRows = 10000;
         }
-        else if (Result == BlazoriseLicenseResult.Unlicensed)
+        else if ( Result == BlazoriseLicenseResult.Unlicensed )
         {
             limitsDataGridMaxRows = DEFAULT_UNLICENSED_LIMIT_DATAGRID_MAX_ROWS;
         }
@@ -214,25 +220,25 @@ public sealed class BlazoriseLicenseProvider
 
     internal int? GetAutocompleteRowsLimit()
     {
-        if (limitsAutocompleteMaxRows.HasValue)
+        if ( limitsAutocompleteMaxRows.HasValue )
             return limitsAutocompleteMaxRows;
 
-        if (Result == BlazoriseLicenseResult.Initializing)
+        if ( Result == BlazoriseLicenseResult.Initializing )
             return null;
 
 
-        if (License is not null)
+        if ( License is not null )
         {
-            if (License.Properties.TryGetValue(Constants.Properties.AUTOCOMPLETE_MAX_ROWS, out var rowsLimitString) && int.TryParse(rowsLimitString, out var rowsLimit))
+            if ( License.Properties.TryGetValue( Constants.Properties.AUTOCOMPLETE_MAX_ROWS, out var rowsLimitString ) && int.TryParse( rowsLimitString, out var rowsLimit ) )
             {
                 limitsAutocompleteMaxRows = rowsLimit;
             }
         }
-        else if (Result == BlazoriseLicenseResult.Community)
+        else if ( Result == BlazoriseLicenseResult.Community )
         {
             limitsAutocompleteMaxRows = 10000;
         }
-        else if (Result == BlazoriseLicenseResult.Unlicensed)
+        else if ( Result == BlazoriseLicenseResult.Unlicensed )
         {
             limitsAutocompleteMaxRows = DEFAULT_UNLICENSED_LIMIT_AUTOCOMPLETE_MAX_ROWS;
         }
@@ -242,25 +248,25 @@ public sealed class BlazoriseLicenseProvider
 
     internal int? GetChartsRowsLimit()
     {
-        if (limitsChartsMaxRows.HasValue)
+        if ( limitsChartsMaxRows.HasValue )
             return limitsChartsMaxRows;
 
-        if (Result == BlazoriseLicenseResult.Initializing)
+        if ( Result == BlazoriseLicenseResult.Initializing )
             return null;
 
 
-        if (License is not null)
+        if ( License is not null )
         {
-            if (License.Properties.TryGetValue(Constants.Properties.CHARTS_MAX_ROWS, out var rowsLimitString) && int.TryParse(rowsLimitString, out var rowsLimit))
+            if ( License.Properties.TryGetValue( Constants.Properties.CHARTS_MAX_ROWS, out var rowsLimitString ) && int.TryParse( rowsLimitString, out var rowsLimit ) )
             {
                 limitsChartsMaxRows = rowsLimit;
             }
         }
-        else if (Result == BlazoriseLicenseResult.Community)
+        else if ( Result == BlazoriseLicenseResult.Community )
         {
             limitsChartsMaxRows = 100;
         }
-        else if (Result == BlazoriseLicenseResult.Unlicensed)
+        else if ( Result == BlazoriseLicenseResult.Unlicensed )
         {
             limitsChartsMaxRows = DEFAULT_UNLICENSED_LIMIT_CHARTS_MAX_ROWS;
         }
@@ -270,25 +276,25 @@ public sealed class BlazoriseLicenseProvider
 
     internal int? GetListViewRowsLimit()
     {
-        if (limitsListViewMaxRows.HasValue)
+        if ( limitsListViewMaxRows.HasValue )
             return limitsListViewMaxRows;
 
-        if (Result == BlazoriseLicenseResult.Initializing)
+        if ( Result == BlazoriseLicenseResult.Initializing )
             return null;
 
 
-        if (License is not null)
+        if ( License is not null )
         {
-            if (License.Properties.TryGetValue(Constants.Properties.LISTVIEW_MAX_ROWS, out var rowsLimitString) && int.TryParse(rowsLimitString, out var rowsLimit))
+            if ( License.Properties.TryGetValue( Constants.Properties.LISTVIEW_MAX_ROWS, out var rowsLimitString ) && int.TryParse( rowsLimitString, out var rowsLimit ) )
             {
                 limitsListViewMaxRows = rowsLimit;
             }
         }
-        else if (Result == BlazoriseLicenseResult.Community)
+        else if ( Result == BlazoriseLicenseResult.Community )
         {
             limitsListViewMaxRows = 100000;
         }
-        else if (Result == BlazoriseLicenseResult.Unlicensed)
+        else if ( Result == BlazoriseLicenseResult.Unlicensed )
         {
             limitsListViewMaxRows = DEFAULT_UNLICENSED_LIMIT_LISTVIEW_MAX_ROWS;
         }
@@ -298,25 +304,25 @@ public sealed class BlazoriseLicenseProvider
 
     internal int? GetTreeViewRowsLimit()
     {
-        if (limitsTreeViewMaxRows.HasValue)
+        if ( limitsTreeViewMaxRows.HasValue )
             return limitsTreeViewMaxRows;
 
-        if (Result == BlazoriseLicenseResult.Initializing)
+        if ( Result == BlazoriseLicenseResult.Initializing )
             return null;
 
 
-        if (License is not null)
+        if ( License is not null )
         {
-            if (License.Properties.TryGetValue(Constants.Properties.TREEVIEW_MAX_ROWS, out var rowsLimitString) && int.TryParse(rowsLimitString, out var rowsLimit))
+            if ( License.Properties.TryGetValue( Constants.Properties.TREEVIEW_MAX_ROWS, out var rowsLimitString ) && int.TryParse( rowsLimitString, out var rowsLimit ) )
             {
                 limitsTreeViewMaxRows = rowsLimit;
             }
         }
-        else if (Result == BlazoriseLicenseResult.Community)
+        else if ( Result == BlazoriseLicenseResult.Community )
         {
             limitsTreeViewMaxRows = 1000;
         }
-        else if (Result == BlazoriseLicenseResult.Unlicensed)
+        else if ( Result == BlazoriseLicenseResult.Unlicensed )
         {
             limitsTreeViewMaxRows = DEFAULT_UNLICENSED_LIMIT_TREEVIEW_MAX_ROWS;
         }

--- a/Source/Blazorise/Licensing/BlazoriseLicenseProvider.cs
+++ b/Source/Blazorise/Licensing/BlazoriseLicenseProvider.cs
@@ -14,13 +14,13 @@ namespace Blazorise.Licensing;
 public sealed class BlazoriseLicenseProvider
 {
     #region Members
-    internal const int DEFAULT_UNLICENSED_LIMIT_DATAGRID_MAX_ROWS = 1000;
-    internal const int DEFAULT_UNLICENSED_LIMIT_AUTOCOMPLETE_MAX_ROWS = 1000;
-    internal const int DEFAULT_UNLICENSED_LIMIT_CHARTS_MAX_ROWS = 10;
-    internal const int DEFAULT_UNLICENSED_LIMIT_LISTVIEW_MAX_ROWS = 1000;
-    internal const int DEFAULT_UNLICENSED_LIMIT_TREEVIEW_MAX_ROWS = 100;
+    public const int DEFAULT_UNLICENSED_LIMIT_DATAGRID_MAX_ROWS = 1000;
+    public const int DEFAULT_UNLICENSED_LIMIT_AUTOCOMPLETE_MAX_ROWS = 1000;
+    public const int DEFAULT_UNLICENSED_LIMIT_CHARTS_MAX_ROWS = 10;
+    public const int DEFAULT_UNLICENSED_LIMIT_LISTVIEW_MAX_ROWS = 1000;
+    public const int DEFAULT_UNLICENSED_LIMIT_TREEVIEW_MAX_ROWS = 100;
 
-    private static readonly Assembly CurrentAssembly = typeof( BlazoriseLicenseProvider ).Assembly;
+    private static readonly Assembly CurrentAssembly = typeof(BlazoriseLicenseProvider).Assembly;
 
     private readonly BlazoriseOptions options;
 
@@ -43,40 +43,36 @@ public sealed class BlazoriseLicenseProvider
     private int? limitsListViewMaxRows;
 
     private int? limitsTreeViewMaxRows;
-
     #endregion
 
     #region Constructors
-
     /// <summary>
     /// A default <see cref="BlazoriseLicenseProvider"/> constructor.
     /// </summary>
     /// <param name="options"></param>
     /// <param name="jsRuntime"></param>
     /// <param name="versionProvider"></param>
-    public BlazoriseLicenseProvider( BlazoriseOptions options, IJSRuntime jsRuntime, IVersionProvider versionProvider )
+    public BlazoriseLicenseProvider(BlazoriseOptions options, IJSRuntime jsRuntime, IVersionProvider versionProvider)
     {
         this.options = options;
         this.jsRuntime = jsRuntime;
         this.versionProvider = versionProvider;
 
-        if ( !initialized )
+        if (!initialized)
         {
             backgroundWorker = new BackgroundWorker();
             backgroundWorker.DoWork += BackgroundWorker_DoWork;
             backgroundWorker.RunWorkerAsync();
         }
     }
-
     #endregion
 
     #region Methods
-
-    private async void BackgroundWorker_DoWork( object sender, DoWorkEventArgs e )
+    private async void BackgroundWorker_DoWork(object sender, DoWorkEventArgs e)
     {
-        if ( initialized )
+        if (initialized)
         {
-            if ( backgroundWorker is not null )
+            if (backgroundWorker is not null)
             {
                 backgroundWorker.DoWork -= BackgroundWorker_DoWork;
                 backgroundWorker.Dispose();
@@ -84,7 +80,7 @@ public sealed class BlazoriseLicenseProvider
             return;
         }
 
-        if ( string.IsNullOrWhiteSpace( options.ProductToken ) )
+        if (string.IsNullOrWhiteSpace(options.ProductToken))
         {
             Result = BlazoriseLicenseResult.Unlicensed;
             return;
@@ -92,39 +88,39 @@ public sealed class BlazoriseLicenseProvider
 
         try
         {
-            if ( IsWebAssembly )
+            if (IsWebAssembly)
             {
-                var wasmLicenseVerifier = LicenseVerifier.Create().WithWebAssemblyRsaPublicKey( jsRuntime, versionProvider, options, PublicKey );
-                var license = await wasmLicenseVerifier.Load( options.ProductToken, true );
+                var wasmLicenseVerifier = LicenseVerifier.Create().WithWebAssemblyRsaPublicKey(jsRuntime, versionProvider, options, PublicKey);
+                var license = await wasmLicenseVerifier.Load(options.ProductToken, true);
 
-                if ( wasmLicenseVerifier.Verify( license, new Assembly[] { CurrentAssembly } ) )
+                if (wasmLicenseVerifier.Verify(license, new Assembly[] { CurrentAssembly }))
                 {
                     License = license;
-                    Result = ResolveBlazoriseLicenseResult( license );
+                    Result = ResolveBlazoriseLicenseResult(license);
                 }
                 else
                 {
                     Result = BlazoriseLicenseResult.Unlicensed;
                 }
 
-                PrintResult = ResolveBlazoriseLicensePrintResult( license );
+                PrintResult = ResolveBlazoriseLicensePrintResult(license);
             }
             else
             {
-                var licenseVerifier = LicenseVerifier.Create().WithRsaPublicKey( PublicKey );
-                var license = await licenseVerifier.Load( options.ProductToken, true );
+                var licenseVerifier = LicenseVerifier.Create().WithRsaPublicKey(PublicKey);
+                var license = await licenseVerifier.Load(options.ProductToken, true);
 
-                if ( licenseVerifier.Verify( license, new Assembly[] { CurrentAssembly } ) )
+                if (licenseVerifier.Verify(license, new Assembly[] { CurrentAssembly }))
                 {
                     License = license;
-                    Result = ResolveBlazoriseLicenseResult( license );
+                    Result = ResolveBlazoriseLicenseResult(license);
                 }
                 else
                 {
                     Result = BlazoriseLicenseResult.Unlicensed;
                 }
 
-                PrintResult = ResolveBlazoriseLicensePrintResult( license );
+                PrintResult = ResolveBlazoriseLicensePrintResult(license);
             }
         }
         catch
@@ -142,37 +138,37 @@ public sealed class BlazoriseLicenseProvider
     /// </summary>
     /// <param name="license"></param>
     /// <returns></returns>
-    private static BlazoriseLicensePrintResult ResolveBlazoriseLicensePrintResult( License license )
+    private static BlazoriseLicensePrintResult ResolveBlazoriseLicensePrintResult(License license)
     {
-        var licenseResult = ResolveBlazoriseLicenseResult( license );
+        var licenseResult = ResolveBlazoriseLicenseResult(license);
 
-        if ( licenseResult == BlazoriseLicenseResult.Unlicensed )
+        if (licenseResult == BlazoriseLicenseResult.Unlicensed)
             return BlazoriseLicensePrintResult.InvalidProductToken;
 
-        if ( licenseResult == BlazoriseLicenseResult.Community )
+        if (licenseResult == BlazoriseLicenseResult.Community)
         {
             return Result == BlazoriseLicenseResult.Community ? BlazoriseLicensePrintResult.Community : BlazoriseLicensePrintResult.CommunityExpired;
         }
 
-        if ( licenseResult == BlazoriseLicenseResult.Licensed )
+        if (licenseResult == BlazoriseLicenseResult.Licensed)
         {
             return Result == BlazoriseLicenseResult.Licensed ? BlazoriseLicensePrintResult.Licensed : BlazoriseLicensePrintResult.LicensedExpired;
         }
 
-        if ( licenseResult == BlazoriseLicenseResult.Trial )
+        if (licenseResult == BlazoriseLicenseResult.Trial)
             return BlazoriseLicensePrintResult.Trial;
 
         return BlazoriseLicensePrintResult.None;
     }
 
-    private static BlazoriseLicenseResult ResolveBlazoriseLicenseResult( License license )
+    private static BlazoriseLicenseResult ResolveBlazoriseLicenseResult(License license)
     {
-        if ( license is null )
+        if (license is null)
             return BlazoriseLicenseResult.Unlicensed;
 
-        if ( license.Properties.TryGetValue( Constants.Properties.LICENSE_TYPE, out var licenseType ) && Enum.TryParse<BlazoriseLicenseType>( licenseType, true, out var licenseTypeAsEnum ) )
+        if (license.Properties.TryGetValue(Constants.Properties.LICENSE_TYPE, out var licenseType) && Enum.TryParse<BlazoriseLicenseType>(licenseType, true, out var licenseTypeAsEnum))
         {
-            switch ( licenseTypeAsEnum )
+            switch (licenseTypeAsEnum)
             {
                 case BlazoriseLicenseType.Community:
                     return BlazoriseLicenseResult.Community;
@@ -190,25 +186,25 @@ public sealed class BlazoriseLicenseProvider
 
     internal int? GetDataGridRowsLimit()
     {
-        if ( limitsDataGridMaxRows.HasValue )
+        if (limitsDataGridMaxRows.HasValue)
             return limitsDataGridMaxRows;
 
-        if ( Result == BlazoriseLicenseResult.Initializing )
+        if (Result == BlazoriseLicenseResult.Initializing)
             return null;
 
 
-        if ( License is not null )
+        if (License is not null)
         {
-            if ( License.Properties.TryGetValue( Constants.Properties.DATAGRID_MAX_ROWS, out var rowsLimitString ) && int.TryParse( rowsLimitString, out var rowsLimit ) )
+            if (License.Properties.TryGetValue(Constants.Properties.DATAGRID_MAX_ROWS, out var rowsLimitString) && int.TryParse(rowsLimitString, out var rowsLimit))
             {
                 limitsDataGridMaxRows = rowsLimit;
             }
         }
-        else if ( Result == BlazoriseLicenseResult.Community )
+        else if (Result == BlazoriseLicenseResult.Community)
         {
             limitsDataGridMaxRows = 10000;
         }
-        else if ( Result == BlazoriseLicenseResult.Unlicensed )
+        else if (Result == BlazoriseLicenseResult.Unlicensed)
         {
             limitsDataGridMaxRows = DEFAULT_UNLICENSED_LIMIT_DATAGRID_MAX_ROWS;
         }
@@ -218,25 +214,25 @@ public sealed class BlazoriseLicenseProvider
 
     internal int? GetAutocompleteRowsLimit()
     {
-        if ( limitsAutocompleteMaxRows.HasValue )
+        if (limitsAutocompleteMaxRows.HasValue)
             return limitsAutocompleteMaxRows;
 
-        if ( Result == BlazoriseLicenseResult.Initializing )
+        if (Result == BlazoriseLicenseResult.Initializing)
             return null;
 
 
-        if ( License is not null )
+        if (License is not null)
         {
-            if ( License.Properties.TryGetValue( Constants.Properties.AUTOCOMPLETE_MAX_ROWS, out var rowsLimitString ) && int.TryParse( rowsLimitString, out var rowsLimit ) )
+            if (License.Properties.TryGetValue(Constants.Properties.AUTOCOMPLETE_MAX_ROWS, out var rowsLimitString) && int.TryParse(rowsLimitString, out var rowsLimit))
             {
                 limitsAutocompleteMaxRows = rowsLimit;
             }
         }
-        else if ( Result == BlazoriseLicenseResult.Community )
+        else if (Result == BlazoriseLicenseResult.Community)
         {
             limitsAutocompleteMaxRows = 10000;
         }
-        else if ( Result == BlazoriseLicenseResult.Unlicensed )
+        else if (Result == BlazoriseLicenseResult.Unlicensed)
         {
             limitsAutocompleteMaxRows = DEFAULT_UNLICENSED_LIMIT_AUTOCOMPLETE_MAX_ROWS;
         }
@@ -246,25 +242,25 @@ public sealed class BlazoriseLicenseProvider
 
     internal int? GetChartsRowsLimit()
     {
-        if ( limitsChartsMaxRows.HasValue )
+        if (limitsChartsMaxRows.HasValue)
             return limitsChartsMaxRows;
 
-        if ( Result == BlazoriseLicenseResult.Initializing )
+        if (Result == BlazoriseLicenseResult.Initializing)
             return null;
 
 
-        if ( License is not null )
+        if (License is not null)
         {
-            if ( License.Properties.TryGetValue( Constants.Properties.CHARTS_MAX_ROWS, out var rowsLimitString ) && int.TryParse( rowsLimitString, out var rowsLimit ) )
+            if (License.Properties.TryGetValue(Constants.Properties.CHARTS_MAX_ROWS, out var rowsLimitString) && int.TryParse(rowsLimitString, out var rowsLimit))
             {
                 limitsChartsMaxRows = rowsLimit;
             }
         }
-        else if ( Result == BlazoriseLicenseResult.Community )
+        else if (Result == BlazoriseLicenseResult.Community)
         {
             limitsChartsMaxRows = 100;
         }
-        else if ( Result == BlazoriseLicenseResult.Unlicensed )
+        else if (Result == BlazoriseLicenseResult.Unlicensed)
         {
             limitsChartsMaxRows = DEFAULT_UNLICENSED_LIMIT_CHARTS_MAX_ROWS;
         }
@@ -274,25 +270,25 @@ public sealed class BlazoriseLicenseProvider
 
     internal int? GetListViewRowsLimit()
     {
-        if ( limitsListViewMaxRows.HasValue )
+        if (limitsListViewMaxRows.HasValue)
             return limitsListViewMaxRows;
 
-        if ( Result == BlazoriseLicenseResult.Initializing )
+        if (Result == BlazoriseLicenseResult.Initializing)
             return null;
 
 
-        if ( License is not null )
+        if (License is not null)
         {
-            if ( License.Properties.TryGetValue( Constants.Properties.LISTVIEW_MAX_ROWS, out var rowsLimitString ) && int.TryParse( rowsLimitString, out var rowsLimit ) )
+            if (License.Properties.TryGetValue(Constants.Properties.LISTVIEW_MAX_ROWS, out var rowsLimitString) && int.TryParse(rowsLimitString, out var rowsLimit))
             {
                 limitsListViewMaxRows = rowsLimit;
             }
         }
-        else if ( Result == BlazoriseLicenseResult.Community )
+        else if (Result == BlazoriseLicenseResult.Community)
         {
             limitsListViewMaxRows = 100000;
         }
-        else if ( Result == BlazoriseLicenseResult.Unlicensed )
+        else if (Result == BlazoriseLicenseResult.Unlicensed)
         {
             limitsListViewMaxRows = DEFAULT_UNLICENSED_LIMIT_LISTVIEW_MAX_ROWS;
         }
@@ -302,36 +298,34 @@ public sealed class BlazoriseLicenseProvider
 
     internal int? GetTreeViewRowsLimit()
     {
-        if ( limitsTreeViewMaxRows.HasValue )
+        if (limitsTreeViewMaxRows.HasValue)
             return limitsTreeViewMaxRows;
 
-        if ( Result == BlazoriseLicenseResult.Initializing )
+        if (Result == BlazoriseLicenseResult.Initializing)
             return null;
 
 
-        if ( License is not null )
+        if (License is not null)
         {
-            if ( License.Properties.TryGetValue( Constants.Properties.TREEVIEW_MAX_ROWS, out var rowsLimitString ) && int.TryParse( rowsLimitString, out var rowsLimit ) )
+            if (License.Properties.TryGetValue(Constants.Properties.TREEVIEW_MAX_ROWS, out var rowsLimitString) && int.TryParse(rowsLimitString, out var rowsLimit))
             {
                 limitsTreeViewMaxRows = rowsLimit;
             }
         }
-        else if ( Result == BlazoriseLicenseResult.Community )
+        else if (Result == BlazoriseLicenseResult.Community)
         {
             limitsTreeViewMaxRows = 1000;
         }
-        else if ( Result == BlazoriseLicenseResult.Unlicensed )
+        else if (Result == BlazoriseLicenseResult.Unlicensed)
         {
             limitsTreeViewMaxRows = DEFAULT_UNLICENSED_LIMIT_TREEVIEW_MAX_ROWS;
         }
 
         return limitsTreeViewMaxRows;
     }
-
     #endregion
 
     #region Properties
-
     /// <summary>
     /// Gets the license.
     /// </summary>
@@ -351,6 +345,5 @@ public sealed class BlazoriseLicenseProvider
     /// Indicates if the current app is running in WebAssembly mode.
     /// </summary>
     private bool IsWebAssembly => jsRuntime is IJSInProcessRuntime;
-
     #endregion
 }

--- a/Source/Blazorise/Licensing/BlazoriseLicenseProvider.cs
+++ b/Source/Blazorise/Licensing/BlazoriseLicenseProvider.cs
@@ -14,6 +14,7 @@ namespace Blazorise.Licensing;
 public sealed class BlazoriseLicenseProvider
 {
     #region Members
+
     public const int DEFAULT_UNLICENSED_LIMIT_DATAGRID_MAX_ROWS = 1000;
     public const int DEFAULT_UNLICENSED_LIMIT_AUTOCOMPLETE_MAX_ROWS = 1000;
     public const int DEFAULT_UNLICENSED_LIMIT_CHARTS_MAX_ROWS = 10;
@@ -43,9 +44,11 @@ public sealed class BlazoriseLicenseProvider
     private int? limitsListViewMaxRows;
 
     private int? limitsTreeViewMaxRows;
+
     #endregion
 
     #region Constructors
+
     /// <summary>
     /// A default <see cref="BlazoriseLicenseProvider"/> constructor.
     /// </summary>
@@ -65,9 +68,11 @@ public sealed class BlazoriseLicenseProvider
             backgroundWorker.RunWorkerAsync();
         }
     }
+
     #endregion
 
     #region Methods
+
     private async void BackgroundWorker_DoWork( object sender, DoWorkEventArgs e )
     {
         if ( initialized )
@@ -323,9 +328,11 @@ public sealed class BlazoriseLicenseProvider
 
         return limitsTreeViewMaxRows;
     }
+
     #endregion
 
     #region Properties
+
     /// <summary>
     /// Gets the license.
     /// </summary>
@@ -345,5 +352,6 @@ public sealed class BlazoriseLicenseProvider
     /// Indicates if the current app is running in WebAssembly mode.
     /// </summary>
     private bool IsWebAssembly => jsRuntime is IJSInProcessRuntime;
+
     #endregion
 }

--- a/Source/Blazorise/Licensing/BlazoriseLicenseProvider.cs
+++ b/Source/Blazorise/Licensing/BlazoriseLicenseProvider.cs
@@ -20,7 +20,7 @@ public sealed class BlazoriseLicenseProvider
     public const int DEFAULT_UNLICENSED_LIMIT_LISTVIEW_MAX_ROWS = 1000;
     public const int DEFAULT_UNLICENSED_LIMIT_TREEVIEW_MAX_ROWS = 100;
 
-    private static readonly Assembly CurrentAssembly = typeof(BlazoriseLicenseProvider).Assembly;
+    private static readonly Assembly CurrentAssembly = typeof( BlazoriseLicenseProvider ).Assembly;
 
     private readonly BlazoriseOptions options;
 
@@ -93,10 +93,7 @@ public sealed class BlazoriseLicenseProvider
                 var wasmLicenseVerifier = LicenseVerifier.Create().WithWebAssemblyRsaPublicKey( jsRuntime, versionProvider, options, PublicKey );
                 var license = await wasmLicenseVerifier.Load( options.ProductToken, true );
 
-                if ( wasmLicenseVerifier.Verify( license, new Assembly[]
-                {
-                    CurrentAssembly
-                } ) )
+                if ( wasmLicenseVerifier.Verify( license, new Assembly[] { CurrentAssembly } ) )
                 {
                     License = license;
                     Result = ResolveBlazoriseLicenseResult( license );
@@ -113,10 +110,7 @@ public sealed class BlazoriseLicenseProvider
                 var licenseVerifier = LicenseVerifier.Create().WithRsaPublicKey( PublicKey );
                 var license = await licenseVerifier.Load( options.ProductToken, true );
 
-                if ( licenseVerifier.Verify( license, new Assembly[]
-                {
-                    CurrentAssembly
-                } ) )
+                if ( licenseVerifier.Verify( license, new Assembly[] { CurrentAssembly } ) )
                 {
                     License = license;
                     Result = ResolveBlazoriseLicenseResult( license );


### PR DESCRIPTION
## Description

Closes #5797

- Alert in every limited component
  ![image](https://github.com/user-attachments/assets/cf439d18-dfec-499f-b619-b388a63a5e1c)
- pricing table uses the constants from `BlazoriseLicenseProvider` (these should be in sync). Thus the table has changed its values. New table:
  ![image](https://github.com/user-attachments/assets/a7b89db9-8cd2-46f5-a073-7becfa9ecbf1)

### Question

- the `TransferList` has not the constant in `BlazoriseLicenseProvider` and its limitation doesn't appear to be enforced. So:
  - (a) Remove the TransferList from pricing table.
  - (b) Create the constant and enforce the limitation. 

## How Has This Been Tested?

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] The PR is submitted to the correct branch (`master` for dev, `rel-1.x` for maintenance).
- [ ] My code follows the code style of this project.
- [ ] I've added relevant tests.
