### PR TITLE
MessageService: add Choose method

### DIFF
--- a/Documentation/Blazorise.Docs/Models/Snippets.generated.cs
+++ b/Documentation/Blazorise.Docs/Models/Snippets.generated.cs
@@ -12300,26 +12300,55 @@ builder.Services
 </Button>";
 
         public const string BasicMessageServiceExample = @"<Button Color=""Color.Primary"" Clicked=""@ShowInfoMessage"">Say hi!</Button>
-<Button Color=""Color.Danger"" Clicked=""@ShowConfirmMessage"">Confirm</Button>
 
-@code{
+@code {
     [Inject] IMessageService MessageService { get; set; }
 
     Task ShowInfoMessage()
     {
         return MessageService.Info( ""This is a simple info message!"", ""Hello"" );
     }
+}";
 
-    async Task ShowConfirmMessage()
+        public const string MessageServiceChooseExample = @"<Button Color=""Color.Primary"" Clicked=""@ShowChooseDialog"">Choose an option</Button>
+
+<Paragraph>
+    You selected: <Strong>@selectedOption</Strong>
+</Paragraph>
+
+@code {
+    [Inject] IMessageService MessageService { get; set; }
+
+    object selectedOption;
+
+    async Task ShowChooseDialog()
     {
-        if ( await MessageService.Confirm( ""Are you sure you want to confirm?"", ""Confirmation"" ) )
+        selectedOption = await MessageService.Choose( ""Make a Selection"", ""Choose one"", options =>
         {
-            Console.WriteLine( ""OK Clicked"" );
-        }
-        else
-        {
-            Console.WriteLine( ""Cancel Clicked"" );
-        }
+            options.Choices = new List<MessageOptionsChoice>
+            {
+                new(""option-1"", ""Primary Option"", Color.Primary),
+                new(""option-2"", ""Secondary Option"", Color.Secondary),
+                new(""option-3"", ""Success Option"", Color.Success)
+            };
+        } );
+    }
+}";
+
+        public const string MessageServiceConfirmExample = @"<Button Color=""Color.Danger"" Clicked=""@ShowConfirmDelete"">Delete Item</Button>
+
+<Paragraph>
+    Your choice is: <Strong>@result</Strong>
+</Paragraph>
+
+@code {
+    [Inject] IMessageService MessageService { get; set; }
+
+    bool? result;
+
+    async Task ShowConfirmDelete()
+    {
+        result = await MessageService.Confirm( ""Are you sure you want to delete the item?"", ""Confirmation"" );
     }
 }";
 

--- a/Documentation/Blazorise.Docs/Pages/Docs/Services/Messages/Code/BasicMessageServiceExampleCode.html
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Services/Messages/Code/BasicMessageServiceExampleCode.html
@@ -1,27 +1,14 @@
 <div class="blazorise-codeblock">
 <div class="html"><pre>
 <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">Button</span> <span class="htmlAttributeName">Color</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="enum">Color</span><span class="enumValue">.Primary</span><span class="quot">&quot;</span> <span class="htmlAttributeName">Clicked</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="sharpVariable"><span class="atSign">&#64;</span>ShowInfoMessage</span><span class="quot">&quot;</span><span class="htmlTagDelimiter">&gt;</span>Say hi!<span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">Button</span><span class="htmlTagDelimiter">&gt;</span>
-<span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">Button</span> <span class="htmlAttributeName">Color</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="enum">Color</span><span class="enumValue">.Danger</span><span class="quot">&quot;</span> <span class="htmlAttributeName">Clicked</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="sharpVariable"><span class="atSign">&#64;</span>ShowConfirmMessage</span><span class="quot">&quot;</span><span class="htmlTagDelimiter">&gt;</span>Confirm<span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">Button</span><span class="htmlTagDelimiter">&gt;</span>
 </pre></div>
 <div class="csharp"><pre>
-<span class="atSign">&#64;</span>code{
+<span class="atSign">&#64;</span>code {
     [Inject] IMessageService MessageService { <span class="keyword">get</span>; <span class="keyword">set</span>; }
 
     Task ShowInfoMessage()
     {
         <span class="keyword">return</span> MessageService.Info( <span class="string">&quot;This is a simple info message!&quot;</span>, <span class="string">&quot;Hello&quot;</span> );
-    }
-
-    <span class="keyword">async</span> Task ShowConfirmMessage()
-    {
-        <span class="keyword">if</span> ( <span class="keyword">await</span> MessageService.Confirm( <span class="string">&quot;Are you sure you want to confirm?&quot;</span>, <span class="string">&quot;Confirmation&quot;</span> ) )
-        {
-            Console.WriteLine( <span class="string">&quot;OK Clicked&quot;</span> );
-        }
-        <span class="keyword">else</span>
-        {
-            Console.WriteLine( <span class="string">&quot;Cancel Clicked&quot;</span> );
-        }
     }
 }
 </pre></div>

