### PR TITLE
IFileEntryOwner: FileEntry to IFileEntry

### DIFF
--- a/Source/Blazorise/Components/FileEdit/FileEdit.razor.cs
+++ b/Source/Blazorise/Components/FileEdit/FileEdit.razor.cs
@@ -382,7 +382,7 @@ public partial class FileEdit : BaseInputComponent<IFileEntry[]>, IFileEdit,
 
     /// <summary>
     /// Gets or sets the max chunk size when uploading the file.
-    /// Take note that if you're using <see cref="OpenReadStream(FileEntry, CancellationToken)"/> you're provided with a stream and should configure the chunk size when handling with the stream.
+    /// Take note that if you're using <see cref="OpenReadStream(IFileEntry, CancellationToken)"/> you're provided with a stream and should configure the chunk size when handling with the stream.
     /// </summary>
     /// <remarks>
     /// See <see href="https://docs.microsoft.com/en-us/aspnet/core/blazor/javascript-interoperability/call-dotnet-from-javascript?view=aspnetcore-6.0#stream-from-javascript-to-net">docs.microsoft.com</see>.

--- a/Source/Blazorise/Components/FileEdit/FileEdit.razor.cs
+++ b/Source/Blazorise/Components/FileEdit/FileEdit.razor.cs
@@ -220,14 +220,14 @@ public partial class FileEdit : BaseInputComponent<IFileEntry[]>, IFileEdit,
     }
 
     /// <inheritdoc/>
-    public Task WriteToStreamAsync( FileEntry fileEntry, Stream stream, CancellationToken cancellationToken = default )
+    public Task WriteToStreamAsync( IFileEntry fileEntry, Stream stream, CancellationToken cancellationToken = default )
     {
         return new RemoteFileEntryStreamReader( JSFileModule, ElementRef, fileEntry, this, MaxChunkSize, MaxFileSize )
             .WriteToStreamAsync( stream, cancellationToken );
     }
 
     /// <inheritdoc/>
-    public Stream OpenReadStream( FileEntry fileEntry, CancellationToken cancellationToken = default )
+    public Stream OpenReadStream( IFileEntry fileEntry, CancellationToken cancellationToken = default )
     {
         return new RemoteFileEntryStream( JSFileModule, ElementRef, fileEntry, this, MaxFileSize, cancellationToken );
     }

