### PR TITLE
Chart: fix race condition during initialization

### DIFF
--- a/Source/Extensions/Blazorise.Charts/BaseChart.cs
+++ b/Source/Extensions/Blazorise.Charts/BaseChart.cs
@@ -36,7 +36,9 @@ public class BaseChart<TDataSet, TItem, TOptions, TModel> : BaseChart<TItem>, IB
 
             NotifyInitialized();
         }
-        else if ( initialized )
+
+        // Update the charts if the data has changed
+        if ( initialized )
         {
             await Update();
         }


### PR DESCRIPTION
Race condition during initialization of the chart and setting the data might cause the chart not to render correctly. In the init routine always call the Update method to ensure that the chart is updated then it's dirty.

Closes #4317 
