### PR TITLE
Docs: Code block not visible on Validations page global options localization fix

### DIFF
--- a/Documentation/Blazorise.Docs/Models/Snippets.cs
+++ b/Documentation/Blazorise.Docs/Models/Snippets.cs
@@ -19,16 +19,4 @@ public static partial class Snippets
         return (string)field.GetValue( null );
     }
 
-    public const string GlobalLocalizationExample = @"services
-    .AddBlazorise( options =>
-    {
-        options.ValidationMessageLocalizer = ( message, arguments ) =>
-        {
-            var stringLocalizer = options.Services.GetService<ITextLocalizer<YourResourceName>>();
-
-            return stringLocalizer != null && arguments?.Count() > 0
-                ? string.Format( stringLocalizer[message], arguments.ToArray() )
-                : message;
-        };
-    } );";
 }

--- a/Documentation/Blazorise.Docs/Models/Snippets.generated.cs
+++ b/Documentation/Blazorise.Docs/Models/Snippets.generated.cs
@@ -5166,6 +5166,18 @@ Proin volutpat, sapien ut facilisis ultricies, eros purus blandit velit, at ultr
     }
 }";
 
+        public const string GlobalLocalizationExample = @"services.AddBlazorise( options =>
+    {
+        options.ValidationMessageLocalizer = ( message, arguments ) =>
+        {
+            var stringLocalizer = options.Services.GetService<ITextLocalizer<YourResourceName>>();
+
+            return stringLocalizer != null && arguments?.Count() > 0
+                ? string.Format( stringLocalizer[message], arguments.ToArray() )
+                : message;
+        };
+    } );";
+
         public const string LocalizationValidationExample = @"@using Blazorise.Localization
 
 <Validation MessageLocalizer=""@Localize"">

--- a/Documentation/Blazorise.Docs/Pages/Docs/Components/Validations/Examples/GlobalLocalizationExample.snippet
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Components/Validations/Examples/GlobalLocalizationExample.snippet
@@ -1,0 +1,11 @@
+services.AddBlazorise( options =>
+    {
+        options.ValidationMessageLocalizer = ( message, arguments ) =>
+        {
+            var stringLocalizer = options.Services.GetService<ITextLocalizer<YourResourceName>>();
+
+            return stringLocalizer != null && arguments?.Count() > 0
+                ? string.Format( stringLocalizer[message], arguments.ToArray() )
+                : message;
+        };
+    } );


### PR DESCRIPTION
## Description

Closes #6038

The snippet form Snippets.cs was moved into its own file, otherwise the compiler didn't pick it up for `*Code.html` generation.