--- a/Source/Blazorise/Utilities/IO/FileEntryStreamReader.cs
+++ b/Source/Blazorise/Utilities/IO/FileEntryStreamReader.cs
@@ -9,10 +9,10 @@ public abstract class FileEntryStreamReader
 {
     private readonly IJSFileModule jsModule;
     private readonly ElementReference elementRef;
-    private readonly FileEntry fileEntry;
+    private readonly IFileEntry fileEntry;
     private readonly IFileEntryNotifier fileEntryNotifier;
 
-    public FileEntryStreamReader( IJSFileModule jsModule, ElementReference elementRef, FileEntry fileEntry, IFileEntryNotifier fileEntryNotifier )
+    public FileEntryStreamReader( IJSFileModule jsModule, ElementReference elementRef, IFileEntry fileEntry, IFileEntryNotifier fileEntryNotifier )
     {
         this.jsModule = jsModule;
         this.elementRef = elementRef;
@@ -24,7 +24,7 @@ public abstract class FileEntryStreamReader
 
     protected ElementReference ElementRef => elementRef;
 
-    protected FileEntry FileEntry => fileEntry;
+    protected IFileEntry FileEntry => fileEntry;
 
     protected IFileEntryNotifier FileEntryNotifier => fileEntryNotifier;
 }

--- a/Source/Blazorise/Utilities/IO/IFileEntryOwner.cs
+++ b/Source/Blazorise/Utilities/IO/IFileEntryOwner.cs
@@ -20,7 +20,7 @@ public interface IFileEntryOwner
     /// <param name="stream">Target stream.</param>
     /// <param name="cancellationToken">A cancellation token to signal the cancellation of streaming file data.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
-    Task WriteToStreamAsync( FileEntry fileEntry, Stream stream, CancellationToken cancellationToken = default );
+    Task WriteToStreamAsync( IFileEntry fileEntry, Stream stream, CancellationToken cancellationToken = default );
 
     /// <summary>
     /// Opens the stream for reading the uploaded file.
@@ -28,7 +28,7 @@ public interface IFileEntryOwner
     /// <param name="fileEntry">Currently processed file entry.</param>
     /// <param name="cancellationToken">A cancellation token to signal the cancellation of streaming file data.</param>
     /// <returns>Returns the stream for the uploaded file entry.</returns>
-    Stream OpenReadStream( FileEntry fileEntry, CancellationToken cancellationToken = default );
+    Stream OpenReadStream( IFileEntry fileEntry, CancellationToken cancellationToken = default );
 
     /// <summary>
     /// Removes the file entry from js dictionary.

--- a/Source/Blazorise/Utilities/IO/RemoteFileEntryStreamReader.cs
+++ b/Source/Blazorise/Utilities/IO/RemoteFileEntryStreamReader.cs
@@ -28,7 +28,7 @@ internal class RemoteFileEntryStreamReader : FileEntryStreamReader, IDisposable,
 
     #region Constructors
 
-    public RemoteFileEntryStreamReader( IJSFileModule jsModule, ElementReference elementRef, FileEntry fileEntry, IFileEntryNotifier fileEntryNotifier, int maxMessageSize, long maxFileSize )
+    public RemoteFileEntryStreamReader( IJSFileModule jsModule, ElementReference elementRef, IFileEntry fileEntry, IFileEntryNotifier fileEntryNotifier, int maxMessageSize, long maxFileSize )
         : base( jsModule, elementRef, fileEntry, fileEntryNotifier )
     {
         this.maxMessageSize = maxMessageSize;

--- a/Source/Extensions/Blazorise.Markdown/Markdown.razor.cs
+++ b/Source/Extensions/Blazorise.Markdown/Markdown.razor.cs
@@ -567,7 +567,7 @@ public partial class Markdown : BaseComponent,
 
     /// <summary>
     /// Gets or sets the max chunk size when uploading the file.
-    /// Take note that if you're using <see cref="OpenReadStream(FileEntry, CancellationToken)"/> you're provided with a stream and should configure the chunk size when handling with the stream.
+    /// Take note that if you're using <see cref="OpenReadStream(IFileEntry, CancellationToken)"/> you're provided with a stream and should configure the chunk size when handling with the stream.
     /// </summary>
     /// <remarks>
     /// https://docs.microsoft.com/en-us/aspnet/core/blazor/javascript-interoperability/call-dotnet-from-javascript?view=aspnetcore-6.0#stream-from-javascript-to-net

--- a/Source/Extensions/Blazorise.Markdown/Markdown.razor.cs
+++ b/Source/Extensions/Blazorise.Markdown/Markdown.razor.cs
@@ -376,14 +376,14 @@ public partial class Markdown : BaseComponent,
     }
 
     /// <inheritdoc/>
-    public Task WriteToStreamAsync( FileEntry fileEntry, Stream stream, CancellationToken cancellationToken = default )
+    public Task WriteToStreamAsync( IFileEntry fileEntry, Stream stream, CancellationToken cancellationToken = default )
     {
         return new RemoteFileEntryStreamReader( JSFileModule, ElementRef, fileEntry, this, MaxUploadImageChunkSize, ImageMaxSize )
             .WriteToStreamAsync( stream, cancellationToken );
     }
 
     /// <inheritdoc/>
-    public Stream OpenReadStream( FileEntry fileEntry, CancellationToken cancellationToken = default )
+    public Stream OpenReadStream( IFileEntry fileEntry, CancellationToken cancellationToken = default )
     {
         return new RemoteFileEntryStream( JSFileModule, ElementRef, fileEntry, this, ImageMaxSize, cancellationToken );
     }


### PR DESCRIPTION
## Description

Closes #5991

Now the IFileEntryOwner uses the interface IFileEntry.

I went through the code, but I don't see a reason for keeping the interface. Only the one implementation exists and it worked just fine with it. 

What's the reason to keep the interface - is there any upcoming feature that would utilize it?

The failing test isn't related to this change. It was already in here: https://github.com/Megabit/Blazorise/pull/5993/checks . Any idea?