--- a/Documentation/Blazorise.Docs/Pages/Docs/Services/Messages/Code/MessageServiceChooseExampleCode.html
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Services/Messages/Code/MessageServiceChooseExampleCode.html
@@ -1,0 +1,29 @@
+<div class="blazorise-codeblock">
+<div class="html"><pre>
+<span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">Button</span> <span class="htmlAttributeName">Color</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="enum">Color</span><span class="enumValue">.Primary</span><span class="quot">&quot;</span> <span class="htmlAttributeName">Clicked</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="sharpVariable"><span class="atSign">&#64;</span>ShowChooseDialog</span><span class="quot">&quot;</span><span class="htmlTagDelimiter">&gt;</span>Choose an option<span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">Button</span><span class="htmlTagDelimiter">&gt;</span>
+
+<span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">Paragraph</span><span class="htmlTagDelimiter">&gt;</span>
+    You selected: <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">Strong</span><span class="htmlTagDelimiter">&gt;</span><span class="atSign">&#64;</span>selectedOption<span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">Strong</span><span class="htmlTagDelimiter">&gt;</span>
+<span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">Paragraph</span><span class="htmlTagDelimiter">&gt;</span>
+</pre></div>
+<div class="csharp"><pre>
+<span class="atSign">&#64;</span>code {
+    [Inject] IMessageService MessageService { <span class="keyword">get</span>; <span class="keyword">set</span>; }
+
+    <span class="keyword">object</span> selectedOption;
+
+    <span class="keyword">async</span> Task ShowChooseDialog()
+    {
+        selectedOption = <span class="keyword">await</span> MessageService.Choose( <span class="string">&quot;Make a Selection&quot;</span>, <span class="string">&quot;Choose one&quot;</span>, options =&gt;
+        {
+            options.Choices = <span class="keyword">new</span> List&lt;MessageOptionsChoice&gt;
+            {
+                <span class="keyword">new</span>(<span class="string">&quot;option-1&quot;</span>, <span class="string">&quot;Primary Option&quot;</span>, Color.Primary),
+                <span class="keyword">new</span>(<span class="string">&quot;option-2&quot;</span>, <span class="string">&quot;Secondary Option&quot;</span>, Color.Secondary),
+                <span class="keyword">new</span>(<span class="string">&quot;option-3&quot;</span>, <span class="string">&quot;Success Option&quot;</span>, Color.Success)
+            };
+        } );
+    }
+}
+</pre></div>
+</div>

--- a/Documentation/Blazorise.Docs/Pages/Docs/Services/Messages/Code/MessageServiceConfirmExampleCode.html
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Services/Messages/Code/MessageServiceConfirmExampleCode.html
@@ -1,0 +1,21 @@
+<div class="blazorise-codeblock">
+<div class="html"><pre>
+<span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">Button</span> <span class="htmlAttributeName">Color</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="enum">Color</span><span class="enumValue">.Danger</span><span class="quot">&quot;</span> <span class="htmlAttributeName">Clicked</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="sharpVariable"><span class="atSign">&#64;</span>ShowConfirmDelete</span><span class="quot">&quot;</span><span class="htmlTagDelimiter">&gt;</span>Delete Item<span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">Button</span><span class="htmlTagDelimiter">&gt;</span>
+
+<span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">Paragraph</span><span class="htmlTagDelimiter">&gt;</span>
+    Your choice is: <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">Strong</span><span class="htmlTagDelimiter">&gt;</span><span class="atSign">&#64;</span>result<span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">Strong</span><span class="htmlTagDelimiter">&gt;</span>
+<span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">Paragraph</span><span class="htmlTagDelimiter">&gt;</span>
+</pre></div>
+<div class="csharp"><pre>
+<span class="atSign">&#64;</span>code {
+    [Inject] IMessageService MessageService { <span class="keyword">get</span>; <span class="keyword">set</span>; }
+
+    <span class="keyword">bool</span>? result;
+
+    <span class="keyword">async</span> Task ShowConfirmDelete()
+    {
+        result = <span class="keyword">await</span> MessageService.Confirm( <span class="string">&quot;Are you sure you want to delete the item?&quot;</span>, <span class="string">&quot;Confirmation&quot;</span> );
+    }
+}
+</pre></div>
+</div>

