### PR TITLE
DataGrid: refocus to cell when pressed Escape in RapitEdit mode

### DIFF
--- a/Source/Extensions/Blazorise.DataGrid/_DataGridRowEdit.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridRowEdit.razor.cs
@@ -76,7 +76,8 @@ public abstract class _BaseDataGridRowEdit<TItem> : ComponentBase, IDisposable
         var isCellEdit = ParentDataGrid.IsCellEdit && column.CellEditing;
         if ( !isCellEdit )
             return;
-
+        
+        //most of the keydown operations (arrows,focus) are handled in datagrid.js 
         if ( args.Code == "Escape" )
         {
             await Cancel.InvokeAsync();

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridRowEdit.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridRowEdit.razor.cs
@@ -76,7 +76,7 @@ public abstract class _BaseDataGridRowEdit<TItem> : ComponentBase, IDisposable
         var isCellEdit = ParentDataGrid.IsCellEdit && column.CellEditing;
         if ( !isCellEdit )
             return;
-        
+
         //most of the keydown operations (arrows,focus) are handled in datagrid.js 
         if ( args.Code == "Escape" )
         {

--- a/Source/Extensions/Blazorise.DataGrid/wwwroot/datagrid.js
+++ b/Source/Extensions/Blazorise.DataGrid/wwwroot/datagrid.js
@@ -22,7 +22,6 @@ export function initializeTableCellNavigation(element, elementId) {
     element.addEventListener("keydown", KeyDownCellNavigation)
 }
 
-
 export function scrollTo(table, rowUnselectedClass) {
     let allTr = table.querySelectorAll("tbody tr");
     let scrollTo = table.querySelector("tbody > div").offsetHeight;
@@ -66,7 +65,7 @@ function keyPressPreventSubmitOnEnter(e) {
 }
 
 function findAncestorByTagName(el, tagName) {
-    while ((el = el.parentElement) && el.tagName !== tagName );
+    while ((el = el.parentElement) && el.tagName !== tagName);
     return el;
 }
 

--- a/Source/Extensions/Blazorise.DataGrid/wwwroot/datagrid.js
+++ b/Source/Extensions/Blazorise.DataGrid/wwwroot/datagrid.js
@@ -105,6 +105,7 @@ function KeyDownCellNavigation(e) {
     let isDown = e.keyCode == 40;
     let isArrow = isLeft | isUp | isRight | isDown;
     let isEnterKey = e.keyCode == 13;
+    let isEscKey = e.keyCode == 27;
 
     let focusedElement = document.activeElement;
     let allCells = element.querySelectorAll(QUERYSELECTOR_ALL_COLUMNS);
@@ -116,7 +117,7 @@ function KeyDownCellNavigation(e) {
     let index = [].indexOf.call(allCells, focusedElement);
     let isInputFocused = focusedElement && TAG_NAMES_INPUT.includes(focusedElement.tagName);
 
-    if (isInputFocused && isEnterKey) {
+    if (isInputFocused && (isEnterKey || isEscKey)) {
         focusedElement.addEventListener("blur", () => {
             window.setTimeout(() => {
                 let inputStillExists = element.contains(focusedElement);


### PR DESCRIPTION
## Description

Closes #5978

In the end just acknowledging the escape in focus handling was enough

