### PR TITLE
Update bug_report.yaml

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -36,22 +36,29 @@ body:
         - Bulma
         - Material
         - Tailwind
-  - type: textarea
-    id: reproduction-link
-    attributes:
-      label: Link to minimal reproduction or a simple code snippet
-      description: |
-        The easiest way to provide a reproduction is to provide a link to a public GitHub repository or a tool like [Telerik Repl](https://blazorrepl.telerik.com/).
+- type: markdown
+  id: reproduction-link
+  attributes:
+    label: Link to minimal reproduction or a simple code snippet
+    description: |
+      Provide a public GitHub repository (or code snippet). For easy setup, you can use the Blazorise Bug Report Template for each provider: 
+      [Bootstrap4](https://github.com/Blazorise/BugReportBootstrap4),
+      [Bootstrap5](https://github.com/Blazorise/BugReportBootstrap5), 
+      [Tailwind](https://github.com/Blazorise/BugReportTailwind),
+      [Material](https://github.com/Blazorise/BugReportMaterial),
+      [AntDesign](https://github.com/Blazorise/BugReportAntDesign),
+      [Bulma](https://github.com/Blazorise/BugReportBulma), or
+      [FluentUI2](https://github.com/Blazorise/BugReportFluentUI2).
 
-        The reproduction should be **minimal**. This means it should contain only the bare minimum amount of code needed
-        to run the bug, including all the class definitions, models, services, etc.
-      placeholder: Reproduction Link
-    validations:
-      required: true
+      The reproduction should be **minimal**, containing only the essential code needed to demonstrate the bug.
+    placeholder: Reproduction Link
+  validations:
+    required: true
+
   - type: textarea
     id: steps-to-reproduce
     attributes:
-      label: Steps to reproduce
+      label: Steps to reproduce & bug description
       description: |
         What must we do after opening your repro to make the bug happen? Clear and concise reproduction instructions are important for us to be able to triage your issue in a timely manner. Note that you can use [Markdown](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#quoting-code) to format lists and code.
       placeholder: Steps to reproduce

--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -3,4 +3,8 @@
 "Status: Repro Missing":
   comment: >
     Hello @{issue-author},
-    thank you for your submission. The issue was labeled "Status: Repro Missing", as you have not provided a way to reproduce the issue quickly. Most problems already solve themselves when isolated, but we would like you to provide us with a reproducible code to make it easier to investigate a possible bug.
+    thank you for your submission. The issue was labeled "Status: Repro Missing" because you have not provided a way to reproduce the issue quickly. Most problems can be solved when isolated, but we would like you to provide a reproducible code sample to help us investigate a possible bug more effectively.
+
+    For your convenience, you can use our pre-configured [Bug Report Template repositories](https://github.com/Blazorise/BugReportTemplate) to quickly set up a reproducible environment.
+
+    Once you've provided a minimal reproduction, we can proceed with the investigation. Thank you for helping us improve Blazorise!


### PR DESCRIPTION
## Description

Closes #5822

- Multiple bug report repositories were created, one for each provider, with a central hub available [here](https://github.com/Blazorise/BugReportTemplate). The automation is managed by a [GitHub Action](https://github.com/Blazorise/BugReportTemplate/blob/main/.github/workflows/build-template.yml).
  
- For each provider, the action uses `Blazorise.Templates` to generate fresh, up-to-date code.
- It pushes the generated code to the corresponding Bug Report repository (e.g., [BugReportBootstrap5](https://github.com/Blazorise/BugReportBootstrap5)). (so the provider repos are "orphaned")
- Additionally, it copies the README, license, and `.gitignore` files to each repository.
- The README provides basic instructions on how to use the template.
- The action runs daily to:
  - Ensure unique names for each repository (with MMdd suffix), helping us avoid duplicate .NET project names.
  - Keep all repositories up-to-date by using the latest `-f` flag and installing the newest `Blazorise.Templates` version.
