### PR TITLE
Localization: Add culture-specific overloads for text localization APIs

### DIFF
--- a/Documentation/Blazorise.Docs/Pages/News/2025-03-10-release-notes-180.razor
+++ b/Documentation/Blazorise.Docs/Pages/News/2025-03-10-release-notes-180.razor
@@ -170,4 +170,12 @@
     The <Code>MessageService</Code> now supports the <Code>Choices</Code> method, allowing you to display a list of options in a message dialog. This feature is useful for scenarios where you want to present users with multiple choices and handle their selection accordingly.
 </Paragraph>
 
+<Heading Size="HeadingSize.Is3">
+    Culture-specific overloads for text localization
+</Heading>
+
+<Paragraph>
+    The <Code>ITextLocalizer</Code> interface now includes overloads for the <Code>GetString</Code> method that accept a <Code>CultureInfo</Code> parameter. The <Code>CultureInfo</Code> parameter can be used to specify the desired culture for localization, enabling you to retrieve strings that are tailored to the user's language and region. This is particularly useful in scenarios where you need to support multiple languages or regions within your application.
+</Paragraph>
+
 <NewsPagePostInfo UserName="Mladen Macanović" ImageName="mladen" PostedOn="March 10th, 2025" Read="7 min" />

--- a/Source/Blazorise/Localization/ITextLocalizer.cs
+++ b/Source/Blazorise/Localization/ITextLocalizer.cs
@@ -1,7 +1,6 @@
 ﻿#region Using directives
 using System.Collections.Generic;
 using System.Globalization;
-
 #endregion
 
 namespace Blazorise.Localization;
@@ -34,7 +33,7 @@ public interface ITextLocalizer
     /// <param name="arguments">The values to format the string with.</param>
     /// <returns>The formatted string resource <paramref name="name"/> if not found.</returns>
     string this[CultureInfo culture, string name, params object[] arguments] { get; }
-    
+
     /// <summary>
     /// Adds a custom language resource to the list of supported cultures.
     /// </summary>
@@ -48,7 +47,7 @@ public interface ITextLocalizer
     /// <param name="arguments">An object array that contains zero or more objects to format.</param>
     /// <returns>Localized string.</returns>
     string GetString( string name, params object[] arguments );
-    
+
     /// <summary>
     /// Gets the localized string by the name with the optional list object for formatting.
     /// </summary>
@@ -57,14 +56,14 @@ public interface ITextLocalizer
     /// <param name="arguments">An object array that contains zero or more objects to format.</param>
     /// <returns>Localized string.</returns>
     string GetString( CultureInfo culture, string name, params object[] arguments );
-    
+
     /// <summary>
     /// Gets the localized string for each key in the localization object.
     /// </summary>
     /// <param name="arguments">An object array that contains zero or more objects to format.</param>
     /// <returns>Localized key/value pairs.</returns>
     IReadOnlyDictionary<string, string> GetStrings( params object[] arguments );
-    
+
     /// <summary>
     /// Gets the localized string for each key in the localization object.
     /// </summary>

--- a/Source/Blazorise/Localization/ITextLocalizer.cs
+++ b/Source/Blazorise/Localization/ITextLocalizer.cs
@@ -1,5 +1,7 @@
 ﻿#region Using directives
 using System.Collections.Generic;
+using System.Globalization;
+
 #endregion
 
 namespace Blazorise.Localization;
@@ -25,6 +27,15 @@ public interface ITextLocalizer
     string this[string name, params object[] arguments] { get; }
 
     /// <summary>
+    /// Gets the string resource with the given name and formatted with the supplied arguments using specified culture.
+    /// </summary>
+    /// <param name="culture">The culture to use for localization.</param>
+    /// <param name="name">The name of the string resource.</param>
+    /// <param name="arguments">The values to format the string with.</param>
+    /// <returns>The formatted string resource <paramref name="name"/> if not found.</returns>
+    string this[CultureInfo culture, string name, params object[] arguments] { get; }
+    
+    /// <summary>
     /// Adds a custom language resource to the list of supported cultures.
     /// </summary>
     /// <param name="localizationResource">Custom resource model.</param>
@@ -37,13 +48,30 @@ public interface ITextLocalizer
     /// <param name="arguments">An object array that contains zero or more objects to format.</param>
     /// <returns>Localized string.</returns>
     string GetString( string name, params object[] arguments );