--- a/Documentation/Blazorise.Docs/Pages/Docs/Services/Messages/Examples/BasicMessageServiceExample.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Services/Messages/Examples/BasicMessageServiceExample.razor
@@ -1,25 +1,12 @@
 ﻿@namespace Blazorise.Docs.Docs.Examples
 
 <Button Color="Color.Primary" Clicked="@ShowInfoMessage">Say hi!</Button>
-<Button Color="Color.Danger" Clicked="@ShowConfirmMessage">Confirm</Button>
 
-@code{
+@code {
     [Inject] IMessageService MessageService { get; set; }
 
     Task ShowInfoMessage()
     {
         return MessageService.Info( "This is a simple info message!", "Hello" );
-    }
-
-    async Task ShowConfirmMessage()
-    {
-        if ( await MessageService.Confirm( "Are you sure you want to confirm?", "Confirmation" ) )
-        {
-            Console.WriteLine( "OK Clicked" );
-        }
-        else
-        {
-            Console.WriteLine( "Cancel Clicked" );
-        }
     }
 }

--- a/Documentation/Blazorise.Docs/Pages/Docs/Services/Messages/Examples/MessageServiceChooseExample.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Services/Messages/Examples/MessageServiceChooseExample.razor
@@ -1,0 +1,26 @@
+﻿@namespace Blazorise.Docs.Docs.Examples
+
+<Button Color="Color.Primary" Clicked="@ShowChooseDialog">Choose an option</Button>
+
+<Paragraph>
+    You selected: <Strong>@selectedOption</Strong>
+</Paragraph>
+
+@code {
+    [Inject] IMessageService MessageService { get; set; }
+
+    object selectedOption;
+
+    async Task ShowChooseDialog()
+    {
+        selectedOption = await MessageService.Choose( "Make a Selection", "Choose one", options =>
+        {
+            options.Choices = new List<MessageOptionsChoice>
+            {
+                new("option-1", "Primary Option", Color.Primary),
+                new("option-2", "Secondary Option", Color.Secondary),
+                new("option-3", "Success Option", Color.Success)
+            };
+        } );
+    }
+}

--- a/Documentation/Blazorise.Docs/Pages/Docs/Services/Messages/Examples/MessageServiceConfirmExample.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Services/Messages/Examples/MessageServiceConfirmExample.razor
@@ -1,0 +1,18 @@
+﻿@namespace Blazorise.Docs.Docs.Examples
+
+<Button Color="Color.Danger" Clicked="@ShowConfirmDelete">Delete Item</Button>
+
+<Paragraph>
+    Your choice is: <Strong>@result</Strong>
+</Paragraph>
+
+@code {
+    [Inject] IMessageService MessageService { get; set; }
+
+    bool? result;
+
+    async Task ShowConfirmDelete()
+    {
+        result = await MessageService.Confirm( "Are you sure you want to delete the item?", "Confirmation" );
+    }
+}

--- a/Documentation/Blazorise.Docs/Pages/Docs/Services/Messages/MessagePage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Services/Messages/MessagePage.razor
@@ -12,8 +12,7 @@
 </DocsPageLead>
 
 <DocsPageParagraph>
-    The <Code>IMessageService</Code> is a powerful helper utility built on top of <Code>Modal</Code> component
-    and is used for showing the messages and confirmation dialogs to the user.
+    The <Code>IMessageService</Code> is a powerful helper utility built on top of <Code>Modal</Code> component and is used for showing the messages and confirmation dialogs to the user.
 </DocsPageParagraph>
 
 <DocsPageSubtitle>
@@ -45,4 +44,28 @@
         <BasicMessageServiceExample />
     </DocsPageSectionContent>
     <DocsPageSectionSource Code="BasicMessageServiceExample" />
+</DocsPageSection>
+
+<DocsPageSection>
+    <DocsPageSectionHeader Title="Confirm">
+        <DocsPageParagraph>
+            The <Code>Confirm()</Code> method is used to show a confirmation dialog. It can be used to ask the user for confirmation before performing an action, such as deleting an item or submitting a form.
+        </DocsPageParagraph>
+    </DocsPageSectionHeader>
+    <DocsPageSectionContent Outlined>
+        <MessageServiceConfirmExample />
+    </DocsPageSectionContent>
+    <DocsPageSectionSource Code="MessageServiceConfirmExample" />
+</DocsPageSection>
+
+<DocsPageSection>
+    <DocsPageSectionHeader Title="Choose">
+        <DocsPageParagraph>
+            The <Code>Choose()</Code> method is used to show a dialog with multiple choices. It can be used to show a list of options to the user and wait for their selection.
+        </DocsPageParagraph>
+    </DocsPageSectionHeader>
+    <DocsPageSectionContent Outlined>
+        <MessageServiceChooseExample />
+    </DocsPageSectionContent>
+    <DocsPageSectionSource Code="MessageServiceChooseExample" />
 </DocsPageSection>

--- a/Documentation/Blazorise.Docs/Pages/News/2025-03-10-release-notes-180.razor
+++ b/Documentation/Blazorise.Docs/Pages/News/2025-03-10-release-notes-180.razor
@@ -28,7 +28,7 @@
     </UnorderedListItem>
     <UnorderedListItem>
         <Paragraph>
-            <Strong></Strong>:
+            <Strong>MessageService</Strong>: New Choices Method
         </Paragraph>
     </UnorderedListItem>
 </UnorderedList>
@@ -160,6 +160,14 @@
 
 <Paragraph>
     The <code>Highlighter</code> component now supports highlighting multiple phrases within the same text using the new <code>HighlightedTexts</code> parameter. This enhancement allows developers to pass a list of strings to be highlighted simultaneously, replacing the previous limitation of only a single <code>HighlightedText</code>. The update enables more dynamic and flexible highlighting scenarios, such as multi-word search, filtering, and complex keyword matching — all with minimal changes to existing implementations.
+</Paragraph>
+
+<Heading Size="HeadingSize.Is3">
+    Choices on MessageService
+</Heading>
+
+<Paragraph>
+    The <Code>MessageService</Code> now supports the <Code>Choices</Code> method, allowing you to display a list of options in a message dialog. This feature is useful for scenarios where you want to present users with multiple choices and handle their selection accordingly.
 </Paragraph>
 
 <NewsPagePostInfo UserName="Mladen Macanović" ImageName="mladen" PostedOn="March 10th, 2025" Read="7 min" />

--- a/Source/Blazorise/Components/MessageAlert/MessageAlert.razor
+++ b/Source/Blazorise/Components/MessageAlert/MessageAlert.razor
@@ -40,6 +40,19 @@
                     @ConfirmButtonText
                 </Button>
             }
