### PR TITLE
DataGrid: Dynamic data does not create a column when value is null in the first row

### DIFF
--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/DataGrid/BindingData/DynamicPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/DataGrid/BindingData/DynamicPage.razor
@@ -23,6 +23,7 @@
 <DocsPageSection>
     <DocsPageSectionHeader Title="Auto Generate Columns Example">
         The Blazorise DataGrid also supports auto-generating columns based on the data structure. This feature simplifies the process of displaying data by automatically creating columns that match the properties of the bound data objects.
+        Auto-generated columns support nullable data. If your data includes null values, ensure you provide a <Code>NewItemCreator</Code>. DataGrid requires an item with non-null values to properly generate the columns.
     </DocsPageSectionHeader>
     <DocsPageSectionContent FullWidth>
         <DataGridDynamicAutoGenerateExample />

--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/DataGrid/BindingData/DynamicPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/DataGrid/BindingData/DynamicPage.razor
@@ -22,8 +22,12 @@
 
 <DocsPageSection>
     <DocsPageSectionHeader Title="Auto Generate Columns Example">
-        The Blazorise DataGrid also supports auto-generating columns based on the data structure. This feature simplifies the process of displaying data by automatically creating columns that match the properties of the bound data objects.
-        Auto-generated columns support nullable data. If your data includes null values, ensure you provide a <Code>NewItemCreator</Code>. DataGrid requires an item with non-null values to properly generate the columns.
+        <Paragraph>
+            The Blazorise DataGrid also supports auto-generating columns based on the data structure. This feature simplifies the process of displaying data by automatically creating columns that match the properties of the bound data objects.
+        </Paragraph>
+        <Paragraph>
+            Auto-generated columns support nullable data. If your data includes null values, ensure you provide a <Code>NewItemCreator</Code>. DataGrid requires an item with non-null values to properly generate the columns.
+        </Paragraph>
     </DocsPageSectionHeader>
     <DocsPageSectionContent FullWidth>
         <DataGridDynamicAutoGenerateExample />

--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/DataGrid/Examples/DataGridDynamicAutoGenerateExample.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/DataGrid/Examples/DataGridDynamicAutoGenerateExample.razor
@@ -46,10 +46,10 @@
             expando.Add( property.Name,
                 property.PropertyType switch
                 {
-                    { } t when t == typeof(string) => "",
-                    { IsValueType: true }          => Activator.CreateInstance( property.PropertyType )??"",
-                    _                              => "" //better than null
-                });
+                    { } t when t == typeof( string ) => "",
+                    { IsValueType: true } => Activator.CreateInstance( property.PropertyType ) ?? "",
+                    _ => "" //better than null
+                } );
         }
 
         return (ExpandoObject)expando;

--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/DataGrid/Examples/DataGridDynamicAutoGenerateExample.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/DataGrid/Examples/DataGridDynamicAutoGenerateExample.razor
@@ -43,7 +43,13 @@
 
         foreach ( var property in typeof( Employee ).GetProperties() )
         {
-            expando.Add( property.Name, property.PropertyType.IsValueType ? Activator.CreateInstance( property.PropertyType ) : null );
+            expando.Add( property.Name,
+                property.PropertyType switch
+                {
+                    { } t when t == typeof(string) => "",
+                    { IsValueType: true }          => Activator.CreateInstance( property.PropertyType )??"",
+                    _                              => "" //better than null
+                });
         }
 
         return (ExpandoObject)expando;

--- a/Source/Blazorise/Utilities/Formatters/Formaters.cs
+++ b/Source/Blazorise/Utilities/Formatters/Formaters.cs
@@ -123,10 +123,10 @@ public static class Formaters
     /// <returns></returns>
     public static string PascalCaseToFriendlyName( string input )
     {
-        if ( string.IsNullOrWhiteSpace( input ) )
+        if ( string.IsNullOrWhiteSpace( input ) || input.ToUpper(CultureInfo.InvariantCulture) == input )
             return input;
 
-        StringBuilder result = new StringBuilder();
+        StringBuilder result = new ();
         var firstUpperChar = true;
         foreach ( char c in input )
         {

--- a/Source/Blazorise/Utilities/Formatters/Formaters.cs
+++ b/Source/Blazorise/Utilities/Formatters/Formaters.cs
@@ -123,10 +123,10 @@ public static class Formaters
     /// <returns></returns>
     public static string PascalCaseToFriendlyName( string input )
     {
-        if ( string.IsNullOrWhiteSpace( input ) || input.ToUpper(CultureInfo.InvariantCulture) == input )
+        if ( string.IsNullOrWhiteSpace( input ) || input.ToUpper( CultureInfo.InvariantCulture ) == input )
             return input;
 
-        StringBuilder result = new ();
+        StringBuilder result = new();
         var firstUpperChar = true;
         foreach ( char c in input )
         {

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -519,10 +519,10 @@ public partial class DataGrid<TItem> : BaseDataGridComponent
     {
         if ( IsDynamicItem )
         {
-            var item = NewItemCreator is not null 
-                       ? NewItemCreator.Invoke() 
-                       : Data.IsNullOrEmpty() 
-                           ? default 
+            var item = NewItemCreator is not null
+                       ? NewItemCreator.Invoke()
+                       : Data.IsNullOrEmpty()
+                           ? default
                            : Data.FirstOrDefault();
 
             if ( item is ExpandoObject expando )

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -519,11 +519,11 @@ public partial class DataGrid<TItem> : BaseDataGridComponent
     {
         if ( IsDynamicItem )
         {
-            var item = Data.IsNullOrEmpty()
-                ? NewItemCreator is not null
-                    ? NewItemCreator.Invoke()
-                    : default
-                : Data.FirstOrDefault();
+            var item = NewItemCreator is not null 
+                       ? NewItemCreator.Invoke() 
+                       : Data.IsNullOrEmpty() 
+                           ? default 
+                           : Data.FirstOrDefault();
 
             if ( item is ExpandoObject expando )
             {

--- a/Tests/Blazorise.Tests/Utils/FormatersTests.cs
+++ b/Tests/Blazorise.Tests/Utils/FormatersTests.cs
@@ -30,6 +30,8 @@ public class FormatersTests
     [InlineData( "FirstNameVeryLong", "First Name Very Long" )]
     [InlineData( " FirstName ", " First Name " )]
     [InlineData( "_FirstName ", "_First Name " )]
+    [InlineData( "UPPERCASE", "UPPERCASE" )]
+    [InlineData( "UPPER CASE", "UPPER CASE" )]
     [InlineData( null, null )]
     public void PascalCaseToFriendlyName_Returns_FriendlyFormat( string input, string expected )
     {


### PR DESCRIPTION
## Description

Closes #6000

Fixes the issue by changing the logic (order) of obtaining the item to discover columns. The `First` item from `Data` may have a column with a null value, which could result in the column not being displayed at all. This fix applies the `NewItemCreator` first, where the user can ensure non-null values.

