### PR TITLE
DataGrid: Fix paginator items alignment

### DIFF
--- a/Source/Blazorise.AntDesign/Providers/AntDesignClassProvider.cs
+++ b/Source/Blazorise.AntDesign/Providers/AntDesignClassProvider.cs
@@ -829,7 +829,7 @@ public class AntDesignClassProvider : ClassProvider
 
     public override string Display( DisplayType displayType, DisplayDefinition displayDefinition )
     {
-        var baseClass = displayDefinition.Breakpoint != Breakpoint.None
+        var baseClass = displayDefinition.Breakpoint != Breakpoint.None && displayDefinition.Breakpoint != Breakpoint.Mobile
             ? $"ant-display-{ToBreakpoint( displayDefinition.Breakpoint )}-{ToDisplayType( displayType )}"
             : $"ant-display-{ToDisplayType( displayType )}";
 

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridPagination.razor
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridPagination.razor
@@ -216,7 +216,7 @@
                     var pageNumberString = i.ToString();
                     var pageActive = pageNumber == PaginationContext.CurrentPage;
 
-                    <PaginationItem Display="Blazorise.Display.None.OnMobile.InlineFlex.Row.OnTablet" Disabled="@(pageNumber == PaginationContext.CurrentPage)" Active="@pageActive">
+                    <PaginationItem Flex="Blazorise.Flex.InlineFlex.OnTablet.JustifyContent.Center.OnTablet" Display="Blazorise.Display.None.OnMobile.InlineFlex.Row.OnTablet" Disabled="@(pageNumber == PaginationContext.CurrentPage)" Active="@pageActive">
                         <PaginationLink Page="@pageNumberString" Clicked="@OnPaginationItemClick">
                             @if ( PageButtonTemplate is not null )
                             {


### PR DESCRIPTION
## Description

- partially solves #5375 - the paginator problem.
- first is fix for ant design, that's why this is in dev not in support. Prior to this - Ant Design had wrong display on xs. Which resulted for example in: 

 https://github.com/user-attachments/assets/1587e9a3-4e98-4973-9089-edb33ffe08c0  

 (pages in paginator disappears between xs-sm, but again appear under xs)
- the not centered number are solved by `justify-content:center;`  this is because of the container being `inline-flex`.


## How Has This Been Tested?

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [ ] The PR is submitted to the correct branch (`master` for dev, `rel-1.x` for maintenance).
- [ ] My code follows the code style of this project.
- [ ] I've added relevant tests.
