### PR TITLE
[next-2.0] Changes RightAligned to EndAligned on Dropdown and DropdownList

### DIFF
--- a/Source/Blazorise.AntDesign/Providers/AntDesignClassProvider.cs
+++ b/Source/Blazorise.AntDesign/Providers/AntDesignClassProvider.cs
@@ -463,7 +463,7 @@ public class AntDesignClassProvider : ClassProvider
 
     public override string DropdownMenuVisible( bool visible ) => visible ? null : "ant-dropdown-hidden";
 
-    public override string DropdownMenuRight( bool rightAligned ) => rightAligned ? "dropdown-menu-right" : null;
+    public override string DropdownMenuEnd( bool endAligned ) => endAligned ? "dropdown-menu-right" : null;
 
     public override string DropdownToggle( bool isDropdownSubmenu, bool outline ) => isDropdownSubmenu ? "ant-dropdown-menu-item" : "ant-btn ant-dropdown-trigger";
 

--- a/Source/Blazorise.Bootstrap/Providers/BootstrapClassProvider.cs
+++ b/Source/Blazorise.Bootstrap/Providers/BootstrapClassProvider.cs
@@ -471,7 +471,7 @@ public class BootstrapClassProvider : ClassProvider
 
     public override string DropdownMenuVisible( bool visible ) => visible ? Show() : null;
 
-    public override string DropdownMenuRight( bool rightAligned ) => rightAligned ? "dropdown-menu-right" : null;
+    public override string DropdownMenuEnd( bool endAligned ) => endAligned ? "dropdown-menu-right" : null;
 
     public override string DropdownToggle( bool isDropdownSubmenu, bool outline ) => isDropdownSubmenu ? "dropdown-item dropdown-toggle" : "btn dropdown-toggle";
 

--- a/Source/Blazorise.Bootstrap5/Providers/Bootstrap5ClassProvider.cs
+++ b/Source/Blazorise.Bootstrap5/Providers/Bootstrap5ClassProvider.cs
@@ -465,7 +465,7 @@ public class Bootstrap5ClassProvider : ClassProvider
 
     public override string DropdownMenuVisible( bool visible ) => visible ? Show() : null;
 
-    public override string DropdownMenuRight( bool rightAligned ) => rightAligned ? "dropdown-menu-end" : null;
+    public override string DropdownMenuEnd( bool endAligned ) => endAligned ? "dropdown-menu-end" : null;
 
     public override string DropdownToggle( bool isDropdownSubmenu, bool outline ) => isDropdownSubmenu ? "dropdown-item dropdown-toggle" : "btn dropdown-toggle";
 

--- a/Source/Blazorise.Bulma/Providers/BulmaClassProvider.cs
+++ b/Source/Blazorise.Bulma/Providers/BulmaClassProvider.cs
@@ -460,7 +460,7 @@ public class BulmaClassProvider : ClassProvider
 
     public override string DropdownMenuVisible( bool visible ) => null;
 
-    public override string DropdownMenuRight( bool rightAligned ) => null;
+    public override string DropdownMenuEnd( bool endAligned ) => null;
 
     public override string DropdownToggle( bool isDropdownSubmenu, bool outline ) => isDropdownSubmenu ? "dropdown-item" : "button dropdown-trigger";
 

--- a/Source/Blazorise.FluentUI2/Providers/FluentUI2ClassProvider.cs
+++ b/Source/Blazorise.FluentUI2/Providers/FluentUI2ClassProvider.cs
@@ -470,7 +470,7 @@ public class FluentUI2ClassProvider : ClassProvider
 
     public override string DropdownMenuVisible( bool visible ) => visible ? "fui-MenuPopover-show" : null;
 
-    public override string DropdownMenuRight( bool rightAligned ) => rightAligned ? "fui-MenuPopover-right" : null;
+    public override string DropdownMenuEnd( bool endAligned ) => endAligned ? "fui-MenuPopover-right" : null;
 
     public override string DropdownToggle( bool isDropdownSubmenu, bool outline ) => isDropdownSubmenu
         ? "fui-MenuItem"

--- a/Source/Blazorise.Tailwind/Providers/TailwindClassProvider.cs
+++ b/Source/Blazorise.Tailwind/Providers/TailwindClassProvider.cs
@@ -594,7 +594,7 @@ public class TailwindClassProvider : ClassProvider
         ? "b-dropdown-menu-show block"
         : "b-dropdown-menu-hide hidden";
 