+            else if ( IsChoice )
+            {
+                @foreach ( var choice in Choices )
+                {
+                    <Button @key="@choice.Key" Color="@choice.Color" Class="@choice.Class" Padding="@choice.Padding" Clicked="@(() => OnChoiceClicked( choice ))">
+                        @if ( choice.Icon is not null )
+                        {
+                            <Icon Name="@choice.Icon" TextColor="@(choice.IconColor ?? TextColor.Default)" Margin="Blazorise.Margin.Is2.FromEnd" />
+                        }
+                        @choice.Text
+                    </Button>
+                }
+            }
             else
             {
                 <Button Color="@OkButtonColor" Class="@OkButtonClass" Padding="@OkButtonPadding" Clicked="@OnOkClicked">

--- a/Source/Blazorise/Components/MessageAlert/MessageProvider.razor
+++ b/Source/Blazorise/Components/MessageAlert/MessageProvider.razor
@@ -40,6 +40,19 @@
                     @ConfirmButtonText
                 </Button>
             }
+            else if ( IsChoice )
+            {
+                @foreach ( var choice in Choices )
+                {
+                    <Button @key="@choice.Key" Color="@choice.Color" Class="@choice.Class" Padding="@choice.Padding" Clicked="@(() => OnChoiceClicked( choice ))">
+                        @if ( choice.Icon is not null )
+                        {
+                            <Icon Name="@choice.Icon" TextColor="@(choice.IconColor ?? TextColor.Default)" Margin="Blazorise.Margin.Is2.FromEnd" />
+                        }
+                        @choice.Text
+                    </Button>
+                }
+            }
             else
             {
                 <Button Color="@OkButtonColor" Class="@OkButtonClass" Padding="@OkButtonPadding" Clicked="@OnOkClicked">

--- a/Source/Blazorise/Enums/MessageType.cs
+++ b/Source/Blazorise/Enums/MessageType.cs
@@ -29,4 +29,9 @@ public enum MessageType
     /// Prompt the user with the confirmation dialog.
     /// </summary>
     Confirmation,
+
+    /// <summary>
+    /// Represents a selection option within a set of choices.
+    /// </summary>
+    Choice,
 }

