### PR TITLE
Cropper: fix when InitialCoverage options is null

### DIFF
--- a/Source/Extensions/Blazorise.Cropper/Cropper.razor.cs
+++ b/Source/Extensions/Blazorise.Cropper/Cropper.razor.cs
@@ -58,7 +58,7 @@ public partial class Cropper : BaseComponent, IAsyncDisposable
                     {
                         AspectRatio = paramSelectionOptions?.AspectRatio.Value,
                         InitialAspectRatio = paramSelectionOptions?.InitialAspectRatio.Value,
-                        InitialCoverage = paramSelectionOptions?.InitialCoverage.Value,
+                        InitialCoverage = paramSelectionOptions?.InitialCoverage,
                         Movable = paramSelectionOptions?.Movable ?? false,
                         Resizable = paramSelectionOptions?.Resizable ?? false,
                         Zoomable = paramSelectionOptions?.Zoomable ?? false,


### PR DESCRIPTION
## Description

Closes #6004

The `Value` was attempted to be read on null object, this just sends null when the options is not defined