### PR TITLE
DataGrid: Group header column width fix

### DIFF
--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -2866,6 +2866,7 @@ public partial class DataGrid<TItem> : BaseDataGridComponent
             for ( int i = 0; i < orderedDisplayColumns.Count; i++ )
             {
                 var displayColumn = orderedDisplayColumns[i];
+                displayColumn.SetWidthToNull();
                 var colSpan = 1;
 
                 if ( !string.IsNullOrWhiteSpace( displayColumn.HeaderGroupCaption ) && orderedDisplayColumns.Count > i + 1 )

--- a/Source/Extensions/Blazorise.DataGrid/DataGridColumn.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGridColumn.cs
@@ -383,6 +383,8 @@ public partial class DataGridColumn<TItem> : BaseDataGridColumn<TItem>
             : ParentDataGrid.FilterMethod == DataGridFilterMethod.NotEquals ? DataGridColumnFilterMethod.NotEquals
             : DataGridColumnFilterMethod.Contains;
     }
+    
+    internal void SetWidthToNull()=> Width = null;//to supress BL0005
 
     #endregion
 


### PR DESCRIPTION
## Description

Closes #5804

The issue arises because the header group column inherits its width from the first header column with the specified `HeaderGroupCaption.` In my opinion, setting a width on the header group isn’t necessary, at least from what I can foresee.

The simplest solution is to set `Width` to `null`. Simply removing the width from the Razor file (line 42 in DataGrid) won’t be effective, as the width is also applied through `Style` property. 