### PR TITLE
DataGrid: Fix CellsEditableOn behavior for edit modes other than 'Cell'

### DIFF
--- a/Source/Extensions/Blazorise.DataGrid/DataGridColumn.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGridColumn.cs
@@ -646,29 +646,13 @@ public partial class DataGridColumn<TItem> : BaseDataGridColumn<TItem>
     /// <summary>
     /// Returns true if the cell value is editable.
     /// </summary>
-    public bool CellValueIsEditable
-        => Editable && IsCellEditablePerCommand &&
-        (
-            ParentDataGrid.EditMode != DataGridEditMode.Cell 
-            || 
-            ( 
-                ParentDataGrid.EditMode == DataGridEditMode.Cell
-                &&
-                ( 
-                    ( ParentDataGrid.EditState == DataGridEditState.Edit && CellEditing ) 
-                    ||
-                    //We don't have data, let's keep a regular editable row for New.
-                    ParentDataGrid.EditState == DataGridEditState.New 
-                ) 
-            )
-        );
-
-    protected bool IsCellEditablePerCommand
-        => (
-                        ( CellsEditableOnNewCommand && ParentDataGrid.EditState == DataGridEditState.New )
-                        ||
-                        ( CellsEditableOnEditCommand && ParentDataGrid.EditState == DataGridEditState.Edit )
-                        );
+    public bool CellValueIsEditable => Editable && ParentDataGrid.EditState switch
+    {
+        DataGridEditState.New when CellsEditableOnNewCommand => true,
+        DataGridEditState.Edit when CellsEditableOnEditCommand &&
+                                    (ParentDataGrid.EditMode != DataGridEditMode.Cell || CellEditing) => true,
+        _ => false
+    };
 
     /// <summary>
     /// Gets or sets the current sort direction.

--- a/Source/Extensions/Blazorise.DataGrid/DataGridColumn.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGridColumn.cs
@@ -647,16 +647,21 @@ public partial class DataGridColumn<TItem> : BaseDataGridColumn<TItem>
     /// Returns true if the cell value is editable.
     /// </summary>
     public bool CellValueIsEditable
-        => Editable &&
-           (
-                ( ParentDataGrid.EditState == DataGridEditState.Edit && ParentDataGrid.EditMode == DataGridEditMode.Cell && CellEditing
-                    && IsCellEditablePerCommand )
-                ||
-                ( ParentDataGrid.EditMode != DataGridEditMode.Cell
-                    || ( ParentDataGrid.EditState == DataGridEditState.New && ParentDataGrid.EditMode == DataGridEditMode.Cell ) //We don't have data, let's keep a regular editable row for New.
-                    && IsCellEditablePerCommand
-                )
-            );
+        => Editable && IsCellEditablePerCommand &&
+        (
+            ParentDataGrid.EditMode != DataGridEditMode.Cell 
+            || 
+            ( 
+                ParentDataGrid.EditMode == DataGridEditMode.Cell
+                &&
+                ( 
+                    ( ParentDataGrid.EditState == DataGridEditState.Edit && CellEditing ) 
+                    ||
+                    //We don't have data, let's keep a regular editable row for New.
+                    ParentDataGrid.EditState == DataGridEditState.New 
+                ) 
+            )
+        );
 
     protected bool IsCellEditablePerCommand
         => (

--- a/Source/Extensions/Blazorise.DataGrid/DataGridColumn.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGridColumn.cs
@@ -650,7 +650,7 @@ public partial class DataGridColumn<TItem> : BaseDataGridColumn<TItem>
     {
         DataGridEditState.New when CellsEditableOnNewCommand => true,
         DataGridEditState.Edit when CellsEditableOnEditCommand &&
-                                    (ParentDataGrid.EditMode != DataGridEditMode.Cell || CellEditing) => true,
+                                    ( ParentDataGrid.EditMode != DataGridEditMode.Cell || CellEditing ) => true,
         _ => false
     };
 


### PR DESCRIPTION
## Description

This PR fixes the behavior of the `CellValueIsEditable` property in the **DataGrid** component.

- **For edit modes other than `DataGridEditMode.Cell`**: it preserves the previous behavior, ensuring no unexpected changes.  
- **For `DataGridEditMode.Cell`**: it maintains the current functionality, allowing cell-level edits as intended.  

Closes #5976.

---

## How Has This Been Tested?

Tested using the demo pages with the following properties:  
- `CellsEditableOnNewCommand="false"`  
- `CellsEditableOnEditCommand="false"`  

Validated across different `DataGridEditMode` configurations to ensure correct behavior.

---

## Types of Changes

**Bug fix** (non-breaking change that resolves the issue)