--- a/Source/Blazorise/EventArguments/MessageEventArgs.cs
+++ b/Source/Blazorise/EventArguments/MessageEventArgs.cs
@@ -43,7 +43,7 @@ public class MessageEventArgs : EventArgs
     /// <param name="title">Title of the message.</param>
     /// <param name="options">Additional options to override default message settings.</param>
     /// <param name="callback">Callback that will execute once the user responds with an action.</param>
-    public MessageEventArgs( MessageType messageType, string message, string title, MessageOptions options, TaskCompletionSource<bool> callback )
+    public MessageEventArgs( MessageType messageType, string message, string title, MessageOptions options, TaskCompletionSource<object> callback )
         : this( messageType, (MarkupString)message, title, options, callback )
     {
     }
@@ -56,7 +56,7 @@ public class MessageEventArgs : EventArgs
     /// <param name="title">Title of the message.</param>
     /// <param name="options">Additional options to override default message settings.</param>
     /// <param name="callback">Callback that will execute once the user responds with an action.</param>
-    public MessageEventArgs( MessageType messageType, MarkupString message, string title, MessageOptions options, TaskCompletionSource<bool> callback )
+    public MessageEventArgs( MessageType messageType, MarkupString message, string title, MessageOptions options, TaskCompletionSource<object> callback )
     {
         MessageType = messageType;
         Message = message;
@@ -88,5 +88,5 @@ public class MessageEventArgs : EventArgs
     /// <summary>
     /// Gets the callback that will execute once the user responds with an action.
     /// </summary>
-    public TaskCompletionSource<bool> Callback { get; }
+    public TaskCompletionSource<object> Callback { get; }
 }

--- a/Source/Blazorise/Interfaces/IMessageService.cs
+++ b/Source/Blazorise/Interfaces/IMessageService.cs
@@ -105,4 +105,23 @@ public interface IMessageService
     /// <param name="options">Options to override message dialog appearance.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
     Task<bool> Confirm( MarkupString message, string title = null, Action<MessageOptions> options = null );
+
+    /// <summary>
+    /// Prompts the user to make a choice based on a message and optional title and options.
+    /// </summary>
+    /// <param name="message">The text displayed to the user to convey the choice they need to make.</param>
+    /// <param name="title">An optional heading that provides context for the choice being presented.</param>
+    /// <param name="options">An optional delegate that allows customization of the message options available to the user.</param>
+    /// <returns>An asynchronous task that resolves to the user's selected choice.</returns>
+    Task<object> Choose( string message, string title = null, Action<MessageOptions> options = null );
+
+    /// <summary>
+    /// Prompts the user to make a choice based on a message and an optional title. Additional options can be provided
+    /// to customize the prompt.
+    /// </summary>
+    /// <param name="message">The content displayed to the user to inform them about the choice they need to make.</param>
+    /// <param name="title">An optional heading that can provide context or additional information about the choice.</param>
+    /// <param name="options">An optional delegate that allows customization of the message options presented to the user.</param>
+    /// <returns>An object representing the user's selection from the provided choices.</returns>
+    Task<object> Choose( MarkupString message, string title = null, Action<MessageOptions> options = null );
 }

--- a/Source/Blazorise/Models/MessageOptions.cs
+++ b/Source/Blazorise/Models/MessageOptions.cs
@@ -1,4 +1,8 @@
-﻿namespace Blazorise;
+﻿#region Using directives
+using System.Collections.Generic;
+#endregion
+
+namespace Blazorise;
 
 /// <summary>
 /// Options to override message dialog appearance.
@@ -139,6 +143,11 @@ public class MessageOptions
     /// Defines the message dialog size.
     /// </summary>
     public ModalSize Size { get; set; }
+
+    /// <summary>
+    /// Represents a collection of options for message buttons. Each option is of type <see cref="MessageOptionsChoice"/>.
+    /// </summary>
+    public IEnumerable<MessageOptionsChoice> Choices { get; set; }
 
     /// <summary>
     /// Creates the default message options.

