### PR TITLE
Datagrid - prevents submitting form on Enter 

### DIFF
--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor
@@ -12,7 +12,8 @@
     }
     <Form>
 
-        @if ( IsCellEdit && ( CommandColumn is null || !CommandColumn.SaveCommandAllowed ) )
+        @if ( (IsCellEdit && (CommandColumn is null || !CommandColumn.SaveCommandAllowed))
+            || (Filterable && !SubmitFormOnEnter) )
         {
             //Disable the default form behaviour where pressing enter submits the form and posts the page which is not expected in typical SPA fashion.
             <Button Type="ButtonType.Submit" PreventDefaultOnSubmit Disabled Display="Display.None"></Button>


### PR DESCRIPTION
 closes #5790

`SubmitFormOnEnter` is respected even in the case of single input field is present in datagrid (case when filter is on and no other fields are present).