### PR TITLE
Markdown: ImageUploadChanged with multiple files fix

### DIFF
--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/Markdown/MarkdownPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/Markdown/MarkdownPage.razor
@@ -58,7 +58,9 @@
 
 <DocsPageSection>
     <DocsPageSectionHeader Title="Upload image">
-        Uploading image has a similar API to our FileEdit component and it is fairly simple to do.
+        Uploading an image has a similar API to our <Code>FileEdit</Code> component and is fairly simple to use.
+        <Strong>Note that</Strong> the events related to file uploads fire separately for each file instead of grouping them.
+        This behavior comes from the underlying Easy Markdown Editor, which processes files individually.
     </DocsPageSectionHeader>
     <DocsPageSectionContent Outlined FullWidth>
         <MarkdownUploadImageExample />

--- a/Source/Extensions/Blazorise.Markdown/wwwroot/markdown.js
+++ b/Source/Extensions/Blazorise.Markdown/wwwroot/markdown.js
@@ -80,7 +80,9 @@ export function initialize(dotNetObjectRef, element, elementId, options) {
             imageUploadNotifier.onError = onError;
 
             // Reduce to purely serializable data, plus build an index by ID
-            element._blazorFilesById = {};
+            if (element._blazorFilesById == null) {
+                element._blazorFilesById = {};
+            }
 
             var fileEntry = {
                 id: ++nextFileId,


### PR DESCRIPTION
## Description
Closes #5961

This effectively fixes the issue. The previous implementation overwrote the `_blazorFilesById` dictionary, which resulted in [this error](https://github.com/Megabit/Blazorise/blob/bd5b05a8e27a51861b7b6476e42a6930598ff1fe/Source/Blazorise/wwwroot/io.js#L46)  
when calling `await file.WriteToStreamAsync(memoryStream);`

The fix works, but there are plenty of areas for improvement.

## Files One by One, Not Grouped
- As @linkdotnet pointed out in the issue, files are processed one by one, even though `FileChangedEventArgs` supports multiple files at once. This behavior originates from the underlying Easy Markdown Editor and its `imageUploadFunction`, which handles only one file at a time. The relevant implementation is here:  
  [EasyMDE source](https://github.com/Ionaru/easy-markdown-editor/blob/fe680f09f66357243db0b2b4564cdf0dc6d20a1b/src/js/easymde.js#L1956).  

  On the Blazorise side, event handling follows a similar pattern to `FileEdit`, which maintains the same event arguments (`Files` instead of `File`). That said, I think we should improve this, at least by documenting it. Additionally, I believe I can "group" the individual calls from js into a single call to .NET.

## Unreachable Files
The current fixed implementation follows one flow—it keeps files in memory "forever". This is by design because Blazorise cannot effectively predict when a user will call `WriteToStream`.  

This issue could be mitigated by deleting the `blob` from the dictionary (where the files persist "forever") once it has been written to a stream. However, doing so would prevent the user from writing to the stream again or later:

```
private async Task ImageUploadChanged(FileChangedEventArgs events)
{ 
    fileForLater = events.Files.First();
}

IFileEntry? fileForLater;

async Task SomeMethodThatIsCalledLater()
{
    if (fileForLater is null) return; 
    // C# file reference is not null, but the actual blob state in JS is unknown 
    using var memoryStream = new MemoryStream();
    await fileForLater.WriteToStreamAsync(memoryStream);
}
```
The implementation problem lies in the fact that the C# reference is not synchronized with its content on the js side, and there is currently no way to verify this from C# code.

(also) for this reason, the documentation includes a `try-catch` block around this logic. However, I think it would be better to streamline the solution with something like `TryToWriteToStreamAsync`...

Is it worth improving that @stsrki ?

