### PR TITLE
Devops: fix action for ubuntu-latest and invariant culture in tests

### DIFF
--- a/.github/workflows/blazorise-ci-basic.yml
+++ b/.github/workflows/blazorise-ci-basic.yml
@@ -5,7 +5,7 @@ on: [push]
 jobs:
   build:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4

--- a/Tests/Blazorise.Tests/DataGrid/Utils/FunctionCompilerTests.cs
+++ b/Tests/Blazorise.Tests/DataGrid/Utils/FunctionCompilerTests.cs
@@ -26,12 +26,12 @@ public class FunctionCompilerTests
         var test = new Test();
         var valueGetter = FunctionCompiler.CreateValueGetter<Test>( field );
         var value = valueGetter( test );
-        
-        Assert.Equal(expected, value switch
+
+        Assert.Equal( expected, value switch
         {
-            DateTime dt => dt.ToString("M/d/yyyy h:mm:ss tt", CultureInfo.InvariantCulture),
-            _           => value?.ToString()
-        });
+            DateTime dt => dt.ToString( "M/d/yyyy h:mm:ss tt", CultureInfo.InvariantCulture ),
+            _ => value?.ToString()
+        } );
     }
 
     [Theory]
@@ -52,14 +52,13 @@ public class FunctionCompilerTests
     {
         var test = GetTest();
         var valueGetter = FunctionCompiler.CreateValueGetter<Test>( field );
-
         var value = valueGetter( test );
-        Assert.Equal(expected, value switch
-        {
-            DateTime dt        => dt.ToString("M/d/yyyy h:mm:ss tt", CultureInfo.InvariantCulture),
-            _                  => value?.ToString()
-        });
 
+        Assert.Equal( expected, value switch
+        {
+            DateTime dt => dt.ToString( "M/d/yyyy h:mm:ss tt", CultureInfo.InvariantCulture ),
+            _ => value?.ToString()
+        } );
     }
 
     public FunctionCompilerTests()

--- a/Tests/Blazorise.Tests/DataGrid/Utils/FunctionCompilerTests.cs
+++ b/Tests/Blazorise.Tests/DataGrid/Utils/FunctionCompilerTests.cs
@@ -25,8 +25,13 @@ public class FunctionCompilerTests
     {
         var test = new Test();
         var valueGetter = FunctionCompiler.CreateValueGetter<Test>( field );
-
-        Assert.Equal( expected, valueGetter( test )?.ToString() );
+        var value = valueGetter( test );
+        
+        Assert.Equal(expected, value switch
+        {
+            DateTime dt => dt.ToString("M/d/yyyy h:mm:ss tt", CultureInfo.InvariantCulture),
+            _           => value?.ToString()
+        });
     }
 
     [Theory]
@@ -48,7 +53,13 @@ public class FunctionCompilerTests
         var test = GetTest();
         var valueGetter = FunctionCompiler.CreateValueGetter<Test>( field );
 
-        Assert.Equal( expected, valueGetter( test )?.ToString() );
+        var value = valueGetter( test );
+        Assert.Equal(expected, value switch
+        {
+            DateTime dt        => dt.ToString("M/d/yyyy h:mm:ss tt", CultureInfo.InvariantCulture),
+            _                  => value?.ToString()
+        });
+
     }
 
     public FunctionCompilerTests()


### PR DESCRIPTION
Original problem: https://github.com/Megabit/Blazorise/pull/5940#issuecomment-2601019373

The error was this:

```
Assert.Equal() Failure: Strings differ
                              ↓ (pos 19)
Expected: "12/31/9999 11:59:59 PM"
Actual:   "12/31/9999 11:59:59 PM"
                              ↑ (pos 19)


```

Explanation:

```
At position 19, the space before "PM" is different:

    The expected value has a regular space (U+0020).
    The actual value has a narrow no-break space (U+202F), which looks visually similar but is a different Unicode character.
```


It is culture dependent. I don't exactly know why that was happening in ubuntu 24 not 22...

This  fix makes the tests more deterministic.

I re-discovered the issue by an accident. And fixing it till it's in fresh memory...

 