### PR TITLE
Chart: Plugin optimization

### DIFF
--- a/Source/Extensions/Blazorise.Charts.Zoom/ChartZoom.razor
+++ b/Source/Extensions/Blazorise.Charts.Zoom/ChartZoom.razor
@@ -1,2 +1,2 @@
 ﻿@typeparam TItem
-@inherits BaseComponent
+@inherits BaseChartPlugin<TItem, JSChartZoomModule>

--- a/Source/Extensions/Blazorise.Charts.Zoom/ChartZoom.razor.cs
+++ b/Source/Extensions/Blazorise.Charts.Zoom/ChartZoom.razor.cs
@@ -1,9 +1,7 @@
 ﻿#region Using directives
-using System;
 using System.Threading.Tasks;
 using Blazorise.Extensions;
 using Microsoft.AspNetCore.Components;
-using Microsoft.JSInterop;
 #endregion
 
 namespace Blazorise.Charts.Zoom;
@@ -12,101 +10,25 @@ namespace Blazorise.Charts.Zoom;
 /// Provides the annotation capabilities to the supported chart types.
 /// </summary>
 /// <typeparam name="TItem">Data point type.</typeparam>
-public partial class ChartZoom<TItem> : BaseComponent, IAsyncDisposable
+public partial class ChartZoom<TItem> : BaseChartPlugin<TItem, JSChartZoomModule>
 {
-    #region Members
-
-    private const string PluginName = "Zoom";
-
-    #endregion
 
     #region Methods
 
-    /// <inheritdoc/>
-    public override Task SetParametersAsync( ParameterView parameters )
-    {
-        if ( Rendered && JSModule is not null )
-        {
-            var optionsChanged = parameters.TryGetValue<ChartZoomPluginOptions>( nameof( Options ), out var paramOptions ) && !Options.IsEqual( paramOptions );
+    protected override JSChartZoomModule GetNewJsModule() => new( JSRuntime, VersionProvider, BlazoriseOptions );
 
-            if ( optionsChanged )
-            {
-                ExecuteAfterRender( async () =>
-                {
-                    await JSModule.AddZoom( ParentChart.ElementId, Options );
-                } );
-            }
-        }
+    protected override async Task AddPlugin() => await JSModule.AddZoom( ParentChart.ElementId, Options );
 
-        return base.SetParametersAsync( parameters );
-    }
-
-    /// <inheritdoc/>
-    protected override Task OnInitializedAsync()
-    {
-        if ( ParentChart is not null )
-        {
-            ParentChart.Initialized += OnParentChartInitialized;
-
-            ParentChart.NotifyPluginInitialized( PluginName );
-        }
-
-        return base.OnInitializedAsync();
-    }
-
-    private async void OnParentChartInitialized( object sender, EventArgs e )
-    {
-        if ( JSModule == null )
-        {
-            JSModule = new JSChartZoomModule( JSRuntime, VersionProvider, BlazoriseOptions );
-
-            ExecuteAfterRender( async () =>
-            {
-                await JSModule.AddZoom( ParentChart.ElementId, Options );
-            } );
-
-            await InvokeAsync( StateHasChanged );
-        }
-    }
-
-    /// <inheritdoc/>
-    protected override async ValueTask DisposeAsync( bool disposing )
-    {
-        if ( disposing && Rendered )
-        {
-            if ( JSModule is not null )
-                await JSModule.SafeDisposeAsync();
-
-            if ( ParentChart is not null )
-            {
-                ParentChart.Initialized -= OnParentChartInitialized;
-
-                ParentChart.NotifyPluginRemoved( PluginName );
-            }
-        }
-
-        await base.DisposeAsync( disposing );
-    }
+    protected override bool ProceedWithExecution( ParameterView parameters ) 
+        => parameters.TryGetValue<ChartZoomPluginOptions>( nameof( Options ), out var paramOptions ) && !Options.IsEqual( paramOptions );
 
     #endregion
 
     #region Properties
+    
+    protected override string Name => "Zoom";
 
-    /// <inheritdoc/>
-    protected override bool ShouldAutoGenerateId => true;
-
-    protected JSChartZoomModule JSModule { get; private set; }
-
-    [Inject] private IJSRuntime JSRuntime { get; set; }
-
-    [Inject] private IVersionProvider VersionProvider { get; set; }
-
-    /// <summary>
-    /// Gets or sets the blazorise options.
-    /// </summary>
-    [Inject] protected BlazoriseOptions BlazoriseOptions { get; set; }
-
-    [CascadingParameter] protected BaseChart<TItem> ParentChart { get; set; }
+    protected override JSChartZoomModule JSModule { get; set; }
 
     /// <summary>
     /// Defines the options for an annotation.

--- a/Source/Extensions/Blazorise.Charts/BaseChart.cs
+++ b/Source/Extensions/Blazorise.Charts/BaseChart.cs
@@ -34,7 +34,7 @@ public class BaseChart<TDataSet, TItem, TOptions, TModel> : BaseChart<TItem>, IB
 
             initialized = true;
 
-            NotifyInitialized();
+            await NotifyInitialized();
         }
 
         // Update the charts if the data has changed

