### PR TITLE
DataGrid: Fixes Toggleable for DetailRow

### DIFF
--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -1741,18 +1741,19 @@ public partial class DataGrid<TItem> : BaseDataGridComponent
             else if ( DetailRowTrigger is not null )
             {
                 var detailRowTriggerContext = new DetailRowTriggerEventArgs<TItem>( rowInfo.Item );
-                var detailRowTriggerResult = DetailRowTrigger( detailRowTriggerContext );
+                var shouldOpenWhenClosed = DetailRowTrigger( detailRowTriggerContext );
 
                 if ( !skipDetailRowTriggerType && detailRowTriggerType != detailRowTriggerContext.DetailRowTriggerType )
                     return;
-
-                rowInfo.SetRowDetail( detailRowTriggerResult, detailRowTriggerContext.Toggleable );
+                
+                if (detailRowTriggerContext.Toggleable)
+                    rowInfo.SetRowDetail(!rowInfo.HasDetailRow && shouldOpenWhenClosed);
 
                 if ( rowInfo.HasDetailRow && detailRowTriggerContext.Single )
                 {
-                    foreach ( var row in Rows.Where( x => !x.IsEqual( rowInfo ) ) )
+                    foreach ( var row in Rows.Where( x => !x.IsEqual( rowInfo ) ) )//close other detail rows
                     {
-                        row.SetRowDetail( false, false );
+                        row.SetRowDetail( false);
                     }
                 }
             }
@@ -3608,6 +3609,8 @@ public partial class DataGrid<TItem> : BaseDataGridComponent
 
     /// <summary>
     /// A trigger function used to handle the visibility of detail row.
+    /// Return true if you want the detail row to be visible when row is clicked and detail row is not visible.
+    /// Doesn't affect the closing behaviro (will be always close on click)
     /// </summary>
     [Parameter] public Func<DetailRowTriggerEventArgs<TItem>, bool> DetailRowTrigger { get; set; }
 

--- a/Source/Extensions/Blazorise.DataGrid/Models/DataGridRowInfo.cs
+++ b/Source/Extensions/Blazorise.DataGrid/Models/DataGridRowInfo.cs
@@ -46,10 +46,9 @@ public class DataGridRowInfo<TItem>
     /// <summary>
     /// Sets the detail row for the current row.
     /// </summary>
-    /// <param name="hasDetailRow">Indicates whether the detail row is present.</param>
-    /// <param name="toggleable">Indicates whether the detail row can be toggled.</param>
-    public void SetRowDetail( bool hasDetailRow, bool toggleable )
-        => this.hasDetailRow = ( toggleable && !this.hasDetailRow & hasDetailRow ) || ( !toggleable && hasDetailRow );
+    /// <param name="hasDetailRowNew">Open or close the detail row</param>
+    public void SetRowDetail( bool hasDetailRowNew )
+        => this.hasDetailRow = hasDetailRowNew;
 
     /// <summary>
     /// Toggles the visibility of the detail row.


### PR DESCRIPTION
## Description

Closes #6049

- Checks Toggleable first
- Simplifies `SetRowDetail`
- Clarify comments

