### PR TITLE
DataGrid Modal: Fixes fullscreen modal by applying min-height instead of height.

### DIFF
--- a/Source/Extensions/Blazorise.DataGrid/_DataGridModal.razor
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridModal.razor
@@ -1,7 +1,7 @@
 ﻿@typeparam TItem
 @inherits BaseAfterRenderComponent
 
-<Modal @ref="modalRef" Closing="@PopupClosing" Closed="@Cancel">
+<Modal @ref="modalRef" Closing="@PopupClosing" Closed="@Cancel" Style="min-height:100%;height: auto;">
     <ModalContent Size="@PopupSize">
         <Form>
             <ModalHeader>


### PR DESCRIPTION
## Description

Closes #5718


