### PR TITLE
MessageService: fix sizing when showing modal

### DIFF
--- a/Source/Blazorise/Components/MessageProvider/MessageProvider.razor
+++ b/Source/Blazorise/Components/MessageProvider/MessageProvider.razor
@@ -1,6 +1,6 @@
 ﻿@namespace Blazorise
 @inherits BaseComponent
-<Modal @ref="@ModalRef" Closing="@OnModalClosing" Centered="@CenterMessage" Scrollable="@ScrollableMessage" Size="@Size">
+<Modal @ref="@ModalRef" @bind-Visible="@ModalVisible" Closing="@OnModalClosing" Centered="@CenterMessage" Scrollable="@ScrollableMessage" Size="@Size">
     <ModalContent>
         <ModalHeader>
             <ModalTitle Class="@TitleClass">

--- a/Source/Blazorise/Components/MessageProvider/MessageProvider.razor.cs
+++ b/Source/Blazorise/Components/MessageProvider/MessageProvider.razor.cs
@@ -40,13 +40,17 @@ public partial class MessageProvider : BaseComponent, IDisposable
 
     private async void OnMessageReceived( object sender, MessageEventArgs e )
     {
-        MessageType = e.MessageType;
-        Message = e.Message;
-        Title = e.Title;
-        Options = e.Options;
-        Callback = e.Callback;
+        await InvokeAsync( () =>
+        {
+            MessageType = e.MessageType;
+            Message = e.Message;
+            Title = e.Title;
+            Options = e.Options;
+            Callback = e.Callback;
+            ModalVisible = true;
 
-        await InvokeAsync( ModalRef.Show );
+            StateHasChanged();
+        } );
     }
 
     /// <summary>
@@ -141,6 +145,11 @@ public partial class MessageProvider : BaseComponent, IDisposable
     /// Gets or sets the <see cref="Modal"/> reference.
     /// </summary>
     protected Modal ModalRef { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the message modal is visible.
+    /// </summary>
+    protected bool ModalVisible { get; set; }
 
     /// <summary>
     /// If true, modal will act as a prompt dialog.

--- a/Tests/Blazorise.Tests/Components/MessageProviderComponentTest.cs
+++ b/Tests/Blazorise.Tests/Components/MessageProviderComponentTest.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Threading.Tasks;
+using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Blazorise.Tests.Components;
+
+public class MessageProviderComponentTest : TestContext
+{
+    public MessageProviderComponentTest()
+    {
+        Services.AddBlazoriseTests().AddBootstrapProviders().AddEmptyIconProvider();
+        JSInterop
+            .AddBlazoriseButton()
+            .AddBlazoriseModal()
+            .AddBlazoriseClosable();
+    }
+
+    [Fact]
+    public async Task InfoAppliesRequestedSizeBeforeOpening()
+    {
+        var component = RenderComponent<MessageProvider>();
+
+        await ShowInfoMessage( component, options => options.Size = ModalSize.Large );
+
+        component.WaitForAssertion( () => Assert.Contains( "modal-lg", component.Find( ".modal-dialog" ).ClassName ) );
+    }
+
+    [Fact]
+    public async Task InfoDoesNotReusePreviousSize()
+    {
+        var component = RenderComponent<MessageProvider>();
+
+        await ShowInfoMessage( component, options => options.Size = ModalSize.Large );
+        component.WaitForAssertion( () => Assert.Contains( "modal-lg", component.Find( ".modal-dialog" ).ClassName ) );
+
+        await component.Find( "button" ).ClickAsync();
+
+        await ShowInfoMessage( component );
+
+        component.WaitForAssertion( () => Assert.DoesNotContain( "modal-lg", component.Find( ".modal-dialog" ).ClassName ) );
+    }
+
+    private Task ShowInfoMessage( IRenderedComponent<MessageProvider> component, Action<MessageOptions> options = null )
+    {
+        var messageService = Services.GetRequiredService<IMessageService>();
+
+        return component.InvokeAsync( () => messageService.Info( "Message", "Title", options ) );
+    }
+}


### PR DESCRIPTION
Closes #6529

MessageProvider updated its own Options state, then immediately called ModalRef.Show(). That caused the
Modal component to render itself before its Size parameter was refreshed by the parent render. Message text/icon
worked because they were captured from the provider render fragment, but modal parameters like Size were still the
previous value.

**Test:**

```
@inject IMessageService MessageService

<Button Color="Color.Primary" Clicked="@OnLargeClicked">Size Large</Button>
<Button Color="Color.Primary" Clicked="@OnDefaultClicked">Size Default</Button>

@code {

    Task OnLargeClicked()
    {
        return MessageService.Info("Large", "Size", (o) => o.Size = ModalSize.Large);
    }

    Task OnDefaultClicked()
    {
        return MessageService.Info("Default", "Size");
    }
}
```