-    public override string DropdownMenuRight( bool rightAligned ) => rightAligned ? "b-dropdown-menu-right" : null;
+    public override string DropdownMenuEnd( bool endAligned ) => endAligned ? "b-dropdown-menu-right" : null;
 
     public override string DropdownToggle( bool isDropdownSubmenu, bool outline )
     {

--- a/Source/Blazorise/Components/Dropdown/Dropdown.razor.cs
+++ b/Source/Blazorise/Components/Dropdown/Dropdown.razor.cs
@@ -72,7 +72,7 @@ public partial class Dropdown : BaseComponent, IAsyncDisposable
                 options: new()
                 {
                     Direction = GetDropdownDirection().ToString( "g" ),
-                    RightAligned = RightAligned,
+                    EndAligned = EndAligned,
                     DropdownToggleClassNames = ClassProvider.DropdownToggleSelector( IsDropdownSubmenu ),
                     DropdownMenuClassNames = ClassProvider.DropdownMenuSelector(),
                     DropdownShowClassName = ClassProvider.DropdownObserverShow(),
@@ -99,7 +99,7 @@ public partial class Dropdown : BaseComponent, IAsyncDisposable
         builder.Append( ClassProvider.Dropdown( IsDropdownSubmenu ) );
         builder.Append( ClassProvider.DropdownGroup( IsGroup ) );
         builder.Append( ClassProvider.DropdownShow( Visible ) );
-        builder.Append( ClassProvider.DropdownRight( RightAligned ) );
+        builder.Append( ClassProvider.DropdownRight( EndAligned ) );
         builder.Append( ClassProvider.DropdownDisabled( Disabled ) );
         builder.Append( ClassProvider.DropdownDirection( GetDropdownDirection() ) );
 
@@ -428,12 +428,12 @@ public partial class Dropdown : BaseComponent, IAsyncDisposable
     /// If true, a dropdown menu will be right aligned.
     /// </summary>
     [Parameter]
-    public bool RightAligned
+    public bool EndAligned
     {
-        get => state.RightAligned;
+        get => state.EndAligned;
         set
         {
-            state = state with { RightAligned = value };
+            state = state with { EndAligned = value };
 
             DirtyClasses();
         }

--- a/Source/Blazorise/Components/Dropdown/DropdownMenu.razor.cs
+++ b/Source/Blazorise/Components/Dropdown/DropdownMenu.razor.cs
@@ -53,7 +53,7 @@ public partial class DropdownMenu : BaseComponent, IDisposable
         builder.Append( ClassProvider.DropdownMenu() );
         builder.Append( ClassProvider.DropdownMenuScrollable( MaxMenuHeight is not null ) );
         builder.Append( ClassProvider.DropdownMenuVisible( ParentDropdownState.Visible ) );
-        builder.Append( ClassProvider.DropdownMenuRight( ParentDropdownState.RightAligned ) );
+        builder.Append( ClassProvider.DropdownMenuEnd( ParentDropdownState.EndAligned ) );
         builder.Append( ClassProvider.DropdownMenuPositionStrategy( ParentDropdown.PositionStrategy ) );
 
         base.BuildClasses( builder );

--- a/Source/Blazorise/Components/FilePicker/FilePicker.razor
+++ b/Source/Blazorise/Components/FilePicker/FilePicker.razor
@@ -10,7 +10,7 @@
                 @FileComponentFragment
             </Addon>
             <Addon AddonType="AddonType.End">
-                <Dropdown RightAligned PositionStrategy="DropdownPositionStrategy.Absolute">
+                <Dropdown EndAligned PositionStrategy="DropdownPositionStrategy.Absolute">
                     <DropdownToggle Color="Color.Light">
                         (@(FileEdit.Files?.Count() ?? 0))
                     </DropdownToggle>

--- a/Source/Blazorise/Interfaces/IClassProvider.cs
+++ b/Source/Blazorise/Interfaces/IClassProvider.cs
@@ -426,7 +426,7 @@ public interface IClassProvider
 
     string DropdownMenuVisible( bool visible );
 
-    string DropdownMenuRight( bool rightAligned );
+    string DropdownMenuEnd( bool endAligned );
 
     string DropdownToggle( bool isDropdownSubmenu, bool outline );
 

--- a/Source/Blazorise/Modules/JSOptions/DropdownJSOptions.cs
+++ b/Source/Blazorise/Modules/JSOptions/DropdownJSOptions.cs
@@ -23,7 +23,7 @@ public class DropdownJSOptions
     /// <summary>
     /// Gets or sets a value indicating whether the dropdown menu is right-aligned.
     /// </summary>
-    public bool RightAligned { get; set; }
+    public bool EndAligned { get; set; }
 
     /// <summary>
     /// Gets or sets the CSS class names for styling the dropdown toggle element.

--- a/Source/Blazorise/Providers/ClassProvider.cs
+++ b/Source/Blazorise/Providers/ClassProvider.cs
@@ -427,7 +427,7 @@ public abstract class ClassProvider : IClassProvider
 
     public abstract string DropdownMenuVisible( bool visible );
 
-    public abstract string DropdownMenuRight( bool rightAligned );
+    public abstract string DropdownMenuEnd( bool endAligned );
 
     public abstract string DropdownToggle( bool isDropdownSubmenu, bool outline );
 

--- a/Source/Blazorise/Providers/EmptyClassProvider.cs
+++ b/Source/Blazorise/Providers/EmptyClassProvider.cs
@@ -429,7 +429,7 @@ class EmptyClassProvider : IClassProvider
 
     public string DropdownMenuVisible( bool visible ) => null;
 
-    public string DropdownMenuRight( bool rightAligned ) => null;
+    public string DropdownMenuEnd( bool endAligned ) => null;
 
     public string DropdownToggle( bool isDropdownSubmenu, bool outline ) => null;
 

--- a/Source/Blazorise/States/DropdownState.cs
+++ b/Source/Blazorise/States/DropdownState.cs
@@ -15,7 +15,7 @@ public record DropdownState
     /// <summary>
     /// If true, a dropdown menu will be right aligned.
     /// </summary>
-    public bool RightAligned { get; init; }
+    public bool EndAligned { get; init; }
 
     /// <summary>
     /// If true, dropdown would not react to button click.

--- a/Source/Blazorise/wwwroot/floatingUi.js
+++ b/Source/Blazorise/wwwroot/floatingUi.js
@@ -10,7 +10,7 @@ export function createFloatingUiAutoUpdate(targetElement, menuElement, options) 
     //https://floating-ui.com/docs/autoUpdate
     return autoUpdate(targetElement, menuElement, () => {
         computePosition(targetElement, menuElement, { //https://floating-ui.com/docs/computePosition#anchoring
-            placement: getPlacementDirection(options.direction, options.rightAligned), //https://floating-ui.com/docs/computePosition#placement
+            placement: getPlacementDirection(options.direction, options.endAligned), //https://floating-ui.com/docs/computePosition#placement
             strategy: options.strategy, //https://floating-ui.com/docs/computePosition#strategy
             middleware: [flip(), shift({ padding: 0, limiter: limitShift() })] //https://floating-ui.com/docs/computePosition#middleware
         }).then(({ x, y }) => {
@@ -22,8 +22,8 @@ export function createFloatingUiAutoUpdate(targetElement, menuElement, options) 
     });
 }
 
-function getPlacementDirection(direction, rightAligned) {
-    let suffixAlignment = rightAligned ? "end" : "start";
+function getPlacementDirection(direction, endAligned) {
+    let suffixAlignment = endAligned ? "end" : "start";
 
     if (direction === DIRECTION_DEFAULT || direction === DIRECTION_DOWN)
         return 'bottom-' + suffixAlignment;

--- a/Source/Extensions/Blazorise.Components/DropdownList.razor
+++ b/Source/Extensions/Blazorise.Components/DropdownList.razor
@@ -1,7 +1,7 @@
 ﻿@using Microsoft.AspNetCore.Components.Web.Virtualization
 @typeparam TItem
 @typeparam TValue
-<Dropdown @ref="@dropdownRef" ElementId="@ElementId" Class="@Class" Style="@Style" RightAligned="@RightAligned" Disabled="@Disabled" Direction="@Direction" Attributes="@Attributes">
+<Dropdown @ref="@dropdownRef" ElementId="@ElementId" Class="@Class" Style="@Style" EndAligned="@EndAligned" Disabled="@Disabled" Direction="@Direction" Attributes="@Attributes">
     <DropdownToggle @ref="@dropdownToggleRef" Color="@Color" Size="@DropdownToggleSize" TabIndex="@TabIndex">@ChildContent</DropdownToggle>
     <DropdownMenu MaxMenuHeight="@MaxMenuHeight">
         @if ( Data != null )

--- a/Source/Extensions/Blazorise.Components/DropdownList.razor.cs
+++ b/Source/Extensions/Blazorise.Components/DropdownList.razor.cs
@@ -131,7 +131,7 @@ public partial class DropdownList<TItem, TValue> : ComponentBase
     /// <summary>
     /// If true, a dropdown menu will be right aligned.
     /// </summary>
-    [Parameter] public bool RightAligned { get; set; }
+    [Parameter] public bool EndAligned { get; set; }
 
     /// <summary>
     /// If true, dropdown would not react to button click.


### PR DESCRIPTION
## Description

Closes #3835

Questions/todos:

- The comments need to be updated as well. Regarding that: Should we consider unifying the source of `EndAligned` under one interface and then using `///<inheritdoc/>`? This approach would help avoid repeating the same XML comment across four places: `Dropdown.razor.cs`, `DropdownList.razor.cs`, `DropdownJSOptions`, and `DropdownState`. It’s not just about the comments; `EndAligned` has the same meaning in all these contexts, so centralizing it makes sense.

- release notes need a record, but I will do it on the end.

- There’s still one instance of `RightAligned` left - in `BarDropdown`. However, this case is genuinely "right-aligned" because, even with `dir="rtl"`, it retains its alignment. In contrast, `Dropdown` properly respects the start-end directionality. Perhaps it’s worth reconsidering the functionality of `BarDropdown` to align it with the start-end behavior (in a different task)? 
