### PR TITLE
DataGrid: Export: Architecture, csv exporter, external binary data exporter

### DIFF
--- a/Blazorise.sln
+++ b/Blazorise.sln
@@ -161,6 +161,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Blazorise.Weavers", "Source
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Blazorise.Weavers.Fody", "Source\SourceGenerators\Blazorise.Weavers.Fody\Blazorise.Weavers.Fody.csproj", "{FFC4A285-1A16-4DD4-8B8C-141521E405B0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Blazorise.DataGrid.Exporters", "Source\Extensions\Blazorise.DataGrid.Exporters\Blazorise.DataGrid.Exporters.csproj", "{01A482C0-8DD8-4A9D-95FF-5CC2F71DB41B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -423,6 +425,10 @@ Global
 		{FFC4A285-1A16-4DD4-8B8C-141521E405B0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FFC4A285-1A16-4DD4-8B8C-141521E405B0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FFC4A285-1A16-4DD4-8B8C-141521E405B0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{01A482C0-8DD8-4A9D-95FF-5CC2F71DB41B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{01A482C0-8DD8-4A9D-95FF-5CC2F71DB41B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{01A482C0-8DD8-4A9D-95FF-5CC2F71DB41B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{01A482C0-8DD8-4A9D-95FF-5CC2F71DB41B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -495,6 +501,7 @@ Global
 		{EAB7EC89-900A-4280-B24A-152B9DD2B503} = {9731051E-0AA7-411E-A76A-987854F034DA}
 		{BF5FFB8C-45AD-4875-BB01-2DA388890419} = {0538DB67-B4F3-4D00-B969-D3874A52E405}
 		{FFC4A285-1A16-4DD4-8B8C-141521E405B0} = {0538DB67-B4F3-4D00-B969-D3874A52E405}
+		{01A482C0-8DD8-4A9D-95FF-5CC2F71DB41B} = {9731051E-0AA7-411E-A76A-987854F034DA}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {205B3EA4-470F-45DA-911E-346AF7D0A9A5}

--- a/Source/Blazorise/Interfaces/Modules/IJSUtilitiesModule.cs
+++ b/Source/Blazorise/Interfaces/Modules/IJSUtilitiesModule.cs
@@ -165,6 +165,14 @@ public interface IJSUtilitiesModule : IBaseJSModule
     /// <param name="elementId">ID of the rendered element.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
     ValueTask CopyToClipboard( ElementReference elementRef, string elementId );
+    
+    /// <summary>
+    /// Copies the specified string content to the clipboard.
+    /// </summary>
+    /// <param name="stringToCopy">The string content to copy to the clipboard.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    ValueTask CopyStringToClipboard(string stringToCopy);
+
 
     /// <summary>
     /// Writes a log message to the browser console.

--- a/Source/Blazorise/Modules/JSUtilitiesModule.cs
+++ b/Source/Blazorise/Modules/JSUtilitiesModule.cs
@@ -107,6 +107,10 @@ public class JSUtilitiesModule : BaseJSModule, IJSUtilitiesModule
     /// <inheritdoc/>
     public ValueTask CopyToClipboard( ElementReference elementRef, string elementId )
         => InvokeSafeVoidAsync( "copyToClipboard", elementRef, elementId );
+    
+    /// <inheritdoc/>
+    public ValueTask CopyStringToClipboard(string stringToCopy)
+        => InvokeSafeVoidAsync("copyStringToClipboard", stringToCopy);
 
     /// <inheritdoc/>
     public ValueTask Log( string message, params string[] args )

--- a/Source/Blazorise/wwwroot/utilities.js
+++ b/Source/Blazorise/wwwroot/utilities.js
@@ -226,6 +226,12 @@ export function copyToClipboard(element, elementId) {
     }
 }
 
+export function copyStringToClipboard(stringToCopy) {
+    if (navigator.clipboard) {
+        navigator.clipboard.writeText(stringToCopy);
+    }
+}
+
 function getExponentialParts(num) {
     return Array.isArray(num) ? num : String(num).split(/[eE]/);
 }

--- a/Source/Extensions/Blazorise.DataGrid.Exporters/Blazorise.DataGrid.Exporters.csproj
+++ b/Source/Extensions/Blazorise.DataGrid.Exporters/Blazorise.DataGrid.Exporters.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Blazorise.DataGrid\Blazorise.DataGrid.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="MongoDB.Bson" Version="3.3.0" />
+    </ItemGroup>
+
+</Project>

--- a/Source/Extensions/Blazorise.DataGrid.Exporters/Bson/BsonToFileExporter.cs
+++ b/Source/Extensions/Blazorise.DataGrid.Exporters/Bson/BsonToFileExporter.cs
@@ -1,0 +1,46 @@
+using MongoDB.Bson;
+namespace Blazorise.DataGrid.Exporters.Bson;
+public class BsonToFileExporter( BsonFileExportOptions? options=null ) : DataGridExporterToFileBinary<BsonFileExportOptions, ExportResult >( options )
+{
+    public override async Task<byte[]> GetDataForExport(List<List<object>> data, List<string> columnNames)
+    {
+        var bsonDocuments = new List<BsonDocument>();
+
+        foreach (var row in data)
+        {
+            var doc = new BsonDocument();
+
+            for (int i = 0; i < columnNames.Count && i < row.Count; i++)
+            {
+                var key = columnNames[i];
+                var value = row[i];
+
+                doc.Add(key, BsonValue.Create(value));
+            }
+
+            bsonDocuments.Add(doc);
+        }
+
+        var rootDocument = new BsonDocument
+                           {
+                           { "data", new BsonArray(bsonDocuments) }
+                           };
+
+        return rootDocument.ToBson();
+    }
+
+}
+
+public class BsonFileExportOptions : FileExportOptions
+{
+    public override string FileExtension { get; init; } = "bson";
+    public override string MimeType { get; init; } = "application/bson";
+    public bool IncludeTypeInformation { get; init; } = true;
+}
+
+
+
+
+
+
+

--- a/Source/Extensions/Blazorise.DataGrid/JSDataGridModule.cs
+++ b/Source/Extensions/Blazorise.DataGrid/JSDataGridModule.cs
@@ -57,6 +57,14 @@ public class JSDataGridModule : BaseJSModule
         return await moduleInstance.InvokeAsync<int>( "scrollTo", elementRef, classname );
     }
 
+    
+    public virtual async ValueTask<int> ExportToFile( byte[] data, string fileName, string mimeType )
+    {
+        var moduleInstance = await Module;
+
+        return await moduleInstance.InvokeAsync<int>( "exportToFile", data, fileName, mimeType );
+    }
+    
     #endregion
 
     #region Properties

--- a/Source/Extensions/Blazorise.DataGrid/Utils/Export/DataGridExportOptions.cs
+++ b/Source/Extensions/Blazorise.DataGrid/Utils/Export/DataGridExportOptions.cs
@@ -1,0 +1,9 @@
+namespace Blazorise.DataGrid;
+
+public class DataGridExportOptions
+{
+    /// <summary>
+    /// -1 means all rows
+    /// </summary>
+    public int NumberOfRows { get; init; } = -1;
+}

--- a/Source/Extensions/Blazorise.DataGrid/Utils/Export/Formats/Csv/CsvExportHelpers.cs
+++ b/Source/Extensions/Blazorise.DataGrid/Utils/Export/Formats/Csv/CsvExportHelpers.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Blazorise.DataGrid;
+
+static class CsvExportHelpers
+{
+    internal static async Task<string> GetDataForText(List<List<string>> data, List<string> headers, ICsvExportOptions options)
+    {
+        var sb = new StringBuilder();
+
+        if (options?.ExportHeader == true)
+        {
+            sb.AppendLine(string.Join(",", headers.Select(EscapeCsvField)));
+        }
+
+        foreach (var row in data)
+        {
+            sb.AppendLine(string.Join(",", row.Select(EscapeCsvField)));
+        }
+
+        await Task.CompletedTask;
+        return sb.ToString();
+    }
+
+    static string EscapeCsvField(string field)
+    {
+        if (field.Contains('"') || field.Contains(',') || field.Contains('\n') || field.Contains('\r'))
+        {
+            var escaped = field.Replace("\"", "\"\"");
+            return $"\"{escaped}\"";
+        }
+
+        return field;
+    }
+}

--- a/Source/Extensions/Blazorise.DataGrid/Utils/Export/Formats/Csv/Exporters/CsvToClipboardExporter.cs
+++ b/Source/Extensions/Blazorise.DataGrid/Utils/Export/Formats/Csv/Exporters/CsvToClipboardExporter.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Blazorise.DataGrid;
+
+/// <summary>
+/// Provides functionality to export DataGrid content in CSV format directly to the system clipboard.
+/// </summary>
+public class CsvToClipboardExporter : DataGridExporterToClipboardText<CsvClipboardExportOptions, ExportResult>
+{
+    public CsvToClipboardExporter(CsvClipboardExportOptions options = null) : base(options) { }
+
+    public override async Task<string> GetDataForExport( List<List<string>> data, List<string> columnNames )
+    {
+        var content = await CsvExportHelpers.GetDataForText( data, columnNames, ClipboardOptions );
+        return content;
+    }
+
+    
+}

--- a/Source/Extensions/Blazorise.DataGrid/Utils/Export/Formats/Csv/Exporters/CsvToFileExporter.cs
+++ b/Source/Extensions/Blazorise.DataGrid/Utils/Export/Formats/Csv/Exporters/CsvToFileExporter.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Blazorise.DataGrid;
+
+/// <summary>
+/// Exports DataGrid content to a CSV file using the specified file export options.
+/// </summary>
+public class CsvToFileExporter : DataGridExporterToFileText<CsvFileExportOptions, ExportResult >
+{
+    public CsvToFileExporter(CsvFileExportOptions options = null) : base(options) { }
+
+    public override async Task<byte[]> GetDataForExport( List<List<string>> data, List<string> columnNames )
+    {
+        var content = await CsvExportHelpers.GetDataForText( data, columnNames, FileOptions );
+        var bytes = Encoding.UTF8.GetBytes( content );
+        return bytes;
+    }
+}

--- a/Source/Extensions/Blazorise.DataGrid/Utils/Export/Formats/Csv/Exporters/CsvToTextExporter.cs
+++ b/Source/Extensions/Blazorise.DataGrid/Utils/Export/Formats/Csv/Exporters/CsvToTextExporter.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+namespace Blazorise.DataGrid;
+
+/// <summary>
+/// Exports DataGrid content to a CSV-formatted string using the specified text export options.
+/// </summary>
+public class CsvToTextExporter : DataGridExporterToText<CsvTextExportOptions, TextExportResult>
+{
+    public CsvToTextExporter(CsvTextExportOptions options = null) : base(options) { }
+
+    public override async Task<TextExportResult> Export( List<List<string>> data, List<string> columnNames )
+    {
+        var content = await CsvExportHelpers.GetDataForText( data, columnNames, TextOptions );
+        return new TextExportResult {IsSuccess = true, Text = content};    
+    }
+}

--- a/Source/Extensions/Blazorise.DataGrid/Utils/Export/Formats/Csv/Options/CsvClipboardExportOptions.cs
+++ b/Source/Extensions/Blazorise.DataGrid/Utils/Export/Formats/Csv/Options/CsvClipboardExportOptions.cs
@@ -1,0 +1,9 @@
+namespace Blazorise.DataGrid;
+
+/// <summary>
+/// Represents configuration options for exporting DataGrid content to the clipboard in CSV format.
+/// </summary>
+public  class CsvClipboardExportOptions: ClipboardExportOptions, ICsvExportOptions
+{
+    public bool ExportHeader { get; init; } = true;
+}

--- a/Source/Extensions/Blazorise.DataGrid/Utils/Export/Formats/Csv/Options/CsvFileExportOptions.cs
+++ b/Source/Extensions/Blazorise.DataGrid/Utils/Export/Formats/Csv/Options/CsvFileExportOptions.cs
@@ -1,0 +1,13 @@
+namespace Blazorise.DataGrid;
+
+/// <summary>
+/// Represents the options for exporting data to a CSV file.
+/// </summary>
+public class CsvFileExportOptions: FileExportOptions,ICsvExportOptions
+{
+    public override  string FileExtension { get; init; } = "csv";
+    public override string MimeType { get; init; } = "text/csv;charset=utf-8";
+
+    public bool ExportHeader { get; init; } = true;
+}
+

--- a/Source/Extensions/Blazorise.DataGrid/Utils/Export/Formats/Csv/Options/CsvTextExportOptions.cs
+++ b/Source/Extensions/Blazorise.DataGrid/Utils/Export/Formats/Csv/Options/CsvTextExportOptions.cs
@@ -1,0 +1,9 @@
+namespace Blazorise.DataGrid;
+
+/// <summary>
+/// Represents configuration options for exporting DataGrid content to a CSV-formatted text string.
+/// </summary>
+public class CsvTextExportOptions:TextExportOptions, ICsvExportOptions
+{
+    public bool ExportHeader { get; init; } = true;
+}

--- a/Source/Extensions/Blazorise.DataGrid/Utils/Export/Formats/Csv/Options/ICsvExportOptions.cs
+++ b/Source/Extensions/Blazorise.DataGrid/Utils/Export/Formats/Csv/Options/ICsvExportOptions.cs
@@ -1,0 +1,10 @@
+namespace Blazorise.DataGrid;
+
+/// <summary>
+/// Defines common CSV-specific export options shared across various export targets (e.g., file, clipboard, text).
+/// </summary>
+public interface ICsvExportOptions
+{
+    public bool ExportHeader { get; init; } 
+
+}

--- a/Source/Extensions/Blazorise.DataGrid/Utils/Export/Targets/Clipboard/ClipboardExportOptions.cs
+++ b/Source/Extensions/Blazorise.DataGrid/Utils/Export/Targets/Clipboard/ClipboardExportOptions.cs
@@ -1,0 +1,16 @@
+namespace Blazorise.DataGrid;
+
+/// <summary>
+/// Marker interface for clipboard export options.
+/// </summary>
+public interface IClipboardExportOptions
+{
+}
+
+/// <summary>
+/// Base class for clipboard export configuration options.
+/// </summary>
+public abstract  class ClipboardExportOptions:IClipboardExportOptions
+{
+    
+}

--- a/Source/Extensions/Blazorise.DataGrid/Utils/Export/Targets/Clipboard/DataGridExporterToClipboard.cs
+++ b/Source/Extensions/Blazorise.DataGrid/Utils/Export/Targets/Clipboard/DataGridExporterToClipboard.cs
@@ -1,0 +1,69 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Blazorise.Modules;
+
+namespace Blazorise.DataGrid;
+
+/// <summary>
+/// Base class for exporting DataGrid content as text (string-based) to the clipboard using specified options.
+/// </summary>
+public abstract class DataGridExporterToClipboardText<TOptions,TExportResult>:DataGridExporterToClipboard<TOptions,TExportResult, string>, IDataGridExporterText<TExportResult>
+where TOptions: IClipboardExportOptions, new()
+where TExportResult: IExportResult, new()
+{
+    protected DataGridExporterToClipboardText(TOptions options) : base(options)
+    {
+    }
+}
+
+/// <summary>
+/// Base class for exporting DataGrid content in binary format to the clipboard using specified options.
+/// </summary>
+public abstract class DataGridExporterToClipboardBinary<TOptions,TExportResult>
+:DataGridExporterToClipboard<TOptions,TExportResult,object>, IDataGridExporterBinary<TExportResult>
+where TOptions: IClipboardExportOptions, new()
+where TExportResult: IExportResult, new()
+{
+    protected DataGridExporterToClipboardBinary(TOptions options) : base(options)
+    {
+    }
+}
+
+
+/// <summary>
+/// 🚫 This is an internal base class for clipboard export targets.  
+/// Do not use this class directly.  
+/// Instead, use a specialized implementation such as <see cref="DataGridExporterToClipboardText{TOptions, TExportResult}"/>.
+/// </summary>
+[System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+public abstract class DataGridExporterToClipboard<TOptions, TExportResult, TCellValue>:IDataGridExporter<TExportResult,TCellValue>, IClipboardExportTarget
+where TOptions: IClipboardExportOptions, new()
+where TExportResult : IExportResult, new()
+{
+    protected DataGridExporterToClipboard( TOptions options )
+        => ClipboardOptions = options ?? new();
+    public IJSUtilitiesModule JSUtilitiesModule { get; set; }
+
+    public async Task<TExportResult> Export( List<List<TCellValue>> data, List<string> columnNames )
+    {
+        var text = await GetDataForExport( data, columnNames );
+        await JSUtilitiesModule.CopyStringToClipboard( text );
+        
+        return  await GetExportResult( true );
+
+    }
+    
+    public abstract Task< string> GetDataForExport( List<List<TCellValue>> data, List<string> columnNames );
+
+    public virtual Task<TExportResult> GetExportResult(bool success)
+    {
+        var res= new TExportResult { IsSuccess = success};
+        return Task.FromResult( res );
+    }
+
+    
+    
+    
+    public TOptions ClipboardOptions { get; init; }
+
+}

--- a/Source/Extensions/Blazorise.DataGrid/Utils/Export/Targets/Clipboard/IClipboardExportTarget.cs
+++ b/Source/Extensions/Blazorise.DataGrid/Utils/Export/Targets/Clipboard/IClipboardExportTarget.cs
@@ -1,0 +1,12 @@
+using Blazorise.Modules;
+
+namespace Blazorise.DataGrid;
+
+/// <summary>
+/// Defines clipboard-specific interop functionality for DataGrid export targets.
+/// </summary>
+public interface IClipboardExportTarget
+{
+     IJSUtilitiesModule JSUtilitiesModule { get; set; }
+
+}

--- a/Source/Extensions/Blazorise.DataGrid/Utils/Export/Targets/ExportResult.cs
+++ b/Source/Extensions/Blazorise.DataGrid/Utils/Export/Targets/ExportResult.cs
@@ -1,0 +1,20 @@
+namespace Blazorise.DataGrid;
+
+/// <summary>
+/// Represents a generic result of a DataGrid export operation, indicating whether the export was successful.
+/// </summary>
+public interface IExportResult
+{
+    bool IsSuccess { get; init; }
+}
+
+/// <summary>
+/// Default implementation of <see cref="IExportResult"/>, representing the outcome of a DataGrid export operation.
+/// </summary>
+public class ExportResult : IExportResult
+{
+    public bool IsSuccess { get; init; }
+}
+
+
+

--- a/Source/Extensions/Blazorise.DataGrid/Utils/Export/Targets/File/DataGridExporterToFile.cs
+++ b/Source/Extensions/Blazorise.DataGrid/Utils/Export/Targets/File/DataGridExporterToFile.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Blazorise.DataGrid;
+
+/// <summary>
+/// Base class for exporting DataGrid content as text (string-based) to a file using specified file export options.
+/// </summary>
+public abstract class DataGridExporterToFileText<TOptions,TExportResult>:DataGridExporterToFile<TOptions,TExportResult, string>, IDataGridExporterText<TExportResult>
+where TOptions: IFileExportOptions, new()
+where TExportResult: IExportResult, new()
+{
+    protected DataGridExporterToFileText(TOptions options) : base(options)
+    {
+    }
+}
+
+/// <summary>
+/// Base class for exporting DataGrid content in binary format to a file using specified file export options.
+/// </summary>
+public abstract class DataGridExporterToFileBinary<TOptions,TExportResult>
+:DataGridExporterToFile<TOptions,TExportResult,object>, IDataGridExporterBinary<TExportResult>
+where TOptions: IFileExportOptions, new()
+where TExportResult: IExportResult, new()
+{
+    protected DataGridExporterToFileBinary(TOptions options) : base(options)
+    {
+    }
+}
+
+
+/// <summary>
+/// 🚫 Internal base class. Do not use directly. Inherit from <see cref="DataGridExporterToFileText{TOptions,TExportResult}"/> or <see cref="DataGridExporterToFileBinary{TOptions,TExportResult}"/>.
+/// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public abstract class DataGridExporterToFile<TOptions,TExportResult, TCellValue>:
+IFileExportTarget 
+where TOptions: IFileExportOptions, new()
+where TExportResult: IExportResult, new()
+{
+    protected DataGridExporterToFile(TOptions options)
+        => FileOptions = options ?? new();
+    public JSDataGridModule JsDataGridModule { get; set; }
+
+    public abstract Task<byte[]> GetDataForExport( List<List<TCellValue>> data, List<string> columnNames );
+
+    public virtual Task<TExportResult> GetExportResult(int exportToFileResult)
+    {
+        var res= new TExportResult { IsSuccess = exportToFileResult == 1 };
+        return Task.FromResult( res );
+    }
+
+    public async Task<TExportResult> Export( List<List<TCellValue>> data, List<string> columnNames )
+    {
+        var bytes = await GetDataForExport( data, columnNames );
+        var res =  await JsDataGridModule.ExportToFile(bytes, FileOptions.FileName, FileOptions.MimeType );
+        
+        return  await GetExportResult( res );
+    }
+    public TOptions FileOptions { get; init; }
+}
+
+

--- a/Source/Extensions/Blazorise.DataGrid/Utils/Export/Targets/File/FileExportOptions.cs
+++ b/Source/Extensions/Blazorise.DataGrid/Utils/Export/Targets/File/FileExportOptions.cs
@@ -1,0 +1,23 @@
+namespace Blazorise.DataGrid;
+
+/// <summary>
+/// Defines configuration options for exporting DataGrid content to a file, including file name, extension, and MIME type.
+/// </summary>
+public interface IFileExportOptions
+{
+    public string FileName => $"{FileNameNoExtension}.{FileExtension}";
+    public  string FileNameNoExtension { get; init; }
+    public  string FileExtension { get; init; } 
+    public  string MimeType { get; init; }
+}
+
+/// <summary>
+/// Base class for file export options, providing default values for file name and MIME type.
+/// </summary>
+public abstract class FileExportOptions:IFileExportOptions
+{
+    public  string FileNameNoExtension { get; init; } = "exported-data";
+    public abstract string FileExtension { get; init; }
+    public virtual string MimeType { get; init; } = "application/text";
+}
+

--- a/Source/Extensions/Blazorise.DataGrid/Utils/Export/Targets/File/IFileExportTarget.cs
+++ b/Source/Extensions/Blazorise.DataGrid/Utils/Export/Targets/File/IFileExportTarget.cs
@@ -1,0 +1,9 @@
+namespace Blazorise.DataGrid;
+
+/// <summary>
+/// Defines file-specific interop functionality for DataGrid export targets, including access to the JavaScript export module.
+/// </summary>
+public interface IFileExportTarget
+{
+    JSDataGridModule JsDataGridModule { get; set; }
+}

--- a/Source/Extensions/Blazorise.DataGrid/Utils/Export/Targets/IDataGridExporter.cs
+++ b/Source/Extensions/Blazorise.DataGrid/Utils/Export/Targets/IDataGridExporter.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Blazorise.DataGrid;
+
+
+/// <summary>
+/// Represents a DataGrid exporter that handles string-based (textual) cell values, such as CSV or plain text formats.
+/// </summary>
+public interface IDataGridExporterText<TExportResult> : IDataGridExporter<TExportResult,string>
+where TExportResult : IExportResult
+{
+    
+}
+
+/// <summary>
+/// Represents a DataGrid exporter that handles object-based (typed or binary) cell values for formats like Excel or BSON.
+/// </summary>
+public interface IDataGridExporterBinary<TExportResult> : IDataGridExporter<TExportResult,object>
+where TExportResult : IExportResult
+{
+    
+}
+
+/// <summary>
+/// 🚫 This is an internal base interface for DataGrid exporters and should not be implemented directly.
+/// Use <see cref="IDataGridExporterText{TExportResult}"/> or <see cref="IDataGridExporterBinary{TExportResult}"/> instead.
+/// Defines a generic interface for exporting DataGrid content using a specified cell value type and export result type.
+/// </summary>
+[System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+
+public interface IDataGridExporter<TExportResult, TDataType>
+where TExportResult: IExportResult
+{
+     Task<TExportResult> Export( List<List<TDataType>> data, List<string> columnNames );
+
+}
+
+
+

--- a/Source/Extensions/Blazorise.DataGrid/Utils/Export/Targets/Text/DataGridExporterToText.cs
+++ b/Source/Extensions/Blazorise.DataGrid/Utils/Export/Targets/Text/DataGridExporterToText.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Blazorise.DataGrid;
+
+/// <summary>
+/// Base class for exporting DataGrid content as plain text using the specified text export options.
+/// Intended for formats like CSV or TSV where cell values are represented as strings.
+/// </summary>
+public abstract class DataGridExporterToText<TOptions, TExportResult>: IDataGridExporter<TExportResult,string>
+    where TOptions : ITextExportOptions, new()
+    where TExportResult: ITextExportResult
+{
+    
+    protected DataGridExporterToText( TOptions options )
+        => TextOptions = options ?? new();
+    public TOptions TextOptions { get; init; }
+
+    public abstract Task<TExportResult> Export( List<List<string>> data, List<string> columnNames );
+}
+
+

--- a/Source/Extensions/Blazorise.DataGrid/Utils/Export/Targets/Text/TextExportOptions.cs
+++ b/Source/Extensions/Blazorise.DataGrid/Utils/Export/Targets/Text/TextExportOptions.cs
@@ -1,0 +1,17 @@
+namespace Blazorise.DataGrid;
+
+/// <summary>
+/// Marker interface for text export option types used in string-based DataGrid exports.
+/// </summary>
+public interface ITextExportOptions
+{
+    
+}
+
+/// <summary>
+/// Base class for text export configuration options used in string-based DataGrid exports.
+/// </summary>
+public class TextExportOptions:ITextExportOptions
+{
+    
+}

--- a/Source/Extensions/Blazorise.DataGrid/Utils/Export/Targets/Text/TextExportResult.cs
+++ b/Source/Extensions/Blazorise.DataGrid/Utils/Export/Targets/Text/TextExportResult.cs
@@ -1,0 +1,18 @@
+namespace Blazorise.DataGrid;
+
+/// <summary>
+/// Represents the result of a text-based DataGrid export, including the exported text content.
+/// </summary>
+public interface ITextExportResult: IExportResult
+{
+    public string Text { get; init; }
+}
+
+/// <summary>
+/// Concrete implementation of <see cref="ITextExportResult"/>, containing the exported text and success status.
+/// </summary>
+public class TextExportResult : ITextExportResult
+{
+    public bool IsSuccess { get; init; }
+    public string Text { get; init; }
+}

--- a/Source/Extensions/Blazorise.DataGrid/wwwroot/datagrid.js
+++ b/Source/Extensions/Blazorise.DataGrid/wwwroot/datagrid.js
@@ -200,6 +200,35 @@ function KeyDownCellNavigation(e) {
         }
         return;
     }
+    
+    
 
 
 }
+
+export function exportToFile(data, fileName, mimeType) {
+    // Convert .NET byte array to Uint8Array
+    const uint8Array = new Uint8Array(data);
+
+    // Create Blob with specified MIME type
+    const blob = new Blob([uint8Array], { type: mimeType });
+
+    // Create temporary URL
+    const url = URL.createObjectURL(blob);
+
+    // Create hidden anchor element
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = fileName;
+    document.body.appendChild(a);
+
+    // Trigger download
+    a.click();
+
+    // Cleanup
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+
+    return 1; // Success
+}
+


### PR DESCRIPTION
## Description

Closes #6042

This pull request introduces a new **exporter architecture** for the DataGrid component.

As part of this architecture, I've also included two example supported formats
- `Csv` – a **text-based** format that is bundled in the `Blazorise.DataGrid` package.
- `Bson` – a **binary** format that is simple to work with and demonstrates external extensibility. It requires an additional dependency and is implemented in a separate project (`Blazorise.DataGrid.Exporters`). (This is where Excel exporters should go too).

While the new architecture is not small, it enables a powerful level of extensibility. Creating a CSV exporter, for example, could be done with much less code — but the purpose of this system is to ensure **external exporters can be plugged into DataGrid easily**.

With this architecture, no changes are needed in the `Blazorise.DataGrid` core codebase to support new exporters. A developer only needs to implement a single abstract class, focusing purely on the core export logic and options. Thanks to these design choices, the boilerplate for creating a new exporter (e.g. a potential JSON exporter) is reduced to a minimum (see the `BsonToFileExporter`).

While developing the architecture, I also re-evaluated what "export" should mean in the DataGrid context. It doesn't have to mean only exporting to a file — it can also mean exporting to a string (TextExporter), the clipboard, or any other target. Currently, we support 3 targets:
- **File**
- **Clipboard**
- **Text** (in-memory string)

This concept of "targets" opens up future extensibility such as:
- API-based export
- Printer
- Email or sharing
- Chat/Telegram integration

(Many of these could work with the simple `TextTarget` or minor variations of it, so I din't go much deeper)

---

## Nomenclature

- **Target**: The destination where exported DataGrid content ends up (File, Clipboard, Text).
- **Format**: The format in which data is encoded (CSV, BSON, XML, etc.).
- **Exporter**: A combination of format and target, e.g. `CsvToFileExporter`. This is why the `Csv` directory contains multiple files — it supports multiple targets.

---

## Getting data from DataGrid

This area still needs improvement, as my knowledge of the full DataGrid capabilities is limited. Currently, only columns with a defined `Field` are exported, and the value is either formatted (for text) or raw (for binary).

One potential future enhancement:  
A property like `BaseDataGridColumn.Func<object, object> ExportValue` could be used to customize how each column is exported — giving the developer full control per column.

The data passed to exporters is structured as a `List<List<object>>` or `List<List<string>>`, depending on whether the export is binary or text-based.

---

## Usage

As simple as:

```csharp
// Simple export to CSV with default options
dataGridRef.Export(new CsvToFileExporter());

// Copy to clipboard without headers
dataGridRef.Export(new CsvToClipboardExporter(new() { ExportHeader = false }));

// Export to CSV file with a custom file name and only the first 3 rows
dataGridRef.Export(
    new CsvToFileExporter(new() { FileNameNoExtension = "custom-csv-file" }),
    new DataGridExportOptions { NumberOfRows = 3 }
);

// Bson export (defined in an external project)
dataGridRef.Export(new BsonToFileExporter());
```

As shown above, only one public method in `DataGrid.razor.cs` is needed to support all export formats and targets.

---

- This PR does not include UI changes (e.g. export button). That could come in a future PR.
- `Blazorise.DataGrid.Exporters` is an external test project designed to validate the extensibility of the exporter system. It serves as a foundation for future projects where we'll support additional exporters that require external dependencies (e.g., Excel). It can be merged in this test form - it does nothing wrong.

