### PR TITLE
DateEdit: properly parse the seconds part

### DIFF
--- a/Source/Blazorise/Utilities/Formatters/Parsers.cs
+++ b/Source/Blazorise/Utilities/Formatters/Parsers.cs
@@ -18,7 +18,7 @@ public static class Parsers
     /// <summary>
     /// Internal date-time format. Compatible with HTML date inputs.
     /// </summary>
-    public const string InternalDateTimeFormat = "yyyy-MM-ddTHH:mm";
+    public const string InternalDateTimeFormat = "yyyy-MM-ddTHH:mm:ss";
 
     /// <summary>
     /// Internal month format. Compatible with HTML date inputs.
@@ -64,8 +64,10 @@ public static class Parsers
     public static readonly string[] SupportedParseDateTimeFormats = new string[]
     {
         InternalDateTimeFormat,
+        $"{InternalDateFormat}:ss",
         ExternalDateTimeFormat,
         "yyyy-MM-ddTHH:mm",
+        "yyyy-MM-ddTHH:mm:ss",
         CultureInfo.InvariantCulture.DateTimeFormat.LongDatePattern,
         CultureInfo.InvariantCulture.DateTimeFormat.ShortDatePattern,
         "o", // a string representing UTC

--- a/Source/Blazorise/Utilities/Formatters/Parsers.cs
+++ b/Source/Blazorise/Utilities/Formatters/Parsers.cs
@@ -66,7 +66,6 @@ public static class Parsers
         InternalDateTimeFormat,
         ExternalDateTimeFormat,
         "yyyy-MM-ddTHH:mm",
-        "yyyy-MM-ddTHH:mm:ss",
         CultureInfo.InvariantCulture.DateTimeFormat.LongDatePattern,
         CultureInfo.InvariantCulture.DateTimeFormat.ShortDatePattern,
         "o", // a string representing UTC

--- a/Source/Blazorise/Utilities/Formatters/Parsers.cs
+++ b/Source/Blazorise/Utilities/Formatters/Parsers.cs
@@ -53,6 +53,7 @@ public static class Parsers
         InternalDateFormat,
         ExternalDateFormat,
         "yyyy-MM-ddTHH:mm",
+        "yyyy-MM-ddTHH:mm:ss",
         CultureInfo.InvariantCulture.DateTimeFormat.LongDatePattern,
         CultureInfo.InvariantCulture.DateTimeFormat.ShortDatePattern,
         "o", // a string representing UTC

--- a/Source/Blazorise/Utilities/Formatters/Parsers.cs
+++ b/Source/Blazorise/Utilities/Formatters/Parsers.cs
@@ -64,7 +64,6 @@ public static class Parsers
     public static readonly string[] SupportedParseDateTimeFormats = new string[]
     {
         InternalDateTimeFormat,
-        $"{InternalDateFormat}:ss",
         ExternalDateTimeFormat,
         "yyyy-MM-ddTHH:mm",
         "yyyy-MM-ddTHH:mm:ss",


### PR DESCRIPTION
Closes #5953

Fixes the date parser by adding the seconds part.

```
<Div>
    <Paragraph>
        <DateEdit TValue="DateTime?" InputMode="DateInputMode.DateTime" @bind-Date="@DateValue" />
    </Paragraph>
    <Paragraph>
        @DateValue
    </Paragraph>
</Div>

<Div>
    <Paragraph>
        <DateEdit TValue="DateTime?" InputMode="DateInputMode.Date" @bind-Date="@Date" />
    </Paragraph>
    <Paragraph>
        @Date
    </Paragraph>
</Div>
@code {
    private DateTime? DateValue { get; set; } = DateTime.Today.Add(new TimeSpan(18, 03, 24));
    private DateTime? Date { get; set; } = DateTime.Today.Add(new TimeSpan(18, 03, 24));
}
```