### PR TITLE
FilePicker and Markdown: Remove file entries on destroy and file change event

### DIFF
--- a/Source/Blazorise/Components/FileEdit/FileEdit.razor.cs
+++ b/Source/Blazorise/Components/FileEdit/FileEdit.razor.cs
@@ -148,11 +148,6 @@ public partial class FileEdit : BaseInputComponent<IFileEntry[]>, IFileEdit,
 
         await Changed.InvokeAsync( new( files ) );
 
-        foreach ( var file in files )
-        {
-            await file.Owner.RemoveFileEntry( file.Id );
-        }
-
         await InvokeAsync( StateHasChanged );
     }
 

--- a/Source/Blazorise/Components/FilePicker/FilePicker.razor
+++ b/Source/Blazorise/Components/FilePicker/FilePicker.razor
@@ -12,13 +12,13 @@
             <Addon AddonType="AddonType.End">
                 <Dropdown RightAligned PositionStrategy="DropdownPositionStrategy.Absolute">
                     <DropdownToggle Color="Color.Light">
-                        (@(FileEdit.Files?.Count() ?? 0))
+                        (@(FileEditRef.Files?.Count() ?? 0))
                     </DropdownToggle>
 
-                    @if ( !FileEdit?.Files?.IsNullOrEmpty() ?? false )
+                    @if ( !FileEditRef?.Files?.IsNullOrEmpty() ?? false )
                     {
                         <DropdownMenu Class="b-file-picker-files">
-                            @foreach ( var file in FileEdit.Files )
+                            @foreach ( var file in FileEditRef.Files )
                             {
                                 <DropdownItem @key="file.Id" Class="b-file-picker-file">
                                     @FileContentFragment(file)
@@ -37,13 +37,13 @@
 
     <Span Class="b-text-drop" Display="Blazorise.Display.Block" TextAlignment="TextAlignment.Center" Margin="Blazorise.Margin.Is2.FromTop">@DragAndDropString</Span>
 
-    @if ( !FileEdit?.Files?.IsNullOrEmpty() ?? false )
+    @if ( !FileEditRef?.Files?.IsNullOrEmpty() ?? false )
     {
         <div Class="b-file-picker-files-container">
             @if ( ShowMode == FilePickerShowMode.List )
             {
                 <ListGroup Class="b-file-picker-files" Margin="Blazorise.Margin.Is2.OnY">
-                    @foreach ( var file in FileEdit.Files )
+                    @foreach ( var file in FileEditRef.Files )
                     {
                         <ListGroupItem @key="file.Id" Class="b-file-picker-file">
                             @FileContentFragment(file)
@@ -76,7 +76,7 @@
 @code {
     private RenderFragment FileComponentFragment => __builder =>
     {
-        <FileEdit @ref="FileEdit" ElementId="@ElementId" Multiple="@Multiple" Directory="@Directory" Placeholder="@Placeholder" Disabled="@Disabled" ReadOnly="@ReadOnly" Filter="@Filter" MaxChunkSize="@MaxChunkSize" MaxFileSize="@MaxFileSize" SegmentFetchTimeout="@SegmentFetchTimeout" Changed="@OnChanged" Started="@OnStarted" Ended="@OnEnded" Written="@Written" Progressed="@OnProgressed" AutoReset="@AutoReset" DisableProgressReport="@DisableProgressReport" BrowseButtonLocalizer="@FilePickerLocalizer" Attributes="@Attributes">
+        <FileEdit @ref="FileEditRef" ElementId="@ElementId" Multiple="@Multiple" Directory="@Directory" Placeholder="@Placeholder" Disabled="@Disabled" ReadOnly="@ReadOnly" Filter="@Filter" MaxChunkSize="@MaxChunkSize" MaxFileSize="@MaxFileSize" SegmentFetchTimeout="@SegmentFetchTimeout" Changed="@OnChanged" Started="@OnStarted" Ended="@OnEnded" Written="@Written" Progressed="@OnProgressed" AutoReset="@AutoReset" DisableProgressReport="@DisableProgressReport" BrowseButtonLocalizer="@FilePickerLocalizer" Attributes="@Attributes">
             <ChildContent>
                 @ChildTemplate
             </ChildContent>

--- a/Source/Blazorise/Components/FilePicker/FilePicker.razor.cs
+++ b/Source/Blazorise/Components/FilePicker/FilePicker.razor.cs
@@ -85,7 +85,7 @@ public partial class FilePicker : BaseComponent, IAsyncDisposable
     /// </summary>
     /// <returns></returns>
     public int GetProgressPercentage()
-        => (int)( FileEdit.GetCurrentProgress().Progress * 100d );
+        => (int)( FileEditRef.GetCurrentProgress().Progress * 100d );
 
     /// <summary>
     /// Tracks whether the current file is being uploaded.
@@ -107,7 +107,7 @@ public partial class FilePicker : BaseComponent, IAsyncDisposable
     /// </summary>
     /// <returns></returns>
     public bool IsUploadReady()
-        => FileEdit.Files?.Any( x => x.Status == FileEntryStatus.Ready ) ?? false;
+        => FileEditRef?.Files?.Any( x => x.Status == FileEntryStatus.Ready ) ?? false;
 
     /// <summary>
     /// Converts the file size in bytes into a proper human readable format.
@@ -161,7 +161,7 @@ public partial class FilePicker : BaseComponent, IAsyncDisposable
     /// <param name="confirm">Wether to show a confirmation popup.</param>
     public Task RemoveFile( IFileEntry file, bool confirm = false )
     {
-        var removeFileAction = () => FileEdit.RemoveFile( file.Id ).AsTask();
+        var removeFileAction = () => FileEditRef.RemoveFile( file.Id ).AsTask();
 
         if ( confirm )
             return filePickerConfirmModalRef.OpenModal( _FilePickerConfirmModal.ConfirmOperation.RemoveFile, removeFileAction );
@@ -178,7 +178,7 @@ public partial class FilePicker : BaseComponent, IAsyncDisposable
         var clearAction = async () =>
         {
             await Cancel();
-            await FileEdit.Reset();
+            await FileEditRef.Reset();
         };
 
         if ( confirm )
@@ -306,7 +306,7 @@ public partial class FilePicker : BaseComponent, IAsyncDisposable
     /// <summary>
     /// Accesses the FileEdit
     /// </summary>
-    public FileEdit FileEdit;
+    public FileEdit FileEditRef;
 
     /// <summary>
     /// Gets or sets the main container element id.

--- a/Source/Blazorise/Components/FilePicker/FilePicker.razor.cs
+++ b/Source/Blazorise/Components/FilePicker/FilePicker.razor.cs
@@ -193,12 +193,15 @@ public partial class FilePicker : BaseComponent, IAsyncDisposable
     /// <returns></returns>
     public async Task UploadAll()
     {
-        if ( Upload.HasDelegate && !FileEdit.Files.IsNullOrEmpty() )
+        if ( Upload.HasDelegate && !FileEditRef.Files.IsNullOrEmpty() )
         {
             cts = new();
-            foreach ( var file in FileEdit.Files )
+            foreach ( var file in FileEditRef.Files )
             {
                 await UploadFile( file );
+
+                if ( FileEditRef is IFileEntryOwner fileEntryOwner )
+                    await fileEntryOwner.RemoveFileEntry( file );
             }
         }
     }

--- a/Source/Blazorise/Interfaces/Modules/IJSFileModule.cs
+++ b/Source/Blazorise/Interfaces/Modules/IJSFileModule.cs
@@ -31,12 +31,4 @@ public interface IJSFileModule : IBaseJSModule
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
     ValueTask<IJSStreamReference> ReadDataAsync( ElementReference elementRef, int fileEntryId, CancellationToken cancellationToken = default );
-
-    /// <summary>
-    /// Removes file entry from js dictionary
-    /// </summary>
-    /// <param name="elementRef">Reference to the rendered element.</param>
-    /// <param name="fileEntryId"></param>
-    /// <returns>A task that represents the asynchronous operation.</returns>
-    ValueTask RemoveFileEntry( ElementReference elementRef, int fileEntryId );
 }

--- a/Source/Blazorise/Interfaces/Modules/IJSFileModule.cs
+++ b/Source/Blazorise/Interfaces/Modules/IJSFileModule.cs
@@ -36,7 +36,7 @@ public interface IJSFileModule : IBaseJSModule
     /// Removes file entry from js dictionary
     /// </summary>
     /// <param name="elementRef">Reference to the rendered element.</param>
-    /// <param name="fileEntryId"></param>
+    /// <param name="fileEntryId">File id.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
     ValueTask RemoveFileEntry( ElementReference elementRef, int fileEntryId );
 }

--- a/Source/Blazorise/Interfaces/Modules/IJSFileModule.cs
+++ b/Source/Blazorise/Interfaces/Modules/IJSFileModule.cs
@@ -31,4 +31,12 @@ public interface IJSFileModule : IBaseJSModule
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
     ValueTask<IJSStreamReference> ReadDataAsync( ElementReference elementRef, int fileEntryId, CancellationToken cancellationToken = default );
+
+    /// <summary>
+    /// Removes file entry from js dictionary
+    /// </summary>
+    /// <param name="elementRef">Reference to the rendered element.</param>
+    /// <param name="fileEntryId"></param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    ValueTask RemoveFileEntry( ElementReference elementRef, int fileEntryId );
 }

--- a/Source/Blazorise/Modules/JSFileModule.cs
+++ b/Source/Blazorise/Modules/JSFileModule.cs
@@ -37,10 +37,6 @@ public class JSFileModule : BaseJSModule, IJSFileModule
     public virtual ValueTask<IJSStreamReference> ReadDataAsync( ElementReference elementRef, int fileEntryId, CancellationToken cancellationToken = default )
         => InvokeSafeAsync<IJSStreamReference>( "readFileDataStream", elementRef, fileEntryId );
 
-    /// <inheritdoc/>
-    public virtual ValueTask RemoveFileEntry( ElementReference elementRef, int fileEntryId )
-        => InvokeSafeVoidAsync( "removeFileEntry", elementRef, fileEntryId );
-
     #endregion
 
     #region Properties

--- a/Source/Blazorise/Modules/JSFileModule.cs
+++ b/Source/Blazorise/Modules/JSFileModule.cs
@@ -37,6 +37,10 @@ public class JSFileModule : BaseJSModule, IJSFileModule
     public virtual ValueTask<IJSStreamReference> ReadDataAsync( ElementReference elementRef, int fileEntryId, CancellationToken cancellationToken = default )
         => InvokeSafeAsync<IJSStreamReference>( "readFileDataStream", elementRef, fileEntryId );
 
+    /// <inheritdoc/>
+    public virtual ValueTask RemoveFileEntry( ElementReference elementRef, int fileEntryId )
+        => InvokeSafeVoidAsync( "removeFileEntry", elementRef, fileEntryId );
+
     #endregion
 
     #region Properties

--- a/Source/Blazorise/Utilities/IO/IFileEntryOwner.cs
+++ b/Source/Blazorise/Utilities/IO/IFileEntryOwner.cs
@@ -31,17 +31,6 @@ public interface IFileEntryOwner
     Stream OpenReadStream( FileEntry fileEntry, CancellationToken cancellationToken = default );
 
     /// <summary>
-    /// Removes the file entry from js dictionary.
-    /// </summary>
-    /// <param name="fileEntryId"></param>
-    /// <param name="cancellationToken"></param>
-    /// <returns></returns>
-    async Task RemoveFileEntry( int fileEntryId, CancellationToken cancellationToken = default )
-    {
-        await JSFileModule.RemoveFileEntry( ElementRef, fileEntryId );
-    }
-
-    /// <summary>
     /// Element reference.
     /// </summary>
     ElementReference ElementRef { get; set; }

--- a/Source/Blazorise/Utilities/IO/IFileEntryOwner.cs
+++ b/Source/Blazorise/Utilities/IO/IFileEntryOwner.cs
@@ -36,7 +36,7 @@ public interface IFileEntryOwner
     /// <param name="fileEntry">Currently processed file entry.</param>
     /// <param name="cancellationToken">A cancellation token to signal the cancellation of streaming file data.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
-    async Task RemoveFileEntry( FileEntry fileEntry, CancellationToken cancellationToken = default )
+    async Task RemoveFileEntry( IFileEntry fileEntry, CancellationToken cancellationToken = default )
     {
         await JSFileModule.RemoveFileEntry( ElementRef, fileEntry.Id );
     }

--- a/Source/Blazorise/Utilities/IO/IFileEntryOwner.cs
+++ b/Source/Blazorise/Utilities/IO/IFileEntryOwner.cs
@@ -33,12 +33,12 @@ public interface IFileEntryOwner
     /// <summary>
     /// Removes the file entry from js dictionary.
     /// </summary>
-    /// <param name="fileEntryId"></param>
-    /// <param name="cancellationToken"></param>
-    /// <returns></returns>
-    async Task RemoveFileEntry( int fileEntryId, CancellationToken cancellationToken = default )
+    /// <param name="fileEntry">Currently processed file entry.</param>
+    /// <param name="cancellationToken">A cancellation token to signal the cancellation of streaming file data.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    async Task RemoveFileEntry( FileEntry fileEntry, CancellationToken cancellationToken = default )
     {
-        await JSFileModule.RemoveFileEntry( ElementRef, fileEntryId );
+        await JSFileModule.RemoveFileEntry( ElementRef, fileEntry.Id );
     }
 
     /// <summary>

--- a/Source/Blazorise/Utilities/IO/IFileEntryOwner.cs
+++ b/Source/Blazorise/Utilities/IO/IFileEntryOwner.cs
@@ -31,6 +31,17 @@ public interface IFileEntryOwner
     Stream OpenReadStream( FileEntry fileEntry, CancellationToken cancellationToken = default );
 
     /// <summary>
+    /// Removes the file entry from js dictionary.
+    /// </summary>
+    /// <param name="fileEntryId"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    async Task RemoveFileEntry( int fileEntryId, CancellationToken cancellationToken = default )
+    {
+        await JSFileModule.RemoveFileEntry( ElementRef, fileEntryId );
+    }
+
+    /// <summary>
     /// Element reference.
     /// </summary>
     ElementReference ElementRef { get; set; }

--- a/Source/Blazorise/Utilities/IO/RemoteFileEntryStreamReader.cs
+++ b/Source/Blazorise/Utilities/IO/RemoteFileEntryStreamReader.cs
@@ -49,7 +49,7 @@ internal class RemoteFileEntryStreamReader : FileEntryStreamReader, IDisposable,
         jsStreamReference = await JSModule.ReadDataAsync( ElementRef, FileEntry.Id, cancellationToken );
 
         return await jsStreamReference.OpenReadStreamAsync(
-            this.maxFileSize,
+            maxFileSize,
             cancellationToken: cancellationToken );
     }
 

--- a/Source/Blazorise/wwwroot/fileEdit.js
+++ b/Source/Blazorise/wwwroot/fileEdit.js
@@ -1,4 +1,5 @@
 import { getRequiredElement } from "./utilities.js?v=1.7.4.0";
+import { removeAllFileEntries } from "./io.js?v=1.7.4.0";
 
 const _instances = [];
 let nextFileId = 0;
@@ -39,8 +40,17 @@ export function removeFile(element, elementId, fileId) {
 }
 
 export function destroy(element, elementId) {
-    var instances = _instances || {};
-    delete instances[elementId];
+    const instances = _instances || {};
+
+    const instance = instances[elementId];
+
+    if (instance) {
+        if (element) {
+            removeAllFileEntries(element);
+        }
+
+        delete instances[elementId];
+    }
 }
 
 export function reset(element, elementId) {
@@ -75,10 +85,11 @@ export function open(element, elementId) {
 
 // Reduce to purely serializable data, plus build an index by ID
 function mapElementFilesToFileEntries(element) {
-
     if (!element._blazorFilesById) {
         element._blazorFilesById = {};
     }
+
+    removeAllFileEntries(element);
 
     let fileList = Array.prototype.map.call(element.files, function (file) {
         file.id = file.id ?? ++nextFileId;

--- a/Source/Blazorise/wwwroot/io.js
+++ b/Source/Blazorise/wwwroot/io.js
@@ -53,6 +53,14 @@ export function removeFileEntry(element, fileEntryId) {
     delete element._blazorFilesById[fileEntryId];
 }
 
+export function removeAllFileEntries(element) {
+    if (element && element._blazorFilesById) {
+        for (var fileId in element._blazorFilesById) {
+            removeFileEntry(element, fileId);
+        }
+    }
+}
+
 function getArrayBufferFromFileAsync(element, fileId) {
     var file = getFileById(element, fileId);
 

--- a/Source/Extensions/Blazorise.Markdown/Markdown.razor.cs
+++ b/Source/Extensions/Blazorise.Markdown/Markdown.razor.cs
@@ -295,11 +295,6 @@ public partial class Markdown : BaseComponent,
             file.FileUploadEndedCallback.SetResult();
         }
 
-        foreach ( var file in fileEntries )
-        {
-            await file.Owner.RemoveFileEntry( file.Id );
-        }
-
         await InvokeAsync( StateHasChanged );
     }
 

--- a/Source/Extensions/Blazorise.Markdown/Markdown.razor.cs
+++ b/Source/Extensions/Blazorise.Markdown/Markdown.razor.cs
@@ -295,6 +295,11 @@ public partial class Markdown : BaseComponent,
             file.FileUploadEndedCallback.SetResult();
         }
 
+        foreach ( var file in fileEntries )
+        {
+            await file.Owner.RemoveFileEntry( file.Id );
+        }
+
         await InvokeAsync( StateHasChanged );
     }
 

--- a/Source/Extensions/Blazorise.Markdown/Markdown.razor.cs
+++ b/Source/Extensions/Blazorise.Markdown/Markdown.razor.cs
@@ -297,7 +297,7 @@ public partial class Markdown : BaseComponent,
 
         foreach ( var file in fileEntries )
         {
-            await file.Owner.RemoveFileEntry( file.Id );
+            await file.Owner.RemoveFileEntry( file );
         }
 
         await InvokeAsync( StateHasChanged );

--- a/Source/Extensions/Blazorise.Markdown/wwwroot/markdown.js
+++ b/Source/Extensions/Blazorise.Markdown/wwwroot/markdown.js
@@ -1,5 +1,6 @@
 import "./vendors/easymde.js?v=1.7.4.0";
 import "./vendors/highlight.js?v=1.7.4.0";
+import { removeAllFileEntries } from "../Blazorise/io.js?v=1.7.4.0";
 
 document.getElementsByTagName("head")[0].insertAdjacentHTML("beforeend", "<link rel=\"stylesheet\" href=\"_content/Blazorise.Markdown/vendors/easymde.css?v=1.7.4.0\" />");
 
@@ -78,6 +79,8 @@ export function initialize(dotNetObjectRef, element, elementId, options) {
         imageCSRFToken: options.imageCSRFToken,
         imageTexts: options.imageTexts,
         imageUploadFunction: (file, onSuccess, onError) => {
+            removeAllFileEntries(element);
+
             // hack to save the reference to the callback functions
             imageUploadNotifier.onSuccess = onSuccess;
             imageUploadNotifier.onError = onError;
@@ -191,6 +194,10 @@ export function destroy(element, elementId) {
     const instance = instances[elementId];
 
     if (instance) {
+        if (element) {
+            removeAllFileEntries(element);
+        }
+
         instance.editor.toTextArea();
         instance.editor = null;
 

--- a/Source/Extensions/Blazorise.Markdown/wwwroot/markdown.js
+++ b/Source/Extensions/Blazorise.Markdown/wwwroot/markdown.js
@@ -79,8 +79,6 @@ export function initialize(dotNetObjectRef, element, elementId, options) {
         imageCSRFToken: options.imageCSRFToken,
         imageTexts: options.imageTexts,
         imageUploadFunction: (file, onSuccess, onError) => {
-            removeAllFileEntries(element);
-
             // hack to save the reference to the callback functions
             imageUploadNotifier.onSuccess = onSuccess;
             imageUploadNotifier.onError = onError;


### PR DESCRIPTION
Further improves on #5980

I have changed how `removeFileEntry` is called. Now, it removes all entries when the component is destroyed and when the file(s) is changed. If there were previous file entries, then it will remove them.

I have also deleted `RemoveFileEntry` as it didn't make sense to keep it.