-
+    
+    /// <summary>
+    /// Gets the localized string by the name with the optional list object for formatting.
+    /// </summary>
+    /// <param name="culture">The culture to use for localization.</param>
+    /// <param name="name">A name to localize.</param>
+    /// <param name="arguments">An object array that contains zero or more objects to format.</param>
+    /// <returns>Localized string.</returns>
+    string GetString( CultureInfo culture, string name, params object[] arguments );
+    
     /// <summary>
     /// Gets the localized string for each key in the localization object.
     /// </summary>
     /// <param name="arguments">An object array that contains zero or more objects to format.</param>
     /// <returns>Localized key/value pairs.</returns>
     IReadOnlyDictionary<string, string> GetStrings( params object[] arguments );
+    
+    /// <summary>
+    /// Gets the localized string for each key in the localization object.
+    /// </summary>
+    /// <param name="culture">The culture to use for localization.</param>
+    /// <param name="arguments">An object array that contains zero or more objects to format.</param>
+    /// <returns>Localized key/value pairs.</returns>
+    IReadOnlyDictionary<string, string> GetStrings( CultureInfo culture, params object[] arguments );
 }
 
 /// <summary>

--- a/Source/Blazorise/Localization/ITextLocalizer.cs
+++ b/Source/Blazorise/Localization/ITextLocalizer.cs
@@ -71,7 +71,7 @@ public interface ITextLocalizer
     /// <param name="arguments">An object array that contains zero or more objects to format.</param>
     /// <returns>Localized key/value pairs.</returns>
     IReadOnlyDictionary<string, string> GetStrings( CultureInfo culture, params object[] arguments );
-    
+
     /// <summary>
     /// Gets the current culture info.
     /// </summary>

--- a/Source/Blazorise/Localization/ITextLocalizer.cs
+++ b/Source/Blazorise/Localization/ITextLocalizer.cs
@@ -71,6 +71,11 @@ public interface ITextLocalizer
     /// <param name="arguments">An object array that contains zero or more objects to format.</param>
     /// <returns>Localized key/value pairs.</returns>
     IReadOnlyDictionary<string, string> GetStrings( CultureInfo culture, params object[] arguments );
+    
+    /// <summary>
+    /// Gets the current culture info.
+    /// </summary>
+    CultureInfo SelectedCulture { get; }
 }
 
 /// <summary>

--- a/Source/Blazorise/Localization/TextLocalizer.cs
+++ b/Source/Blazorise/Localization/TextLocalizer.cs
@@ -214,9 +214,6 @@ public class TextLocalizer<T> : ITextLocalizer<T>
                  } ).ToDictionary( x => x.Key, x => x.Value );
     }
 
-    /// <inheritdoc />
-    public CultureInfo SelectedCulture => localizerService.SelectedCulture;
-
     #endregion
 
     #region Properties
@@ -229,6 +226,9 @@ public class TextLocalizer<T> : ITextLocalizer<T>
 
     /// <inheritdoc/>
     public string this[CultureInfo culture, string name, params object[] arguments] => GetString( culture, name, arguments );
+
+    /// <inheritdoc />
+    public CultureInfo SelectedCulture => localizerService.SelectedCulture;
 
     #endregion
 }

--- a/Source/Blazorise/Localization/TextLocalizer.cs
+++ b/Source/Blazorise/Localization/TextLocalizer.cs
@@ -178,18 +178,18 @@ public class TextLocalizer<T> : ITextLocalizer<T>
         return GetString( localizerService.SelectedCulture, name, arguments );
     }
 
-    
+
     /// <inheritdoc/>
     public virtual string GetString( CultureInfo culture, string name, params object[] arguments )
     {
-        var translations = GetTranslations(culture);
-    
+        var translations = GetTranslations( culture );
+
         if ( translations is null || !translations.TryGetValue( name, out var value ) )
             value = name;
-    
+
         if ( arguments.Length > 0 )
             value = string.Format( culture, value, arguments );
-    
+
         return value;
     }
 
@@ -198,12 +198,12 @@ public class TextLocalizer<T> : ITextLocalizer<T>
     {
         return GetStrings( localizerService.SelectedCulture, arguments );
     }
