### PR TITLE
Markdown: merge uploaded files callback

### DIFF
--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/Markdown/MarkdownPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/Markdown/MarkdownPage.razor
@@ -59,8 +59,6 @@
 <DocsPageSection>
     <DocsPageSectionHeader Title="Upload image">
         Uploading an image has a similar API to our <Code>FileEdit</Code> component and is fairly simple to use.
-        <Strong>Note that</Strong> the events related to file uploads fire separately for each file instead of grouping them.
-        This behavior comes from the underlying Easy Markdown Editor, which processes files individually.
     </DocsPageSectionHeader>
     <DocsPageSectionContent Outlined FullWidth>
         <MarkdownUploadImageExample />

--- a/Source/Blazorise/Interfaces/Modules/IJSFileModule.cs
+++ b/Source/Blazorise/Interfaces/Modules/IJSFileModule.cs
@@ -32,5 +32,11 @@ public interface IJSFileModule : IBaseJSModule
     /// <returns>A task that represents the asynchronous operation.</returns>
     ValueTask<IJSStreamReference> ReadDataAsync( ElementReference elementRef, int fileEntryId, CancellationToken cancellationToken = default );
 
-
+    /// <summary>
+    /// Removes file entry from js dictionary
+    /// </summary>
+    /// <param name="elementRef">Reference to the rendered element.</param>
+    /// <param name="fileEntryId"></param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    ValueTask RemoveFileEntry( ElementReference elementRef, int fileEntryId );
 }

--- a/Source/Blazorise/Modules/BaseJSModule.cs
+++ b/Source/Blazorise/Modules/BaseJSModule.cs
@@ -1,5 +1,6 @@
 ﻿#region Using directives
 using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Blazorise.Extensions;
 using Microsoft.JSInterop;
@@ -136,8 +137,9 @@ public abstract class BaseJSModule : IBaseJSModule, IAsyncDisposable
 
                 await module.InvokeVoidAsync( identifier, args );
             }
-            catch ( Exception )
+            catch ( Exception ex )
             {
+                Debug.WriteLine( $"Exception form InvokeSafeVoidAsync: {ex.Message}" );
             }
         }
         else
@@ -181,8 +183,9 @@ public abstract class BaseJSModule : IBaseJSModule, IAsyncDisposable
 
                 return await module.InvokeAsync<TValue>( identifier, args );
             }
-            catch ( Exception )
+            catch ( Exception ex)
             {
+                Debug.WriteLine( $"Exception form InvokeSafeVoidAsync: {ex.Message}" );
                 return default;
             }
         }

--- a/Source/Blazorise/Modules/JSFileModule.cs
+++ b/Source/Blazorise/Modules/JSFileModule.cs
@@ -36,6 +36,10 @@ public class JSFileModule : BaseJSModule, IJSFileModule
     /// <inheritdoc/>
     public virtual ValueTask<IJSStreamReference> ReadDataAsync( ElementReference elementRef, int fileEntryId, CancellationToken cancellationToken = default )
         => InvokeSafeAsync<IJSStreamReference>( "readFileDataStream", elementRef, fileEntryId );
+    
+    /// <inheritdoc/>
+    public virtual ValueTask RemoveFileEntry( ElementReference elementRef, int fileEntryId )
+        => InvokeSafeVoidAsync( "removeFileEntry", elementRef, fileEntryId);
 
     #endregion
 

--- a/Source/Blazorise/Utilities/IO/FileEntry.cs
+++ b/Source/Blazorise/Utilities/IO/FileEntry.cs
@@ -57,6 +57,11 @@ public class FileEntry : IFileEntry
 
         return Task.CompletedTask;
     }
+    
+    ~FileEntry()
+    {
+        Owner.RemoveFileEntry( Id );
+    }
 
     #endregion
 

--- a/Source/Blazorise/Utilities/IO/IFileEntryOwner.cs
+++ b/Source/Blazorise/Utilities/IO/IFileEntryOwner.cs
@@ -2,6 +2,9 @@
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Blazorise.Modules;
+using Microsoft.AspNetCore.Components;
+
 #endregion
 
 namespace Blazorise;
@@ -27,4 +30,27 @@ public interface IFileEntryOwner
     /// <param name="cancellationToken">A cancellation token to signal the cancellation of streaming file data.</param>
     /// <returns>Returns the stream for the uploaded file entry.</returns>
     Stream OpenReadStream( FileEntry fileEntry, CancellationToken cancellationToken = default );
+
+    
+    /// <summary>
+    /// Removes the file entry from js dictionary.
+    /// </summary>
+    /// <param name="fileEntryId"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    Task RemoveFileEntry( int fileEntryId, CancellationToken cancellationToken = default )
+    {
+        JSFileModule.RemoveFileEntry(ElementRef, fileEntryId);
+        return Task.CompletedTask;
+    }
+    
+    /// <summary>
+    /// ElementReference from BaseComponent
+    /// </summary>
+    ElementReference ElementRef { get; set; }
+
+    /// <summary>
+    /// JSFileModule 
+    /// </summary>    
+    IJSFileModule JSFileModule { get; set; }  
 }

