### PR TITLE
Chart: fix Cutout option

### DIFF
--- a/Documentation/Blazorise.Docs/Pages/News/2025-03-10-release-notes-180.razor
+++ b/Documentation/Blazorise.Docs/Pages/News/2025-03-10-release-notes-180.razor
@@ -155,6 +155,18 @@
 </Paragraph>
 
 <Heading Size="HeadingSize.Is3">
+    Renamed Chart Options
+</Heading>
+
+<Paragraph>
+    We had a wrongly named option on the <Code>DoughnutChartOptions</Code>, and <Code>PieChartOptions</Code> classes. The <Code>CutoutPercentage</Code> property has been renamed to <Code>Cutout</Code>. This change aligns with the Chart.js documentation and ensures consistency across the API. Since the field was already wrongly named, this change should not break any existing code. However, if you were using the <Code>CutoutPercentage</Code> property, you will need to update your code to use the new <Code>Cutout</Code> property.
+</Paragraph>
+
+<Paragraph>
+    To make it more flexible we have also made it an <Code>object</Code> type, so you can use it as a percentage or a number. This change allows you to specify the cutout value in either pixels or as a percentage of the chart's radius, providing greater flexibility in how you configure your charts.
+</Paragraph>
+
+<Heading Size="HeadingSize.Is3">
     Autocomplete: Disabled Items
 </Heading>
 

--- a/Source/Extensions/Blazorise.Charts/Options/Specifics/DoughnutChartOptions.cs
+++ b/Source/Extensions/Blazorise.Charts/Options/Specifics/DoughnutChartOptions.cs
@@ -7,8 +7,8 @@ namespace Blazorise.Charts;
 public class DoughnutChartOptions : PieChartOptions
 {
     /// <summary>
-    /// The percentage of the chart that is cut out of the middle.
+    /// The portion of the chart that is cut out of the middle. If string and ending with '%', percentage of the chart radius. number is considered to be pixels.
     /// </summary>
     [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-    public new int? CutoutPercentage { get; set; }
+    public new object Cutout { get; set; }
 }

--- a/Source/Extensions/Blazorise.Charts/Options/Specifics/PieChartOptions.cs
+++ b/Source/Extensions/Blazorise.Charts/Options/Specifics/PieChartOptions.cs
@@ -8,10 +8,10 @@ namespace Blazorise.Charts;
 public class PieChartOptions : ChartOptions
 {
     /// <summary>
-    /// The percentage of the chart that is cut out of the middle.
+    /// The portion of the chart that is cut out of the middle. If string and ending with '%', percentage of the chart radius. number is considered to be pixels.
     /// </summary>
     [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-    public int? CutoutPercentage { get; set; }
+    public object Cutout { get; set; }
 
     /// <summary>
     /// Starting angle to draw arcs from.


### PR DESCRIPTION
Closes #6009

My first idea was to just add the JSON property name, but since this field is already wrong, it shouldn't affect anyone. So I have just renamed it. And to make it more flexible, I made it an `object` so that it can accept string and number as per chartjs specs.