### PR TITLE
RichTextEdit: Only register additional plug-ins if specified in options

### DIFF
--- a/Source/Extensions/Blazorise.RichTextEdit/wwwroot/richtextedit.js
+++ b/Source/Extensions/Blazorise.RichTextEdit/wwwroot/richtextedit.js
@@ -37,16 +37,6 @@ export function initialize(dotnetAdapter, element, elementId, options) {
         theme: options.theme
     };
 
-    if(options.useTables === true) {
-        Quill.register({ 'modules/table-better': QuillTableBetter }, true);
-        quillOptions.modules['table-better'] = {
-            toolbarTable: true
-        };
-        quillOptions.modules.keyboard = {
-            bindings: QuillTableBetter.keyboardBindings
-        };
-    }
-
     if (options.submitOnEnter === true) {
         quillOptions.modules.keyboard = {
             bindings: {
@@ -65,8 +55,21 @@ export function initialize(dotnetAdapter, element, elementId, options) {
         };
     }
 
-    if (options.useResize) {
+    if (options.useTables === true) {
+        Quill.register({ 'modules/table-better': QuillTableBetter }, true);
+
+        quillOptions.modules['table-better'] = {
+            toolbarTable: true
+        };
+
+        quillOptions.modules.keyboard = {
+            bindings: QuillTableBetter.keyboardBindings
+        };
+    }
+
+    if (options.useResize === true) {
         Quill.register({ 'modules/resize': QuillResize }, true);
+
         quillOptions.modules.resize = {
             tools: [
                 "left",


### PR DESCRIPTION
## Description
This is related to this issue: https://blazorise.com/support/issues/319/recommended-way-to-register-custom-quill-plug-ins

When registering a different table plug-in than table-better (namely "better-table"), the table-better plug-in is still registered. When using a table created from the other table plug-in, the table-better plug-in still creates a dropdown. You then end up with two dropdowns and one of them is not working.
With this fix, the plug-in is only registered when you specify it in the RichText options.

## How Has This Been Tested?
I tested whether the table plug-in and resize plug-in as well as keyboard shortcuts still work on the Material Demo page (http://localhost:14298/tests/richtextedit).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] The PR is submitted to the correct branch (`master` for dev, `rel-1.x` for maintenance).
- [x] My code follows the code style of this project.
~~- [ ] I've added relevant tests.~~ -> Not applicable
