### PR TITLE
MemoEdit: include border size when autosizing

### DIFF
--- a/Source/Blazorise/wwwroot/memoEdit.js
+++ b/Source/Blazorise/wwwroot/memoEdit.js
@@ -99,9 +99,10 @@ export function updateOptions(element, elementId, options) {
 
 function onInputChanged(e) {
     if (e && e.target) {
-        e.target.style.height = 'auto';
-        e.target.style.height = this.scrollHeight + 'px';
-        e.target.style.overflowY = 'hidden';
+        const textarea = e.target;
+        textarea.style.height = 'auto';
+        textarea.style.overflowY = 'hidden';
+        textarea.style.height = `${textarea.scrollHeight + 2}px`; // The +2 accounts for browser rendering inaccuracies with scrollHeight
     }
 }
 

--- a/Source/Blazorise/wwwroot/memoEdit.js
+++ b/Source/Blazorise/wwwroot/memoEdit.js
@@ -104,13 +104,11 @@ function onInputChanged(e) {
 
         const borderTop = parseFloat(computedStyle.borderTopWidth) || 0;
         const borderBottom = parseFloat(computedStyle.borderBottomWidth) || 0;
-        const paddingTop = parseFloat(computedStyle.paddingTop) || 0;
-        const paddingBottom = parseFloat(computedStyle.paddingBottom) || 0;
 
         textarea.style.height = 'auto';
         textarea.style.overflowY = 'hidden';
 
-        const totalExtraSpace = borderTop + borderBottom + paddingTop + paddingBottom;
+        const totalExtraSpace = borderTop + borderBottom;
 
         textarea.style.height = `${textarea.scrollHeight + totalExtraSpace}px`;
     }

--- a/Source/Blazorise/wwwroot/memoEdit.js
+++ b/Source/Blazorise/wwwroot/memoEdit.js
@@ -100,9 +100,19 @@ export function updateOptions(element, elementId, options) {
 function onInputChanged(e) {
     if (e && e.target) {
         const textarea = e.target;
+        const computedStyle = window.getComputedStyle(textarea);
+
+        const borderTop = parseFloat(computedStyle.borderTopWidth) || 0;
+        const borderBottom = parseFloat(computedStyle.borderBottomWidth) || 0;
+        const paddingTop = parseFloat(computedStyle.paddingTop) || 0;
+        const paddingBottom = parseFloat(computedStyle.paddingBottom) || 0;
+
         textarea.style.height = 'auto';
         textarea.style.overflowY = 'hidden';
-        textarea.style.height = `${textarea.scrollHeight + 2}px`; // The +2 accounts for browser rendering inaccuracies with scrollHeight
+
+        const totalExtraSpace = borderTop + borderBottom + paddingTop + paddingBottom;
+
+        textarea.style.height = `${textarea.scrollHeight + totalExtraSpace}px`;
     }
 }
 


### PR DESCRIPTION
Fixes problem with auto size showing the scrollbar

> Another question: We have the issue that a memoedit with Autosize=”true” shows a scrollbar. Its height is a few pixels too small. This is especially a problem because the scrollbar hides the green check-mark of a validation in the top right corner. I saw this has been an issue in an earlier version of Blazorise and has been fixed. Is it possible this issue has been re-introduced in 1.7?

Test code:

```razor
<Div>
    <MemoEdit Text="@memoText"
              Size="Size.Small"
              TextWeight="TextWeight.Light"
              ReplaceTab="true"
              AutoSize="true"
              Overflow="Overflow.Auto"
              ReadOnly="false">
    </MemoEdit>
</Div>

<Button Clicked="SetText">Set Text</Button>
@code {
    private string memoText;

    private void SetText()
    {
        var emp = new Employee { Id = 1, FirstName = "Alexander Maximilian", LastName = "Hohenberg Von Strassburg", Email = "alexander.maximilian@example.com", City = "Berlin", Zip = "10115", DateOfBirth = new DateTime(1985, 5, 15), Childrens = 2, Salary = 50000, IsActive = true };

        var options = new JsonSerializerOptions();

        options.WriteIndented = true;

        memoText = System.Text.Json.JsonSerializer.Serialize(emp, options);
    }
}
```