### PR TITLE
Autocomplete: bubble SearchKeyDown without SelectedValuesChanged in c…

### DIFF
--- a/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
+++ b/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
@@ -380,6 +380,12 @@ public partial class Autocomplete<TItem, TValue> : BaseAfterRenderComponent, IAs
                 return;
             }
 
+            if ( SelectionMode == AutocompleteSelectionMode.Checkbox )
+            {
+                await SearchKeyDown.InvokeAsync( eventArgs );
+                return;
+            }
+
             await SelectedOrResetOnCommit();
             await SearchKeyDown.InvokeAsync( eventArgs );
             return;

--- a/Tests/BasicTestApp.Client/AutocompleteCheckboxComponent.razor
+++ b/Tests/BasicTestApp.Client/AutocompleteCheckboxComponent.razor
@@ -1,17 +1,18 @@
 ﻿<Autocomplete TItem="Country"
-                TValue="string"
-                Data="@Countries"
-                TextField="@(( item ) => item.Name)"
-                ValueField="@(( item ) => item.Iso)"
-              @bind-SelectedValues="SelectedValues"
+              TValue="string"
+              Data="@Countries"
+              TextField="@(( item ) => item.Name)"
+              ValueField="@(( item ) => item.Iso)"
+              SelectedValues="SelectedValues"
+              SelectedValuesChanged="OnSelectedValuesChanged"
               @bind-SelectedTexts="SelectedTexts"
-                Placeholder="Search..."
-                FreeTyping
-                SelectionMode="AutocompleteSelectionMode.Checkbox">
+              Placeholder="Search..."
+              FreeTyping
+              SelectionMode="AutocompleteSelectionMode.Checkbox">
     <NotFoundContent> Sorry... @context was not found! :( </NotFoundContent>
 </Autocomplete>
 
-@code{
+@code {
     [Inject]
     public CountryData CountryData { get; set; }
     public IEnumerable<Country> Countries;
@@ -22,8 +23,17 @@
         await base.OnInitializedAsync();
     }
 
+    Task OnSelectedValuesChanged( List<string> newValues )
+    {
+        SelectedValues = newValues;
+        return SelectedValuesChanged.InvokeAsync( SelectedValues );
+    }
+
     [Parameter]
     public List<string> SelectedValues { get; set; }
+
+    [Parameter]
+    public EventCallback<List<string>> SelectedValuesChanged { get; set; }
 
     [Parameter]
     public List<string> SelectedTexts { get; set; }

--- a/Tests/Blazorise.Tests/Components/AutocompleteCheckboxComponentTest.cs
+++ b/Tests/Blazorise.Tests/Components/AutocompleteCheckboxComponentTest.cs
@@ -1,5 +1,6 @@
 ﻿#region Using directives
 
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Bunit;
 using Xunit;
@@ -77,5 +78,26 @@ public class AutocompleteCheckboxComponentTest : AutocompleteMultipleBaseCompone
     public Task RemoveValues_ShouldRemove( string[] startTexts, string[] removeTexts, string[] expectedTexts )
     {
         return TestRemoveValues<AutocompleteCheckboxComponent>( startTexts, removeTexts, expectedTexts );
+    }
+
+    [Fact]
+    public async Task SelectedValuesChanged_ShouldNotTrigger_OnConfirmWhileTyping()
+    {
+        var selectedValuesChanged = 0;
+
+        var comp = RenderComponent<AutocompleteCheckboxComponent>( parameters =>
+        {
+            parameters.Add( x => x.SelectedValues, new List<string> { "PT", "HR" } );
+            parameters.Add( x => x.SelectedValuesChanged, ( List<string> values ) => selectedValuesChanged++ );
+        } );
+
+        var autoComplete = comp.Find( ".b-is-autocomplete input" );
+
+        await autoComplete.FocusAsync( new() );
+        await autoComplete.InputAsync( "A" );
+        await autoComplete.KeyDownAsync( new() { Code = "Enter" } );
+
+        comp.WaitForAssertion( () => Assert.Equal( new[] { "Portugal", "Croatia" }, comp.Instance.SelectedTexts ), TestExtensions.WaitTime );
+        Assert.Equal( 0, selectedValuesChanged );
     }
 }


### PR DESCRIPTION
- Adjusted confirm-key handling in Source/Extensions/Blazorise.Components/Autocomplete.razor.cs so checkbox-mode
  autocompletes no longer toggle selections when Enter is pressed while typing; the confirm key now simply bubbles
  through SearchKeyDown, keeping SelectedValuesChanged tied to actual checkbox toggles.
- Added a regression test in Tests/Blazorise.Tests/Components/AutocompleteCheckboxComponentTest.cs to ensure pressing
  Enter while typing in checkbox mode doesn’t fire SelectedValuesChanged or alter the preselected values.