### PR TITLE
DataGrid: Add New method overload

### DIFF
--- a/Documentation/Blazorise.Docs/Pages/News/2025-03-10-release-notes-180.razor
+++ b/Documentation/Blazorise.Docs/Pages/News/2025-03-10-release-notes-180.razor
@@ -86,4 +86,14 @@
     From our community member <Anchor To="https://github.com/11bthornton" Title="Link to 11bthornton">11bthornton</Anchor>, we have received a contribution that enhances the <Code>PdfViewer</Code> component. The component now supports the <Code>PrintRequested</Code> event callback, which triggers when the user requests to print the PDF document. It is a small but significant improvement that enhances the user experience.
 </Paragraph>
 
+<Heading Size="HeadingSize.Is3">
+    DataGrid: Programmatic Addition of Items to Batch Edit Collection
+</Heading>
+
+<Paragraph>
+    Introduced the <Code>AddItemToBatchItems</Code> method in DataGrid, enabling the programmatic addition of new items to the batch edit collection when batch editing is enabled.
+    This method ensures that newly added items are tracked as unsaved changes, allowing them to be persisted upon saving or discarded upon cancellation.
+</Paragraph>
+
+
 <NewsPagePostInfo UserName="Mladen Macanović" ImageName="mladen" PostedOn="March 10th, 2025" Read="7 min" />

--- a/Documentation/Blazorise.Docs/Pages/News/2025-03-10-release-notes-180.razor
+++ b/Documentation/Blazorise.Docs/Pages/News/2025-03-10-release-notes-180.razor
@@ -91,8 +91,7 @@
 </Heading>
 
 <Paragraph>
-    Introduced the <Code>AddItemToBatchItems</Code> method in DataGrid, enabling the programmatic addition of new items to the batch edit collection when batch editing is enabled.
-    This method ensures that newly added items are tracked as unsaved changes, allowing them to be persisted upon saving or discarded upon cancellation.
+    Introduced the <Code>Task New( TItem newItem )</Code> overload method in DataGrid, enabling the programmatic addition of new items to the batch edit collection when batch editing is enabled. This method ensures that newly added items are tracked as unsaved changes, allowing them to be persisted upon saving or discarded upon cancellation.
 </Paragraph>
 
 

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -1057,7 +1057,7 @@ public partial class DataGrid<TItem> : BaseDataGridComponent
     /// <returns>A task that represents the asynchronous operation.</returns>
     public Task New()
     {
-        return ProcessNewItem( CreateNewItem() );
+        return New( CreateNewItem() );
     }
 
     /// <summary>
@@ -1065,17 +1065,7 @@ public partial class DataGrid<TItem> : BaseDataGridComponent
     /// depending on whether batch editing is enabled.
     /// </summary>
     /// <returns>A task that represents the asynchronous operation.</returns>
-    public Task New( TItem newItem )
-    {
-        return ProcessNewItem( newItem );
-    }
-
-    /// <summary>
-    /// Processes a new item for the DataGrid.
-    /// </summary>
-    /// <param name="newItem">The new item to be processed.</param>
-    /// <returns>A task that represents the asynchronous operation.</returns>
-    private async Task ProcessNewItem( TItem newItem )
+    public async Task New( TItem newItem )
     {
         if ( BatchEdit )
         {

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -1064,11 +1064,17 @@ public partial class DataGrid<TItem> : BaseDataGridComponent
     /// Adds a new item to the DataGrid, either by opening it in edit mode or by adding the batch edit collection,
     /// depending on whether batch editing is enabled.
     /// </summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
     public Task New( TItem newItem )
     {
         return ProcessNewItem( newItem );
     }
 
+    /// <summary>
+    /// Processes a new item for the DataGrid.
+    /// </summary>
+    /// <param name="newItem">The new item to be processed.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
     private async Task ProcessNewItem( TItem newItem )
     {
         if ( BatchEdit )

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -375,9 +375,31 @@ public partial class DataGrid<TItem> : BaseDataGridComponent
     /// Links the child row with this datagrid.
     /// </summary>
     /// <param name="row">Row to add.</param>
-    public void AddRow( DataGridRowInfo<TItem> row )
+    internal void AddRow( DataGridRowInfo<TItem> row )
     {
         Rows.Add( row );
+    }
+
+    
+    /// <summary>
+    /// Adds a new item to the batch edit collection, representing unsaved changes if batch editing is enabled.
+    /// If batch editing is disabled, the method does nothing.
+    /// Ensure that a new instance of <typeparamref name="TItem"/> is provided.
+    /// </summary>
+    /// <param name="newItem">Item to add</param>
+    public async Task AddItemToBatchChanges( TItem newItem )
+    {
+        if ( !BatchEdit ) return;
+        
+        batchChanges ??= new();
+
+        var batchItem = new DataGridBatchEditItem<TItem>( editItem, newItem, DataGridBatchEditItemState.New
+        , new Dictionary<string, CellEditContext> { } );
+        batchChanges.Add( batchItem );
+
+        SetDirty();
+
+        await BatchChange.InvokeAsync( new( batchItem ) );
     }
 
     /// <summary>


### PR DESCRIPTION
## Description

Closes #5996

Introduces the `AddItemToBatchChanges` method, enabling programmatic insertion of items into the batch edit collection when batch editing is enabled.  

It addresses the original request:  

> **"DataGrid: Functionality to clone a given row without changing the source data."**  

Rather than duplicating rows directly, this approach adds items to the batch collection, allowing them to be saved or discarded like any other batch edit change.  


Users can insert a new instance of `TItem` into the batch edit collection as shown:  

```csharp
<Button Clicked="OnAddNewRowClicked">Add new row</Button>

private async Task OnAddNewRowClicked(MouseEventArgs obj)
{
    var newEmployee = new Employee
    {
        FirstName = "John", 
        LastName = "Doe", 
        Email = "john.doe@example.com",
        Salary = 50000, 
        Id = 99999
    };

    await dataGridRef.AddItemToBatchChanges(newEmployee);
}
```


If users need to duplicate a row, they must create a new TItem, ensuring control over cloning behavior.