--- a/Source/Extensions/Blazorise.Charts/BaseChartPlugin.cs
+++ b/Source/Extensions/Blazorise.Charts/BaseChartPlugin.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Threading.Tasks;
+using Blazorise.Extensions;
+using Blazorise.Modules;
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
+
+namespace Blazorise.Charts;
+
+public abstract class BaseChartPlugin : BaseComponent, IAsyncDisposable
+{
+    protected internal abstract Task OnParentChartInitialized();
+    protected internal abstract string Name { get; }
+}
+
+public abstract class BaseChartPlugin<TItem, TJSModule> : BaseChartPlugin
+where TJSModule : IBaseJSModule, IAsyncDisposable
+{
+
+    protected abstract TJSModule GetNewJsModule();
+
+    protected abstract Task AddPlugin();
+
+    protected abstract bool ProceedWithExecution( ParameterView parameterView );
+
+    protected internal override async Task OnParentChartInitialized()
+    {
+        if ( JSModule != null ) return;
+        JSModule = GetNewJsModule();
+        ExecuteAfterRender( async () =>
+        {
+            await AddPlugin();
+        } );
+        await InvokeAsync( StateHasChanged );
+    }
+
+    /// <inheritdoc/>
+    public override Task SetParametersAsync( ParameterView parameters )
+    {
+        if ( Rendered && JSModule is not null )
+        {
+            bool optionsChanged = ProceedWithExecution( parameters );
+
+            if ( optionsChanged )
+            {
+                ExecuteAfterRender( async () =>
+                {
+                    await AddPlugin();
+                } );
+            }
+        }
+
+        return base.SetParametersAsync( parameters );
+    }
+
+    /// <inheritdoc/>
+    protected override async ValueTask DisposeAsync( bool disposing )
+    {
+        if ( disposing && Rendered )
+        {
+            if ( JSModule is not null )
+                await JSModule.SafeDisposeAsync();
+
+            ParentChart?.NotifyBasePluginRemoved( this );
+        }
+
+        await base.DisposeAsync( disposing );
+    }
+
+    //  
+    /// <inheritdoc/>
+    protected override Task OnInitializedAsync()
+    {
+        if ( ParentChart is null )
+            throw new InvalidOperationException( $"Chart Plugin {Name} can be used only inside the Blazoris.Chart" );
+        ParentChart.NotifyBasePluginInitialized( this );
+        return base.OnInitializedAsync();
+    }
+    
+    
+    [CascadingParameter] protected BaseChart<TItem> ParentChart { get; set; }
+
+    protected abstract TJSModule JSModule { get; set; }
+    
+    protected override bool ShouldAutoGenerateId => true;
+
+    
+    /// <summary>
+    /// Gets or sets the JS runtime.
+    /// </summary>
+    [Inject] protected IJSRuntime JSRuntime { get; set; }
+
+    /// <summary>
+    /// Gets or sets the version provider.
+    /// </summary>
+    [Inject] protected IVersionProvider VersionProvider { get; set; }
+
+    /// <summary>
+    /// Gets or sets the blazorise options.
+    /// </summary>
+    [Inject] protected BlazoriseOptions BlazoriseOptions { get; set; }
+}

--- a/Source/Extensions/Blazorise.Charts/Blazorise.Charts.csproj
+++ b/Source/Extensions/Blazorise.Charts/Blazorise.Charts.csproj
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <PackageTags>blazorise blazor components chart</PackageTags>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## Description

- Puts common logic and properties into BaseChartPlugin.
- Solves pain-points of async eventing between chart and plugins.
- So far the optimization is done of ChartZoom plugin only...
-  ...because of that the `BaseChartOfT` supports both - the old way and new way - and look relatively dirty.
- This optimization will reduce the necessary code in every plugin significantly, can solve the disposing on one place in initializing on one place. Potential bugs will be solved for all of the plugins at one place.
- The current state is perfectly applicable for `DataLables` and  `Annotations`, for `Streaming` and `Trendline`  it will need few adjustments.

---
There are some questions left:
- Why `Trendline` doesn't have the `DisposeAsync` implementation ?
- Why `Streaming` doesn't have the `OnParameterSet` implementation? 



