### PR TITLE
DevOps: Removes unnecessary dotnet setup

### DIFF
--- a/.github/workflows/blazorise-ci-basic.yml
+++ b/.github/workflows/blazorise-ci-basic.yml
@@ -9,6 +9,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+
+    - name: Setup .NET 9
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '9.0.x'
     
     - name: Restore NuGet Packages
       run: dotnet restore


### PR DESCRIPTION
## Description

Just a quick fix from seeing warnings in gha log.   

dotnet is there on ubuntu by default