--- a/Source/Blazorise/wwwroot/fileEdit.js
+++ b/Source/Blazorise/wwwroot/fileEdit.js
@@ -75,7 +75,10 @@ export function open(element, elementId) {
 
 // Reduce to purely serializable data, plus build an index by ID
 function mapElementFilesToFileEntries(element) {
-    element._blazorFilesById = {};
+
+    if (element._blazorFilesById == null) {
+        element._blazorFilesById = {};
+    }
 
     let fileList = Array.prototype.map.call(element.files, function (file) {
         file.id = file.id ?? ++nextFileId;

--- a/Source/Blazorise/wwwroot/io.js
+++ b/Source/Blazorise/wwwroot/io.js
@@ -49,6 +49,10 @@ function getFileById(element, fileId) {
     return file;
 }
 
+export function removeFileEntry(element, fileEntryId) {
+    delete element._blazorFilesById[fileEntryId];
+}
+
 function getArrayBufferFromFileAsync(element, fileId) {
     var file = getFileById(element, fileId);
 

--- a/Source/Extensions/Blazorise.Markdown/Markdown.razor.cs
+++ b/Source/Extensions/Blazorise.Markdown/Markdown.razor.cs
@@ -272,20 +272,26 @@ public partial class Markdown : BaseComponent,
     /// <summary>
     /// Notifies the component that file input value has changed. This method is intended for internal framework use only and should not be called directly by user code.
     /// </summary>
-    /// <param name="file">Changed file.</param>
+    /// <param name="fileEntries">Array of changed file</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
     [JSInvokable]
-    public async Task NotifyImageUpload( FileEntry file )
+    public async Task NotifyImageUpload( FileEntry[] fileEntries )
     {
-        file.FileUploadEndedCallback = new();
+        foreach ( var file in fileEntries )
+        {
+            file.FileUploadEndedCallback = new();
 
-        // So that method invocations on the file can be dispatched back here
-        file.Owner = (IFileEntryOwner)(object)this;
-
+            // So that method invocations on the file can be dispatched back here
+            file.Owner = this;
+        }
         if ( ImageUploadChanged is not null )
-            await ImageUploadChanged.Invoke( new( file ) );
+            await ImageUploadChanged.Invoke( new( fileEntries ) );
 
-        file.FileUploadEndedCallback.SetResult();
+        foreach ( var file in fileEntries )
+        {            
+            file.FileUploadEndedCallback.SetResult();
+        }
+
         await InvokeAsync( StateHasChanged );
     }
 

--- a/Source/Extensions/Blazorise.Markdown/wwwroot/markdown.js
+++ b/Source/Extensions/Blazorise.Markdown/wwwroot/markdown.js
@@ -49,7 +49,9 @@ export function initialize(dotNetObjectRef, element, elementId, options) {
         onSuccess: (e) => { },
         onError: (e) => { }
     };
-
+    let fileEntriesToNotifyBuffer = [];
+    let notifyUploadTimer = null;
+    
     const mdeOptions = {
         element: document.getElementById(elementId),
         hideIcons: options.hideIcons,
@@ -97,9 +99,26 @@ export function initialize(dotNetObjectRef, element, elementId, options) {
             // Attach the blob data itself as a non-enumerable property so it doesn't appear in the JSON
             Object.defineProperty(fileEntry, 'blob', { value: file });
 
-            dotNetObjectRef.invokeMethodAsync('NotifyImageUpload', fileEntry).then(null, function (err) {
-                throw new Error(err);
-            });
+            fileEntriesToNotifyBuffer.push(fileEntry);
+
+            // Reset debounce timer: if a new file is added within 100ms, reset the timer
+            if (notifyUploadTimer) {
+                clearTimeout(notifyUploadTimer);
+            }
+
+            notifyUploadTimer = setTimeout(() => {
+                // Send batched files to .NET when no more files arrive within 100ms
+                dotNetObjectRef.invokeMethodAsync('NotifyImageUpload', fileEntriesToNotifyBuffer)
+                    .then(() => {
+                        fileEntriesToNotifyBuffer = [];
+                    })
+                    .catch(err => {
+                        fileEntriesToNotifyBuffer = [];
+                        throw new Error(err);
+                    });
+
+                notifyUploadTimer = null;
+            }, 100);
         },
 
         errorMessages: options.errorMessages,


### PR DESCRIPTION
## Description

Closes #5977 

- When user uploads multiple files at once they got all in one batch to the `ImageUploadChanged`. This is done by waiting for the `imageUploadFunction` in js for 100ms. 
- Also fixes issues with deleted reference in js, while keeping the reference in c#. This was also an issue with `FileEdit`. Implementation leverages the finalizer of `FileEntry` object.  (the sub-issue 2)
- Also fixes the sub-issue (1)