--- a/Source/Blazorise/Models/MessageOptionsChoice.cs
+++ b/Source/Blazorise/Models/MessageOptionsChoice.cs
@@ -1,0 +1,79 @@
+﻿#region Using directives
+using System;
+#endregion
+
+namespace Blazorise;
+
+/// <summary>
+/// Represents a command for a choice message, containing properties for a key, display text, icon, icon color, and overall color.
+/// </summary>
+public class MessageOptionsChoice
+{
+    /// <summary>
+    /// A default constructor for the <see cref="MessageOptionsChoice"/> class.
+    /// </summary>
+    public MessageOptionsChoice()
+    {
+        Key = Guid.NewGuid();
+    }
+
+    /// <summary>
+    /// Constructs a new instance with specified text and color for a message option.
+    /// </summary>
+    /// <param name="text">The content that will be displayed as the message option.</param>
+    /// <param name="color">The color that will be used to represent the message option visually.</param>
+    public MessageOptionsChoice( string text, Color color )
+        : this()
+    {
+        Text = text;
+        Color = color;
+    }
+
+    /// <summary>
+    /// Constructs a new instance with specified text and color for a message option.
+    /// </summary>
+    /// <param name="key">The unique key for the result of the choice.</param>
+    /// <param name="text">The content that will be displayed as the message option.</param>
+    /// <param name="color">The color that will be used to represent the message option visually.</param>
+    public MessageOptionsChoice( object key, string text, Color color )
+    {
+        Key = key;
+        Text = text;
+        Color = color;
+    }
+
+    /// <summary>
+    /// Represents the key associated with a data entry. It can hold any type of object.
+    /// </summary>
+    public object Key { get; set; }
+
+    /// <summary>
+    /// Custom text for the choice button.
+    /// </summary>
+    public string Text { get; set; }
+
+    /// <summary>
+    /// Custom icon for the choice button.
+    /// </summary>
+    public object Icon { get; set; }
+
+    /// <summary>
+    /// Custome icon color for the choice button.
+    /// </summary>
+    public TextColor IconColor { get; set; }
+
+    /// <summary>
+    /// Custom color of the choice button.
+    /// </summary>
+    public Color Color { get; set; }
+
+    /// <summary>
+    /// Custom padding of the choice button.
+    /// </summary>
+    public IFluentSpacing Padding { get; set; }
+
+    /// <summary>
+    /// Represents the name of the CSS class as a string.
+    /// </summary>
+    public string Class { get; set; }
+}

--- a/Source/Blazorise/Services/MessageService.cs
+++ b/Source/Blazorise/Services/MessageService.cs
@@ -59,14 +59,33 @@ class MessageService : IMessageService
         => Confirm( (MarkupString)message, title, options );
 
     /// <inheritdoc/>
-    public Task<bool> Confirm( MarkupString message, string title = null, Action<MessageOptions> options = null )
+    public async Task<bool> Confirm( MarkupString message, string title = null, Action<MessageOptions> options = null )
     {
         var messageOptions = MessageOptions.Default;
         options?.Invoke( messageOptions );
 
-        var callback = new TaskCompletionSource<bool>();
+        var callback = new TaskCompletionSource<object>();
 
         MessageReceived?.Invoke( this, new( MessageType.Confirmation, message, title, messageOptions, callback ) );
+
+        var result = await callback.Task;
+
+        return result is bool booleanResult && booleanResult;
+    }
+
+    /// <inheritdoc/>
+    public Task<object> Choose( string message, string title = null, Action<MessageOptions> options = null )
+        => Choose( (MarkupString)message, title, options );
+
+    /// <inheritdoc/>
+    public Task<object> Choose( MarkupString message, string title = null, Action<MessageOptions> options = null )
+    {
+        var messageOptions = MessageOptions.Default;
+        options?.Invoke( messageOptions );
+
+        var callback = new TaskCompletionSource<object>();
+
+        MessageReceived?.Invoke( this, new( MessageType.Choice, message, title, messageOptions, callback ) );
 
         return callback.Task;
     }


### PR DESCRIPTION
While working on the Scheduler component, I needed to have a confirmation dialog with multiple choices. So this PR solves it. 

It adds:

- `Choose` method that awaits the result from the user
- new `MessageOptionsChoice` that holds the information about the buttons on the dialog
- New examples in the docs
- Release notes

The only problem is that I had to change `TaskCompletionSource<bool> Callback` into `TaskCompletionSource<object> Callback`. I'm not sure if this parameter is even used by anyone, considering that `IMessageService` is used to give all information to the component.