### PR TITLE
Analyzers: Reduce memory/CPU overhead

### DIFF
--- a/Source/Helpers/Blazorise.Analyzers/Migration/Rules/MemberRenameAnalyzer.cs
+++ b/Source/Helpers/Blazorise.Analyzers/Migration/Rules/MemberRenameAnalyzer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
@@ -9,6 +10,9 @@ namespace Blazorise.Analyzers.Migration.Rules;
 [DiagnosticAnalyzer( LanguageNames.CSharp )]
 public sealed class MemberRenameAnalyzer : DiagnosticAnalyzer
 {
+    private static readonly IReadOnlyDictionary<(string containingType, string oldName), SymbolMapping> Map = CreateMap();
+    private static readonly HashSet<string> CandidateMemberNames = CreateCandidateMemberNames();
+
     private static readonly DiagnosticDescriptor Rule = new(
         id: "BLZS001",
         title: "Blazorise member renamed",
@@ -23,20 +27,8 @@ public sealed class MemberRenameAnalyzer : DiagnosticAnalyzer
     {
         context.ConfigureGeneratedCodeAnalysis( GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics );
         context.EnableConcurrentExecution();
-        context.RegisterCompilationStartAction( Register );
-    }
-
-    private static void Register( CompilationStartAnalysisContext context )
-    {
-        var map = new Dictionary<(string containingType, string oldName), SymbolMapping>();
-        foreach ( var mapping in BlazoriseMigrationMappings.Symbols )
-        {
-            if ( mapping.NewName is not null )
-                map[(mapping.ContainingType, mapping.OldName)] = mapping;
-        }
-
         context.RegisterOperationAction(
-            ctx => Analyze( ctx, map ),
+            ctx => Analyze( ctx, Map, CandidateMemberNames ),
             OperationKind.FieldReference,
             OperationKind.PropertyReference,
             OperationKind.Invocation );
@@ -44,7 +36,8 @@ public sealed class MemberRenameAnalyzer : DiagnosticAnalyzer
 
     private static void Analyze(
         OperationAnalysisContext context,
-        IReadOnlyDictionary<(string containingType, string oldName), SymbolMapping> map )
+        IReadOnlyDictionary<(string containingType, string oldName), SymbolMapping> map,
+        ISet<string> candidateMemberNames )
     {
         ISymbol? member = context.Operation switch
         {
@@ -57,10 +50,13 @@ public sealed class MemberRenameAnalyzer : DiagnosticAnalyzer
         if ( member is null || member.ContainingType is null )
             return;
 
-        var containingMetadata = RenderTreeMigrationEngine.GetMetadataName( member.ContainingType.ConstructedFrom );
-        var key = (containingMetadata, member.Name);
+        if ( !candidateMemberNames.Contains( member.Name ) )
+            return;
 
-        if ( !map.TryGetValue( key, out var mapping ) )
+        string containingMetadata = RenderTreeMigrationEngine.GetMetadataName( member.ContainingType.ConstructedFrom );
+        (string containingType, string oldName) key = (containingMetadata, member.Name);
+
+        if ( !map.TryGetValue( key, out SymbolMapping mapping ) )
             return;
 
         context.ReportDiagnostic( Diagnostic.Create(
@@ -69,6 +65,32 @@ public sealed class MemberRenameAnalyzer : DiagnosticAnalyzer
             mapping.OldName,
             mapping.NewName,
             mapping.ContainingType ) );
+    }
+
+    private static IReadOnlyDictionary<(string containingType, string oldName), SymbolMapping> CreateMap()
+    {
+        Dictionary<(string containingType, string oldName), SymbolMapping> map = new();
+
+        foreach ( SymbolMapping mapping in BlazoriseMigrationMappings.Symbols )
+        {
+            if ( mapping.NewName is not null )
+                map[(mapping.ContainingType, mapping.OldName)] = mapping;
+        }
+
+        return map;
+    }
+
+    private static HashSet<string> CreateCandidateMemberNames()
+    {
+        HashSet<string> names = new( StringComparer.Ordinal );
+
+        foreach ( SymbolMapping mapping in BlazoriseMigrationMappings.Symbols )
+        {
+            if ( mapping.NewName is not null )
+                names.Add( mapping.OldName );
+        }
+
+        return names;
     }
 }
 

--- a/Source/Helpers/Blazorise.Analyzers/Migration/Rules/TypeRemovedAnalyzer.cs
+++ b/Source/Helpers/Blazorise.Analyzers/Migration/Rules/TypeRemovedAnalyzer.cs
@@ -11,6 +11,9 @@ namespace Blazorise.Analyzers.Migration.Rules;
 [DiagnosticAnalyzer( LanguageNames.CSharp )]
 public sealed class TypeRemovedAnalyzer : DiagnosticAnalyzer
 {
+    private static readonly IReadOnlyDictionary<string, TypeMapping> Map = CreateMap();
+    private static readonly HashSet<string> CandidateSimpleNames = CreateCandidateSimpleNames( Map.Keys );
+
     private static readonly DiagnosticDescriptor Rule = new(
         id: "BLZTYP002",
         title: "Blazorise type removed",
@@ -25,28 +28,44 @@ public sealed class TypeRemovedAnalyzer : DiagnosticAnalyzer
     {
         context.ConfigureGeneratedCodeAnalysis( GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics );
         context.EnableConcurrentExecution();
-        context.RegisterCompilationStartAction( Register );
-    }
-
-    private static void Register( CompilationStartAnalysisContext context )
-    {
-        var map = new Dictionary<string, TypeMapping>( StringComparer.Ordinal );
-        foreach ( var mapping in BlazoriseMigrationMappings.Types )
-        {
-            if ( mapping.NewFullName is null )
-                map[mapping.OldFullName] = mapping;
-        }
-
         context.RegisterSyntaxNodeAction(
-            ctx => Analyze( ctx, map ),
+            ctx => Analyze( ctx, Map, CandidateSimpleNames ),
             SyntaxKind.IdentifierName,
             SyntaxKind.GenericName,
             SyntaxKind.QualifiedName );
     }
 
-    private static void Analyze( SyntaxNodeAnalysisContext context, IReadOnlyDictionary<string, TypeMapping> map )
+    private static IReadOnlyDictionary<string, TypeMapping> CreateMap()
     {
-        var node = context.Node;
+        Dictionary<string, TypeMapping> map = new( StringComparer.Ordinal );
+        foreach ( TypeMapping mapping in BlazoriseMigrationMappings.Types )
+        {
+            if ( mapping.NewFullName is null )
+                map[mapping.OldFullName] = mapping;
+        }
+
+        return map;
+    }
+
+    private static HashSet<string> CreateCandidateSimpleNames( IEnumerable<string> fullNames )
+    {
+        HashSet<string> names = new( StringComparer.Ordinal );
+        foreach ( string fullName in fullNames )
+        {
+            string? simpleName = RenderTreeMigrationEngine.GetSimpleName( fullName );
+            if ( simpleName is not null )
+                names.Add( simpleName );
+        }
+
+        return names;
+    }
+
+    private static void Analyze(
+        SyntaxNodeAnalysisContext context,
+        IReadOnlyDictionary<string, TypeMapping> map,
+        ISet<string> candidateSimpleNames )
+    {
+        SyntaxNode node = context.Node;
 
         if ( node is QualifiedNameSyntax qualified && qualified.Right != node )
             return;
@@ -54,18 +73,33 @@ public sealed class TypeRemovedAnalyzer : DiagnosticAnalyzer
         if ( node.Parent is MemberAccessExpressionSyntax )
             return;
 
-        var symbol = context.SemanticModel.GetSymbolInfo( node ).Symbol;
+        if ( !ShouldAnalyzeNode( node, candidateSimpleNames ) )
+            return;
+
+        ISymbol? symbol = context.SemanticModel.GetSymbolInfo( node ).Symbol;
         if ( symbol is not INamedTypeSymbol namedType )
             return;
 
-        var metadataName = RenderTreeMigrationEngine.GetMetadataName( namedType.ConstructedFrom );
+        string metadataName = RenderTreeMigrationEngine.GetMetadataName( namedType.ConstructedFrom );
 
-        if ( !map.TryGetValue( metadataName, out var mapping ) )
+        if ( !map.TryGetValue( metadataName, out TypeMapping mapping ) )
             return;
 
         context.ReportDiagnostic( Diagnostic.Create(
             Rule,
             node.GetLocation(),
             mapping.OldFullName ) );
+    }
+
+    private static bool ShouldAnalyzeNode( SyntaxNode node, ISet<string> candidateSimpleNames )
+    {
+        string? simpleName = node switch
+        {
+            IdentifierNameSyntax identifierName => identifierName.Identifier.ValueText,
+            GenericNameSyntax genericName => genericName.Identifier.ValueText,
+            _ => null,
+        };
+
+        return simpleName is not null && candidateSimpleNames.Contains( simpleName );
     }
 }


### PR DESCRIPTION
Reduce analyzer memory/CPU overhead without changing diagnostics. Shared per‑compilation caches for migration
mappings/type‑inference data, added fast prefilters to skip blocks/nodes that can’t produce findings, and cached
metadata names to avoid repeated symbol formatting. This keeps analyzer behavior intact while cutting redundant
traversals and GetSymbolInfo calls in large Razor‑generated code.