-    
+
     /// <inheritdoc/>
     public virtual IReadOnlyDictionary<string, string> GetStrings( CultureInfo culture, params object[] arguments )
     {
-        var translations = GetTranslations(culture);
-    
+        var translations = GetTranslations( culture );
+
         return ( from t in translations
                  select new
                  {
@@ -223,7 +223,7 @@ public class TextLocalizer<T> : ITextLocalizer<T>
 
     /// <inheritdoc/>
     public string this[string name, params object[] arguments] => GetString( name, arguments );
-    
+
     /// <inheritdoc/>
     public string this[CultureInfo culture, string name, params object[] arguments] => GetString( culture, name, arguments );
 

--- a/Source/Blazorise/Localization/TextLocalizer.cs
+++ b/Source/Blazorise/Localization/TextLocalizer.cs
@@ -134,8 +134,9 @@ public class TextLocalizer<T> : ITextLocalizer<T>
     /// <summary>
     /// Gets all of the translations.
     /// </summary>
+    /// <param name="culture"></param>
     /// <returns>Key/value pairs of translations.</returns>
-    protected virtual IReadOnlyDictionary<string, string> GetTranslations()
+    protected virtual IReadOnlyDictionary<string, string> GetTranslations( CultureInfo culture )
     {
         // The selected culture can either be a neutral culture (2-digit:"cn") or a specific culture
         // (5-digit:"en-UK").
@@ -149,12 +150,12 @@ public class TextLocalizer<T> : ITextLocalizer<T>
         // 5. Invariant culture (defaults to "en")
         IReadOnlyDictionary<string, string> result;
 
-        if ( localizerService.SelectedCulture is not null
-             && translationsByCulture.TryGetValue( localizerService.SelectedCulture.Name, out result ) )
+        if ( culture is not null
+             && translationsByCulture.TryGetValue( culture.Name, out result ) )
             return result;
 
-        if ( localizerService.SelectedCulture?.Parent is not null && !localizerService.SelectedCulture.IsNeutralCulture
-                                                              && translationsByCulture.TryGetValue( localizerService.SelectedCulture.Parent.Name, out result ) )
+        if ( culture?.Parent is not null && !culture.IsNeutralCulture
+                                                              && translationsByCulture.TryGetValue( culture.Parent.Name, out result ) )
             return result;
 
         if ( CultureInfo.CurrentUICulture is not null
@@ -174,28 +175,41 @@ public class TextLocalizer<T> : ITextLocalizer<T>
     /// <inheritdoc/>
     public virtual string GetString( string name, params object[] arguments )
     {
-        var translations = GetTranslations();
+        return GetString( localizerService.SelectedCulture, name, arguments );
+    }
 
+    
+    /// <inheritdoc/>
+    public virtual string GetString( CultureInfo culture, string name, params object[] arguments )
+    {
+        var translations = GetTranslations(culture);
+    
         if ( translations is null || !translations.TryGetValue( name, out var value ) )
             value = name;
-
+    
         if ( arguments.Length > 0 )
-            value = string.Format( localizerService.SelectedCulture, value, arguments );
-
+            value = string.Format( culture, value, arguments );
+    
         return value;
     }
 
     /// <inheritdoc/>
     public virtual IReadOnlyDictionary<string, string> GetStrings( params object[] arguments )
     {
-        var translations = GetTranslations();
-
+        return GetStrings( localizerService.SelectedCulture, arguments );
+    }
+    
+    /// <inheritdoc/>
+    public virtual IReadOnlyDictionary<string, string> GetStrings( CultureInfo culture, params object[] arguments )
+    {
+        var translations = GetTranslations(culture);
+    
         return ( from t in translations
                  select new
                  {
                      t.Key,
                      Value = arguments.Length > 0
-                         ? string.Format( localizerService.SelectedCulture, t.Value, arguments )
+                         ? string.Format( culture, t.Value, arguments )
                          : t.Value
                  } ).ToDictionary( x => x.Key, x => x.Value );
     }
@@ -209,6 +223,9 @@ public class TextLocalizer<T> : ITextLocalizer<T>
 
     /// <inheritdoc/>
     public string this[string name, params object[] arguments] => GetString( name, arguments );
+    
+    /// <inheritdoc/>
+    public string this[CultureInfo culture, string name, params object[] arguments] => GetString( culture, name, arguments );
 
     #endregion
 }

--- a/Source/Blazorise/Localization/TextLocalizer.cs
+++ b/Source/Blazorise/Localization/TextLocalizer.cs
@@ -214,6 +214,9 @@ public class TextLocalizer<T> : ITextLocalizer<T>
                  } ).ToDictionary( x => x.Key, x => x.Value );
     }
 
+    /// <inheritdoc />
+    public CultureInfo SelectedCulture => localizerService.SelectedCulture;
+
     #endregion
 
     #region Properties


### PR DESCRIPTION
## Description

Closes #6015

Adds `GetString`, `GetStrings` and relevant indexer.

The issue also asks about exposing current culture though `TextLocalizerService`, but it's already there as `SelectedCulture` property.
