### PR TITLE
Modal: Hides scrollbar on modal.Show()

### DIFF
--- a/Source/Blazorise.Bootstrap5/wwwroot/modal.js
+++ b/Source/Blazorise.Bootstrap5/wwwroot/modal.js
@@ -6,6 +6,13 @@ export function open(element, scrollToTop) {
     var modals = Number(document.body.getAttribute("data-modals") || "0");
 
     if (modals === 0) {
+        // Save the original overflow value
+        const originalOverflow = document.body.style.overflow || '';
+        document.body.setAttribute('data-original-overflow', originalOverflow);
+
+        // Hide the scrollbar
+        document.body.style.overflow = 'hidden';
+
         addClassToBody("modal-open");
     }
 
@@ -32,6 +39,9 @@ export function close(element) {
     }
 
     if (modals === 0) {
+        // Restore the original overflow value
+        document.body.style.overflow = document.body.getAttribute('data-original-overflow') || '';
+        document.body.removeAttribute('data-original-overflow');
         removeClassFromBody("modal-open");
     }
 


### PR DESCRIPTION
## Description  

Closes #5911  

When a modal is opened, the scrollbar on the body is removed. The emphasis here is on "on the body," as many sites, including [blazorise.com](https://blazorise.com), the demo sites, and numerous other web pages, don’t use the body as the main scrolling element. 

Currently, the solution is implemented for Bootstrap 5, but I need clarification on a few points before proceeding with other providers.  

## Code Questions  

The scrollbar-hiding functionality is based on Bootstrap's [scrollbar.js](https://github.com/twbs/bootstrap/blob/main/js/src/util/scrollbar.js). It seems that Blazorise already has parts of this functionality implemented in `modal.js` for the Bootstrap 5, Bootstrap, and Tailwind providers.  

Most of the code in [modal.js](https://github.com/Megabit/Blazorise/blob/458799c524ca5f1f01370cf8e69a55d379355864/Source/Blazorise.Bootstrap5/wwwroot/modal.js) appears to handle the correction of UI elements with `fixed` and `sticky` positioning when the scrollbar is removed. This correction is likely necessary to compensate for the blank space left by the scrollbar removal.

What confuses me most is the apparent absence of actual scrollbar removal in the existing code. Without this step, there’s nothing to compensate for, making much of the code seem redundant.

Here are my key questions:  
- If this compensation is necessary, why doesn’t the corresponding code appear in other providers?  
- Am I missing something about how this is meant to function?  

## Proposal  

1. Move the scrollbar handling code into a shared `scrollbar.js` and use it for scrollbar removal and width compensation across all providers. This would require some refactoring, as the handling of `fixed` and `sticky` classes is provider-specific.  
2. Consider merging all the `modal.js` files into a single shared file to simplify maintenance.  

### A Note on Sticky and Fixed Compensation  

I’m not convinced that the compensation for sticky and fixed elements is needed. In my testing, removing the scrollbar didn’t appear to affect these elements significantly because the body padding already compensates for the scrollbar width.  

Even if there are edge cases where this is an issue, the worst-case scenario seems to be a minor (approximately 20px) horizontal shift in elements that will be inactive and covered by the modal anyway. Removing this part of the code would significantly simplify the `modal.js` script.  
