### PR TITLE
Dropzone: Reordered property to expose current order

### DIFF
--- a/Documentation/Blazorise.Docs/Models/Snippets.generated.cs
+++ b/Documentation/Blazorise.Docs/Models/Snippets.generated.cs
@@ -2048,7 +2048,7 @@ public partial class CaptchaInput : BaseInputComponent<bool>
         {
             var dropzone = i.ToString();
 
-            <DropZone TItem=""DropItem"" Name=""@dropzone"" AllowReorder Padding=""Padding.Is3"" Margin=""Margin.Is3"" Flex=""Flex.Grow.Is1"">
+            <DropZone TItem=""DropItem"" Name=""@dropzone"" AllowReorder Reordered=""indices=> Reordered(indices, dropzone)"" Padding=""Padding.Is3"" Margin=""Margin.Is3"" Flex=""Flex.Grow.Is1"">
                 <Heading Size=""HeadingSize.Is4"" Margin=""Margin.Is3.FromBottom"">Drop Zone @dropzone</Heading>
             </DropZone>
         }
@@ -2061,6 +2061,11 @@ public partial class CaptchaInput : BaseInputComponent<bool>
         </Card>
     </ItemTemplate>
 </DropContainer>
+
+
+<Div >
+  @reorderStatus
+</Div>
 @code {
     public class DropItem
     {
@@ -2081,6 +2086,14 @@ public partial class CaptchaInput : BaseInputComponent<bool>
     private Task ItemDropped( DraggableDroppedEventArgs<DropItem> dropItem )
     {
         dropItem.Item.Group = dropItem.DropZoneName;
+        return Task.CompletedTask;
+    }
+
+    string reorderStatus = """";
+    
+    private Task Reordered(Dictionary<DropItem, int> indices, string dropzone)
+    {
+        reorderStatus = $""Order in dropzone {dropzone}: {string.Join("", "", indices.OrderBy(x => x.Value).Select(x => x.Key.Name))}"";
         return Task.CompletedTask;
     }
 }";

--- a/Documentation/Blazorise.Docs/Pages/Docs/Components/DragDrops/Code/DragDropReorderingExampleCode.html
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Components/DragDrops/Code/DragDropReorderingExampleCode.html
@@ -6,7 +6,7 @@
         {
             var dropzone = i.ToString();
 
-            <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">DropZone</span> <span class="htmlAttributeName">TItem</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">DropItem</span><span class="quot">&quot;</span> <span class="htmlAttributeName">Name</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="sharpVariable"><span class="atSign">&#64;</span>dropzone</span><span class="quot">&quot;</span> <span class="htmlAttributeName">AllowReorder</span> <span class="htmlAttributeName">Padding</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="enum">Padding</span><span class="enumValue">.Is3</span><span class="quot">&quot;</span> <span class="htmlAttributeName">Margin</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="enum">Margin</span><span class="enumValue">.Is3</span><span class="quot">&quot;</span> <span class="htmlAttributeName">Flex</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">Flex.Grow.Is1</span><span class="quot">&quot;</span><span class="htmlTagDelimiter">&gt;</span>
+            <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">DropZone</span> <span class="htmlAttributeName">TItem</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">DropItem</span><span class="quot">&quot;</span> <span class="htmlAttributeName">Name</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="sharpVariable"><span class="atSign">&#64;</span>dropzone</span><span class="quot">&quot;</span> <span class="htmlAttributeName">AllowReorder</span> <span class="htmlAttributeName">Reordered</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">indices=&gt; Reordered(indices, dropzone)</span><span class="quot">&quot;</span> <span class="htmlAttributeName">Padding</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="enum">Padding</span><span class="enumValue">.Is3</span><span class="quot">&quot;</span> <span class="htmlAttributeName">Margin</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="enum">Margin</span><span class="enumValue">.Is3</span><span class="quot">&quot;</span> <span class="htmlAttributeName">Flex</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">Flex.Grow.Is1</span><span class="quot">&quot;</span><span class="htmlTagDelimiter">&gt;</span>
                 <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">Heading</span> <span class="htmlAttributeName">Size</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="enum">HeadingSize</span><span class="enumValue">.Is4</span><span class="quot">&quot;</span> <span class="htmlAttributeName">Margin</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">Margin.Is3.FromBottom</span><span class="quot">&quot;</span><span class="htmlTagDelimiter">&gt;</span>Drop Zone <span class="atSign">&#64;</span>dropzone<span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">Heading</span><span class="htmlTagDelimiter">&gt;</span>
             <span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">DropZone</span><span class="htmlTagDelimiter">&gt;</span>
         }
@@ -19,6 +19,11 @@
         <span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">Card</span><span class="htmlTagDelimiter">&gt;</span>
     <span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">ItemTemplate</span><span class="htmlTagDelimiter">&gt;</span>
 <span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">DropContainer</span><span class="htmlTagDelimiter">&gt;</span>
+
+
+<span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">Div</span> <span class="htmlTagDelimiter">&gt;</span>
+  <span class="atSign">&#64;</span>reorderStatus
+<span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">Div</span><span class="htmlTagDelimiter">&gt;</span>
 </pre></div>
 <div class="csharp"><pre>
 <span class="atSign">&#64;</span>code {
@@ -41,6 +46,14 @@
     <span class="keyword">private</span> Task ItemDropped( DraggableDroppedEventArgs&lt;DropItem&gt; dropItem )
     {
         dropItem.Item.Group = dropItem.DropZoneName;
+        <span class="keyword">return</span> Task.CompletedTask;
+    }
+
+    <span class="keyword">string</span> reorderStatus = <span class="string">&quot;&quot;</span>;
+    
+    <span class="keyword">private</span> Task Reordered(Dictionary&lt;DropItem, <span class="keyword">int</span>&gt; indices, <span class="keyword">string</span> dropzone)
+    {
+        reorderStatus = $<span class="string">&quot;Order in dropzone {dropzone}: {string.Join(&quot;</span>, <span class="string">&quot;, indices.OrderBy(x =&gt; x.Value).Select(x =&gt; x.Key.Name))}&quot;</span>;
         <span class="keyword">return</span> Task.CompletedTask;
     }
 }

--- a/Documentation/Blazorise.Docs/Pages/Docs/Components/DragDrops/DragDropPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Components/DragDrops/DragDropPage.razor
@@ -58,6 +58,7 @@
     <DocsPageSectionHeader Title="Reorder items">
         <Paragraph>
             Items can be reordered inside each dropzone with the <Code>AllowReorder</Code> bool set to true on the dropzone.
+            The <Code>Reordered</Code> function triggers each time the order changes or items are added or removed from the dropzone, providing the current order in a dictionary.
         </Paragraph>
     </DocsPageSectionHeader>
     <DocsPageSectionContent Outlined FullWidth>
@@ -162,6 +163,9 @@
     </DocsAttributesItem>
     <DocsAttributesItem Name="AllowReorder" Type="bool" Default="false">
         If true, the reordering of the items will be enabled.
+    </DocsAttributesItem>
+    <DocsAttributesItem Name="Reordered" Type="Func<Dictionary<TItem, int>, Task>">
+        The callback that is raised when the order of items changes. Only if <see cref="AllowReorder"/> is enabled.
     </DocsAttributesItem>
     <DocsAttributesItem Name="OnlyZone" Type="bool" Default="false">
         If true, will only act as a dropable zone and not render any items.

--- a/Documentation/Blazorise.Docs/Pages/Docs/Components/DragDrops/Examples/DragDropReorderingExample.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Components/DragDrops/Examples/DragDropReorderingExample.razor
@@ -5,7 +5,7 @@
         {
             var dropzone = i.ToString();
 
-            <DropZone TItem="DropItem" Name="@dropzone" AllowReorder Padding="Padding.Is3" Margin="Margin.Is3" Flex="Flex.Grow.Is1">
+            <DropZone TItem="DropItem" Name="@dropzone" AllowReorder Reordered="indices=> Reordered(indices, dropzone)" Padding="Padding.Is3" Margin="Margin.Is3" Flex="Flex.Grow.Is1">
                 <Heading Size="HeadingSize.Is4" Margin="Margin.Is3.FromBottom">Drop Zone @dropzone</Heading>
             </DropZone>
         }
@@ -18,6 +18,11 @@
         </Card>
     </ItemTemplate>
 </DropContainer>
+
+
+<Div >
+  @reorderStatus
+</Div>
 @code {
     public class DropItem
     {
@@ -38,6 +43,14 @@
     private Task ItemDropped( DraggableDroppedEventArgs<DropItem> dropItem )
     {
         dropItem.Item.Group = dropItem.DropZoneName;
+        return Task.CompletedTask;
+    }
+
+    string reorderStatus = "";
+    
+    private Task Reordered(Dictionary<DropItem, int> indices, string dropzone)
+    {
+        reorderStatus = $"Order in dropzone {dropzone}: {string.Join(", ", indices.OrderBy(x => x.Value).Select(x => x.Key.Name))}";
         return Task.CompletedTask;
     }
 }

--- a/Source/Blazorise/Components/Droppable/DropZone.razor.cs
+++ b/Source/Blazorise/Components/Droppable/DropZone.razor.cs
@@ -175,8 +175,13 @@ public partial class DropZone<TItem> : BaseComponent, IAsyncDisposable
                 {
                     indices[item.Key] = index++;
                 }
+                if ( AllowReorder )
+                {
+                    Reordered?.Invoke( indices );
+                }
             }
         }
+
 
         recalculateItems = true;
         shouldRerender = true;
@@ -300,8 +305,9 @@ public partial class DropZone<TItem> : BaseComponent, IAsyncDisposable
                     }
 
                     indices.Add( context, newIndex );
-                }
+                } 
             }
+            
         }
         else
         {
@@ -504,6 +510,11 @@ public partial class DropZone<TItem> : BaseComponent, IAsyncDisposable
     /// If true, the reordering of the items will be enabled.
     /// </summary>
     [Parameter] public bool AllowReorder { get; set; }
+    
+    /// <summary>
+    /// The callback that is raised when the order of items changed. Only if <see cref="AllowReorder"/> is enabled.
+    /// </summary>
+    [Parameter] public Func<Dictionary<TItem, int>, Task> Reordered { get; set; }
 
     /// <summary>
     /// If true, will only act as a dropable zone and not render any items.


### PR DESCRIPTION
[Closes #5830](https://github.com/Megabit/Blazorise/issues/5830)


https://github.com/user-attachments/assets/a91132c5-6438-446f-a4a1-eeb71b3f94cf



This function triggers every time the order changes:

- when an item is dragged to a new position
- when an item is added from a different zone
- when an item is removed

While removing and adding items isn’t technically reordering, I believe these actions should also trigger the function.
 
Currently, it also fires when a user drags an item and drops it back in the same position. While this doesn’t alter the collection, the function still invokes. We could compare the old and new dictionary to prevent this, but is it worth the additional complexity?




