### PR TITLE
Table: don't resize columns with FixedPosition

### DIFF
--- a/Source/Blazorise/Components/Table/TableHeaderCell.razor
+++ b/Source/Blazorise/Components/Table/TableHeaderCell.razor
@@ -2,6 +2,7 @@
 @inherits BaseDraggableComponent
 <th @ref="@ElementRef" id="@ElementId" scope="col" class="@ClassNames" style="@StyleNames" @onclick="@OnClickHandler" colspan="@ColumnSpan" rowspan="@RowSpan"
     draggable="@DraggableString"
+    data-fixed-position="@FixedPositionDataAttribute"
     @ondragend="@OnDragEndHandler"
     @ondragend:preventDefault="@DragEndPreventDefault"
     @ondragenter="@OnDragEnterHandler"

--- a/Source/Blazorise/Components/Table/TableHeaderCell.razor.cs
+++ b/Source/Blazorise/Components/Table/TableHeaderCell.razor.cs
@@ -143,11 +143,12 @@ public partial class TableHeaderCell : BaseDraggableComponent, IDisposable
     /// <summary>
     /// Gets the fixed position data attribute.
     /// </summary>
-    protected string FixedPositionDataAttribute => FixedPosition == TableColumnFixedPosition.Start
-        ? "start"
-        : FixedPosition == TableColumnFixedPosition.End
-            ? "end"
-            : null;
+    protected string FixedPositionDataAttribute => FixedPosition switch
+    {
+        TableColumnFixedPosition.Start => "start",
+        TableColumnFixedPosition.End => "end",
+        _ => null
+    };
 
     /// <summary>
     /// Gets or sets the cascaded parent table component.

--- a/Source/Blazorise/Components/Table/TableHeaderCell.razor.cs
+++ b/Source/Blazorise/Components/Table/TableHeaderCell.razor.cs
@@ -146,7 +146,7 @@ public partial class TableHeaderCell : BaseDraggableComponent, IDisposable
     protected string FixedPositionDataAttribute => FixedPosition == TableColumnFixedPosition.Start
         ? "start"
         : FixedPosition == TableColumnFixedPosition.End
-            ? $"end"
+            ? "end"
             : null;
 
     /// <summary>

--- a/Source/Blazorise/Components/Table/TableHeaderCell.razor.cs
+++ b/Source/Blazorise/Components/Table/TableHeaderCell.razor.cs
@@ -141,6 +141,15 @@ public partial class TableHeaderCell : BaseDraggableComponent, IDisposable
     #region Properties
 
     /// <summary>
+    /// Gets the fixed position data attribute.
+    /// </summary>
+    protected string FixedPositionDataAttribute => FixedPosition == TableColumnFixedPosition.Start
+        ? "start"
+        : FixedPosition == TableColumnFixedPosition.End
+            ? $"end"
+            : null;
+
+    /// <summary>
     /// Gets or sets the cascaded parent table component.
     /// </summary>
     [CascadingParameter] protected Table ParentTable { get; set; }

--- a/Source/Blazorise/Components/Table/TableRowCell.razor
+++ b/Source/Blazorise/Components/Table/TableRowCell.razor
@@ -19,6 +19,7 @@
     @oncontextmenu="@OnContextMenuHandler"
     @oncontextmenu:preventDefault="@ContextMenuPreventDefault"
     data-caption="@MobileModeCaption"
+    data-fixed-position="@FixedPositionDataAttribute"
     @attributes="@Attributes">
     @ChildContent
 </td>

--- a/Source/Blazorise/Components/Table/TableRowCell.razor.cs
+++ b/Source/Blazorise/Components/Table/TableRowCell.razor.cs
@@ -146,7 +146,7 @@ public partial class TableRowCell : BaseDraggableComponent, IDisposable
     protected string FixedPositionDataAttribute => FixedPosition == TableColumnFixedPosition.Start
         ? "start"
         : FixedPosition == TableColumnFixedPosition.End
-            ? $"end"
+            ? "end"
             : null;
 
     /// <summary>

--- a/Source/Blazorise/Components/Table/TableRowCell.razor.cs
+++ b/Source/Blazorise/Components/Table/TableRowCell.razor.cs
@@ -141,6 +141,15 @@ public partial class TableRowCell : BaseDraggableComponent, IDisposable
     #region Properties
 
     /// <summary>
+    /// Gets the fixed position data attribute.
+    /// </summary>
+    protected string FixedPositionDataAttribute => FixedPosition == TableColumnFixedPosition.Start
+        ? "start"
+        : FixedPosition == TableColumnFixedPosition.End
+            ? $"end"
+            : null;
+
+    /// <summary>
     /// Gets or sets the cascaded parent table component.
     /// </summary>
     [CascadingParameter] protected Table ParentTable { get; set; }

--- a/Source/Blazorise/Components/Table/TableRowCell.razor.cs
+++ b/Source/Blazorise/Components/Table/TableRowCell.razor.cs
@@ -143,11 +143,12 @@ public partial class TableRowCell : BaseDraggableComponent, IDisposable
     /// <summary>
     /// Gets the fixed position data attribute.
     /// </summary>
-    protected string FixedPositionDataAttribute => FixedPosition == TableColumnFixedPosition.Start
-        ? "start"
-        : FixedPosition == TableColumnFixedPosition.End
-            ? "end"
-            : null;
+    protected string FixedPositionDataAttribute => FixedPosition switch
+    {
+        TableColumnFixedPosition.Start => "start",
+        TableColumnFixedPosition.End => "end",
+        _ => null
+    };
 
     /// <summary>
     /// Gets or sets the cascaded parent table component.

--- a/Source/Blazorise/wwwroot/table.js
+++ b/Source/Blazorise/wwwroot/table.js
@@ -127,7 +127,7 @@ export function initializeResizable(element, elementId, mode) {
                 return;
 
             // if the column already has both min and max width set, then we don't need to resize it
-            if (col.style.minWidth && col.style.maxWidth && !col.dataset.resized) {
+            if (((col.style.minWidth && col.style.maxWidth) || col.dataset.fixedPosition) && !col.dataset.resized) {
                 return;
             }
 


### PR DESCRIPTION
Closes https://blazorise.com/support/issues/238/help-understanding-datagrid-column-sizing

In my previous fix I have only disabled resizing of columns that have `min-width` and `max-width`. With this fix, I also disabled resizer for columns that have FixedPosition defined.