### PR TITLE
Markdown: add missing ToolbarButtonClassPrefix JS option

### DIFF
--- a/Source/Extensions/Blazorise.Markdown/Markdown.razor.cs
+++ b/Source/Extensions/Blazorise.Markdown/Markdown.razor.cs
@@ -102,6 +102,7 @@ public partial class Markdown : BaseComponent,
             Toolbar = Toolbar != null && toolbarButtons?.Count > 0
                 ? MarkdownActionProvider.Serialize( toolbarButtons )
                 : null,
+            ToolbarButtonClassPrefix = ToolbarButtonClassPrefix,
             ToolbarTips = ToolbarTips,
             UploadImage = UploadImage,
             ImageMaxSize = ImageMaxSize,

--- a/Source/Extensions/Blazorise.Markdown/MarkdownJSOptions.cs
+++ b/Source/Extensions/Blazorise.Markdown/MarkdownJSOptions.cs
@@ -73,6 +73,11 @@ public class MarkdownJSOptions
     public IEnumerable<object> Toolbar { get; set; }
 
     /// <summary>
+    /// Gets or sets a prefix to the toolbar button classes when set. For example, a value of `"mde"` results in `"mde-bold"` for the Bold button.
+    /// </summary>
+    public string ToolbarButtonClassPrefix { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether tooltips are shown on the toolbar.
     /// </summary>
     public bool ToolbarTips { get; set; }


### PR DESCRIPTION
Closes #5876