### PR TITLE
PdfViewer: Introduce PrintRequested EventCallback

### DIFF
--- a/Documentation/Blazorise.Docs/Pages/News/2025-03-10-release-notes-180.razor
+++ b/Documentation/Blazorise.Docs/Pages/News/2025-03-10-release-notes-180.razor
@@ -78,4 +78,12 @@
     The <Code>Cropper</Code> component has been enhanced with the <Code>ImageLoadingFailed</Code> event, which triggers when an image fails to load. This event provides a way to handle errors and display a custom message or image in place of the failed image.
 </Paragraph>
 
+<Heading Size="HeadingSize.Is3">
+    PdfViewer Component Enhancements
+</Heading>
+
+<Paragraph>
+    From our community member <Anchor To="https://github.com/11bthornton" Title="Link to 11bthornton">11bthornton</Anchor>, we have received a contribution that enhances the <Code>PdfViewer</Code> component. The component now supports the <Code>PrintRequested</Code> event callback, which triggers when the user requests to print the PDF document. It is a small but significant improvement that enhances the user experience.
+</Paragraph>
+
 <NewsPagePostInfo UserName="Mladen Macanović" ImageName="mladen" PostedOn="March 10th, 2025" Read="7 min" />

--- a/Source/Extensions/Blazorise.PdfViewer/PdfViewer.razor.cs
+++ b/Source/Extensions/Blazorise.PdfViewer/PdfViewer.razor.cs
@@ -211,6 +211,8 @@ public partial class PdfViewer : BaseComponent, IAsyncDisposable
         if ( string.IsNullOrEmpty( Source ) )
             return;
 
+        await PrintRequested.InvokeAsync();
+
         if ( JSModule is not null )
         {
             await JSModule.Print( Source );
@@ -340,6 +342,11 @@ public partial class PdfViewer : BaseComponent, IAsyncDisposable
     /// Gets or sets the callback event that is triggered when the PDF document is loaded.
     /// </summary>
     [Parameter] public EventCallback<PdfLoadedEventArgs> Loaded { get; set; }
+
+    /// <summary>
+    /// Gets or sets the callback event that is triggered when the PDF document is requested to be printed.
+    /// </summary>
+    [Parameter] public EventCallback PrintRequested { get; set; }
 
     /// <summary>
     /// Gets or sets the scale factor for displaying the PDF document.


### PR DESCRIPTION
## Description

Hello, thank you for taking the time to read this. Thought about raising this as an issue for discussion first but as implementation was simple, thought I'd just get straight to the point.

Currently, the PdfViewer component provides a callback as a parameter for the following events:

- `Loaded`
- `PageNumberChanged`
- `ScaleChanged`

However, it does not provide a callback that can be invoked when the document is requested to be printed.

This adds a `PrintRequested` Eventcallback parameter to `PdfViewer`.

### Context
We have an application that uses `PdfViewer` in combination with `PdfViewerToolbar`. As a result, the user uses the toolbar's print button rather than a custom button that invokes `Print` directly on a reference to the PdfViewer component. Since we're not doing the latter, we can't invoke some custom functionality at time of print request.

If there's a better way of achieving the desired effect, please let me know.

#### Discussion point:

This solution invokes the callback before the browser print window opens - so in my case, I am aware that the user may or may not actually go on to print / export the document. The other option could be a `Printed` EventCallback, but this would be a bit more complex to implement.

Example use:

```razor
@using Blazorise.PdfViewer

@page "/"

<PageTitle>Home</PageTitle>

<PdfViewerContainer>
    <PdfViewerToolbar />
    <PdfViewer PrintRequested="OnPrintRequested" Source="@($"data:application/pdf;base64,{base64String}")" />
</PdfViewerContainer>

@code {
    string base64String = "Omitted for brevity";

    private void OnPrintRequested()
    {
        Console.WriteLine("Print requested");
    }
}
```

## How Has This Been Tested?
Manually - correct me if I'm wrong but other events in this component do not have tests either. Happy to look into doing so if desired.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] The PR is submitted to the correct branch (`master` for dev, `rel-1.x` for maintenance).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests. - **see section above**
