### PR TITLE
Table: fix resizing of columns in responsive mode

### DIFF
--- a/Source/Blazorise/wwwroot/table.js
+++ b/Source/Blazorise/wwwroot/table.js
@@ -193,7 +193,10 @@ export function initializeResizable(element, elementId, mode) {
                 resizer.style.height = `${calculateTableActualHeight()}px`;
 
                 // Update the width of column
-                col.style.width = `${w + dx}px`;
+                const widthStyle = `${w + dx}px`;
+                col.style.width = widthStyle;
+                col.style.minWidth = widthStyle;
+                col.style.maxWidth = widthStyle;
             };
 
             // When user releases the mouse, remove the existing event listeners

--- a/Source/Blazorise/wwwroot/table.js
+++ b/Source/Blazorise/wwwroot/table.js
@@ -85,7 +85,7 @@ export function fixedHeaderScrollTableToRow(element, elementId, row) {
 export function initializeResizable(element, elementId, mode) {
     const resizerClass = "b-table-resizer";
     const resizingClass = "b-table-resizing";
-    const resizerHeaderMode = 0;
+    const RESIZER_HEADER_MODE = 0;
     let cols = null;
 
     element = getRequiredElement(element, elementId);
@@ -113,7 +113,7 @@ export function initializeResizable(element, elementId, mode) {
         };
 
         const calculateModeHeight = () => {
-            return mode === resizerHeaderMode
+            return mode === RESIZER_HEADER_MODE
                 ? element !== null
                     ? element.querySelector('tr:first-child > th:first-child').offsetHeight
                     : 0

--- a/Source/Blazorise/wwwroot/table.js
+++ b/Source/Blazorise/wwwroot/table.js
@@ -125,6 +125,12 @@ export function initializeResizable(element, elementId, mode) {
         const createResizableColumn = function (col) {
             if (col.querySelector(`.${resizerClass}`) !== null)
                 return;
+
+            // if the column already has both min and max width set, then we don't need to resize it
+            if (col.style.minWidth && col.style.maxWidth) {
+                return;
+            }
+
             // Add a resizer element to the column
             const resizer = document.createElement('div');
             resizer.classList.add(resizerClass);

--- a/Source/Blazorise/wwwroot/table.js
+++ b/Source/Blazorise/wwwroot/table.js
@@ -83,8 +83,8 @@ export function fixedHeaderScrollTableToRow(element, elementId, row) {
 }
 
 export function initializeResizable(element, elementId, mode) {
-    const resizerClass = "b-table-resizer";
-    const resizingClass = "b-table-resizing";
+    const RESIZER_CLASS = "b-table-resizer";
+    const RESIZING_CLASS = "b-table-resizing";
     const RESIZER_HEADER_MODE = 0;
     let cols = null;
 
@@ -123,7 +123,7 @@ export function initializeResizable(element, elementId, mode) {
         let actualHeight = calculateModeHeight();
 
         const createResizableColumn = function (col) {
-            if (col.querySelector(`.${resizerClass}`) !== null)
+            if (col.querySelector(`.${RESIZER_CLASS}`) !== null)
                 return;
 
             // if the column already has both min and max width set, then we don't need to resize it
@@ -133,7 +133,7 @@ export function initializeResizable(element, elementId, mode) {
 
             // Add a resizer element to the column
             const resizer = document.createElement('div');
-            resizer.classList.add(resizerClass);
+            resizer.classList.add(RESIZER_CLASS);
 
             // Set the height
             resizer.style.height = `${actualHeight}px`;
@@ -189,7 +189,7 @@ export function initializeResizable(element, elementId, mode) {
                 document.addEventListener('pointermove', mouseMoveHandler);
                 document.addEventListener('pointerup', mouseUpHandler);
 
-                resizer.classList.add(resizingClass);
+                resizer.classList.add(RESIZING_CLASS);
             };
 
             const mouseMoveHandler = function (e) {
@@ -210,9 +210,9 @@ export function initializeResizable(element, elementId, mode) {
             const mouseUpHandler = function () {
                 mouseUpDate = new Date();
 
-                resizer.classList.remove(resizingClass);
+                resizer.classList.remove(RESIZING_CLASS);
 
-                element.querySelectorAll(`.${resizerClass}`).forEach(x => x.style.height = `${calculateModeHeight()}px`);
+                element.querySelectorAll(`.${RESIZER_CLASS}`).forEach(x => x.style.height = `${calculateModeHeight()}px`);
 
                 document.removeEventListener('pointermove', mouseMoveHandler);
                 document.removeEventListener('pointerup', mouseUpHandler);

--- a/Source/Blazorise/wwwroot/table.js
+++ b/Source/Blazorise/wwwroot/table.js
@@ -166,18 +166,18 @@ export function initializeResizable(element, elementId, mode) {
             col.appendChild(resizer);
 
             // Track the current position of mouse
-            let x = 0;
-            let w = 0;
+            let startX = 0;
+            let startWidth = 0;
 
             const mouseDownHandler = function (e) {
                 mouseDownDate = new Date();
 
                 // Get the current mouse position
-                x = e.clientX;
+                startX = e.clientX;
 
                 // Calculate the current width of column
                 const styles = window.getComputedStyle(col);
-                w = parseInt(styles.width, 10);
+                startWidth = parseInt(styles.width, 10);
 
                 // Attach listeners for document's events
                 document.addEventListener('pointermove', mouseMoveHandler);
@@ -188,12 +188,12 @@ export function initializeResizable(element, elementId, mode) {
 
             const mouseMoveHandler = function (e) {
                 // Determine how far the mouse has been moved
-                const dx = e.clientX - x;
+                const dx = e.clientX - startX;
 
                 resizer.style.height = `${calculateTableActualHeight()}px`;
 
                 // Update the width of column
-                const widthStyle = `${w + dx}px`;
+                const widthStyle = `${startWidth + dx}px`;
                 col.style.width = widthStyle;
                 col.style.minWidth = widthStyle;
                 col.style.maxWidth = widthStyle;

--- a/Source/Blazorise/wwwroot/table.js
+++ b/Source/Blazorise/wwwroot/table.js
@@ -127,7 +127,7 @@ export function initializeResizable(element, elementId, mode) {
                 return;
 
             // if the column already has both min and max width set, then we don't need to resize it
-            if (col.style.minWidth && col.style.maxWidth) {
+            if (col.style.minWidth && col.style.maxWidth && !col.dataset.resized) {
                 return;
             }
 
@@ -203,6 +203,7 @@ export function initializeResizable(element, elementId, mode) {
                 col.style.width = widthStyle;
                 col.style.minWidth = widthStyle;
                 col.style.maxWidth = widthStyle;
+                col.dataset.resized = true;
             };
 
             // When user releases the mouse, remove the existing event listeners


### PR DESCRIPTION
Closes #5907, #5904, #5216

While trying to come up with a solution to resizing in responsive mode, I noticed that we just need to define `minWidth` and `maxWidth` to make it work. After that I added a check to disable resizing if the user had explicitly defined min/max width.

**Pros**: it works as expected now

**Cons**: for fixed columns, the user should explicitly define HeaderCellStyle

**Test code:**

```
<DataGrid TItem="Employee"
          Data="@employeeList"
          @bind-SelectedRow="@selectedEmployee"
          Responsive
          Resizable
          ResizeMode="TableResizeMode.Columns">
    <DataGridCommandColumn />
    <DataGridColumn Field="@nameof(Employee.Id)" Caption="#" Sortable="false" Width="400px" CellStyle="@((item)=>"min-width:400px;max-width:400px;")" HeaderCellStyle="min-width:400px;max-width:400px" />
    <DataGridColumn Field="@nameof(Employee.FirstName)" Caption="First Name" Width="2400px" CellStyle="@((item)=>"min-width:2400px;max-width:2400px;")" HeaderCellStyle="min-width:2400px;max-width:2400px" />
    <DataGridColumn Field="@nameof(Employee.LastName)" Caption="Last Name" />
    <DataGridColumn Field="@nameof(Employee.Email)" Caption="Email" />
    <DataGridColumn Field="@nameof(Employee.Salary)" Caption="Salary" />
</DataGrid>

@code {
    [Inject]
    public EmployeeData EmployeeData { get; set; }
    private List<Employee> employeeList;
    private Employee selectedEmployee;
    private TableResizeMode resizeMode = TableResizeMode.Header;

    protected override async Task OnInitializedAsync()
    {
        employeeList = await EmployeeData.GetDataAsync();
        await base.OnInitializedAsync();
    }
}
```