### PR TITLE
Autocomplete: checkbox cursor:pointer

### DIFF
--- a/Source/Blazorise/Components/Dropdown/DropdownItem.razor
+++ b/Source/Blazorise/Components/Dropdown/DropdownItem.razor
@@ -11,7 +11,7 @@
             @if ( ShowCheckbox )
             {
                 <Div Display="Blazorise.Display.InlineBlock">
-                    <Check TValue="bool" Value="@(@checked)" ValueChanged="@CheckedChangedHandler" ValueExpression="@checkedExpression" Disabled="@Disabled">
+                    <Check Cursor="Cursor.Pointer" TValue="bool" Value="@(@checked)" ValueChanged="@CheckedChangedHandler" ValueExpression="@checkedExpression" Disabled="@Disabled">
                         @*The <div> blocks clicks to the checkbox label (where the ChildContent gets).
                         Clicking the label normally redirects the event to checkbox, and in the meantime the textbox looses focus (which is something we trying to prevent).
                         This is done specially for Autocomplete.CloseOnSelection = false;


### PR DESCRIPTION
## Description

Closes https://blazorise.com/support/issues/267/unexpected-cursor-and-click-behaviour-in-autocomplete

Fix for 2.0, as it will be needed. We can also "backport" to 1.7
