### PR TITLE
DataGrid: fix filter on numeric values

### DIFF
--- a/Source/Extensions/Blazorise.DataGrid/_DataGridCellNumericEdit.razor
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridCellNumericEdit.razor
@@ -15,7 +15,6 @@
 }
 
 @code {
-
     private RenderFragment NumericPickerFragment => builder =>
     {
         var underlyingType = Nullable.GetUnderlyingType(valueType) ?? valueType;
@@ -77,5 +76,4 @@
         builder.AddAttribute(6, nameof( NumericEdit<object>.ElementId ), elementId);
         builder.CloseComponent();
     };
-
 }


### PR DESCRIPTION
## Description

Closes #6121

- The issue was caused by the default value of the `int` type. Although `0` was present in the input, it was not considered the actual value of the filter, so clicking the "Filter" button had no effect. (the value for filter is assigned on input change)
- The original issue can be mitigated by first inserting a non-0 value and then inserting `0` (or simply by pressing the up and down arrows inside the picker).

The solution in this pr is to wrap both `int` and `int?` (and any other numeric values) in `NumericPicker<int?>`. This allows the input to start empty, which forces the user to explicitly enter `0`. This aligns better with the logic, as having `0` as a default value was rather confusing. This might be considered as a breaking change. Additionally, the datagrid and filter already support `null` values (e.g., when clearing a filter).

This solution appears to work without issues as far as I can tell, but there might be some caveats I haven't foreseen.
