### PR TITLE
Chart.Zoom: add null check to JSModule

### DIFF
--- a/Source/Extensions/Blazorise.Charts.Zoom/ChartZoom.razor.cs
+++ b/Source/Extensions/Blazorise.Charts.Zoom/ChartZoom.razor.cs
@@ -74,7 +74,7 @@ public partial class ChartZoom<TItem> : BaseComponent, IAsyncDisposable
     {
         if ( disposing && Rendered )
         {
-            if(JSModule is not null)
+            if ( JSModule is not null )
                 await JSModule.SafeDisposeAsync();
 
             if ( ParentChart is not null )

--- a/Source/Extensions/Blazorise.Charts.Zoom/ChartZoom.razor.cs
+++ b/Source/Extensions/Blazorise.Charts.Zoom/ChartZoom.razor.cs
@@ -74,7 +74,8 @@ public partial class ChartZoom<TItem> : BaseComponent, IAsyncDisposable
     {
         if ( disposing && Rendered )
         {
-            await JSModule.SafeDisposeAsync();
+            if(JSModule is not null)
+                await JSModule.SafeDisposeAsync();
 
             if ( ParentChart is not null )
             {


### PR DESCRIPTION
## Description

Closes #6006  

A simple null check will prevent a null reference exception in case the loading of the parent chart is slow for some reason. More explanation is available in the related issue.  

I consider this a hotfix. Other places (for example, `ChartDataLabels`) suffer from a similar condition. However, there are many more such "suffering conditions" that might be worth fixing together.




