### PR TITLE
Accesibility: improve FocusTrap and MessageProvider

### DIFF
--- a/Source/Blazorise/Components/FocusTrap/FocusTrap.razor
+++ b/Source/Blazorise/Components/FocusTrap/FocusTrap.razor
@@ -1,11 +1,7 @@
 ﻿@namespace Blazorise
 @inherits BaseFocusableContainerComponent
 <CascadingValue Value="@this" IsFixed>
-    <div @ref="@ElementRef" id="@ElementId" class="@ClassNames" style="@StyleNames" @onkeydown="@OnKeyPressedHandler" @onkeyup="@OnKeyPressedHandler" tabindex="-1" @attributes="@Attributes">
-        <div tabindex="@FocusableTabIndex" @ref="@startSecondRef" @onfocus="@OnFocusEndHandler"></div>
-        <div tabindex="@FocusableTabIndex" @ref="@startFirstRef" @onfocus="@OnFocusEndHandler"></div>
+    <div @ref="@ElementRef" id="@ElementId" class="@ClassNames" style="@StyleNames" tabindex="-1" @attributes="@Attributes">
         @ChildContent
-        <div tabindex="@FocusableTabIndex" @ref="@endFirstRef" @onfocus="@OnFocusStartHandler"></div>
-        <div tabindex="@FocusableTabIndex" @ref="@endSecondRef" @onfocus="@OnFocusStartHandler"></div>
     </div>
 </CascadingValue>

--- a/Source/Blazorise/Components/FocusTrap/FocusTrap.razor.cs
+++ b/Source/Blazorise/Components/FocusTrap/FocusTrap.razor.cs
@@ -1,8 +1,8 @@
 #region Using directives
 using System.Threading.Tasks;
+using Blazorise.Modules;
 using Blazorise.Utilities;
 using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Web;
 #endregion
 
 namespace Blazorise;
@@ -14,17 +14,7 @@ public partial class FocusTrap : BaseFocusableContainerComponent
 {
     #region Members
 
-    private ElementReference startFirstRef;
-
-    private ElementReference startSecondRef;
-
-    private ElementReference endFirstRef;
-
-    private ElementReference endSecondRef;
-
-    private bool shiftTabPressed;
-
-    private bool shouldRender = true;
+    private bool jsInitialized;
 
     #endregion
 
@@ -33,9 +23,16 @@ public partial class FocusTrap : BaseFocusableContainerComponent
     /// <inheritdoc/>
     public override async Task SetParametersAsync( ParameterView parameters )
     {
-        if ( Rendered && parameters.TryGetValue<bool>( nameof( Active ), out var activeParam ) && Active != activeParam && activeParam )
+        if ( Rendered && parameters.TryGetValue<bool>( nameof( Active ), out var activeParam ) && Active != activeParam )
         {
-            ExecuteAfterRender( SetFocus );
+            if ( activeParam )
+            {
+                ExecuteAfterRender( InitializeAndSetFocus );
+            }
+            else
+            {
+                ExecuteAfterRender( DestroyFocusTrap );
+            }
         }
 
         await base.SetParametersAsync( parameters );
@@ -46,10 +43,21 @@ public partial class FocusTrap : BaseFocusableContainerComponent
     {
         if ( firstRender && Active )
         {
-            ExecuteAfterRender( SetFocus );
+            ExecuteAfterRender( InitializeAndSetFocus );
         }
 
         return base.OnAfterRenderAsync( firstRender );
+    }
+
+    /// <inheritdoc/>
+    protected override async ValueTask DisposeAsync( bool disposing )
+    {
+        if ( disposing && Rendered )
+        {
+            await DestroyFocusTrap();
+        }
+
+        await base.DisposeAsync( disposing );
     }
 
     /// <inheritdoc/>
@@ -69,62 +77,52 @@ public partial class FocusTrap : BaseFocusableContainerComponent
         if ( Rendered )
         {
             if ( HasFocusableComponents )
+            {
                 await HandleFocusableComponent();
+            }
             else
-                await startFirstRef.FocusAsync();
+            {
+                await JSFocusTrapModule.Focus( ElementRef, ElementId );
+            }
         }
     }
 
     /// <summary>
-    /// Handles the focus start event.
+    /// Initializes the focus trap and sets focus to the first focusable child.
     /// </summary>
-    /// <param name="args">Supplies information about a focus event that is being raised.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
-    protected virtual async Task OnFocusStartHandler( FocusEventArgs args )
+    private async Task InitializeAndSetFocus()
     {
-        if ( !shiftTabPressed )
+        await InitializeFocusTrap();
+        await SetFocus();
+    }
+
+    /// <summary>
+    /// Initializes the JavaScript focus trap handler.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    private async Task InitializeFocusTrap()
+    {
+        if ( !jsInitialized )
         {
-            await startFirstRef.FocusAsync();
+            jsInitialized = true;
+
+            await JSFocusTrapModule.Initialize( ElementRef, ElementId );
         }
     }
 
     /// <summary>
-    /// Handles the focus end event.
+    /// Destroys the JavaScript focus trap handler.
     /// </summary>
-    /// <param name="args">Supplies information about a focus event that is being raised.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
-    protected virtual async Task OnFocusEndHandler( FocusEventArgs args )
+    private async Task DestroyFocusTrap()
     {
-        if ( shiftTabPressed )
+        if ( jsInitialized )
         {
-            await endFirstRef.FocusAsync();
+            jsInitialized = false;
+
+            await JSFocusTrapModule.Destroy( ElementRef, ElementId );
         }
-    }
-
-    /// <summary>
-    /// Handles the keyboard events.
-    /// </summary>
-    /// <param name="args">Supplies information about a keyboard event that is being raised.</param>
-    /// <returns>A task that represents the asynchronous operation.</returns>
-    protected virtual void OnKeyPressedHandler( KeyboardEventArgs args )
-    {
-        shouldRender = false;
-
-        if ( args.Key == "Tab" )
-        {
-            shiftTabPressed = args.ShiftKey;
-        }
-    }
-
-    /// <inheritdoc/>
-    protected override bool ShouldRender()
-    {
-        if ( shouldRender )
-            return true;
-
-        shouldRender = true;
-
-        return false;
     }
 
     #endregion
@@ -132,9 +130,9 @@ public partial class FocusTrap : BaseFocusableContainerComponent
     #region Properties
 
     /// <summary>
-    /// Gets the focusable element tab index.
+    /// Specifies the <see cref="IJSFocusTrapModule"/> instance.
     /// </summary>
-    protected int FocusableTabIndex => Active ? 0 : -1;
+    [Inject] protected IJSFocusTrapModule JSFocusTrapModule { get; set; }
 
     /// <summary>
     /// If true the TAB focus will be activated.

--- a/Source/Blazorise/Components/MessageProvider/MessageProvider.razor.cs
+++ b/Source/Blazorise/Components/MessageProvider/MessageProvider.razor.cs
@@ -95,13 +95,7 @@ public partial class MessageProvider : BaseComponent, IDisposable
         return InvokeAsync( async () =>
         {
             await ModalRef.Hide();
-
-            if ( IsConfirmation && Callback is not null && !Callback.Task.IsCompleted )
-            {
-                await InvokeAsync( () => Callback.SetResult( false ) );
-            }
-
-            await Canceled.InvokeAsync();
+            await NotifyCanceled();
         } );
     }
 
@@ -129,12 +123,38 @@ public partial class MessageProvider : BaseComponent, IDisposable
     /// Handles the <see cref="Modal"/> closing event.
     /// </summary>
     /// <param name="eventArgs">Provides the data for the modal closing event.</param>
-    protected virtual Task OnModalClosing( ModalClosingEventArgs eventArgs )
+    protected virtual async Task OnModalClosing( ModalClosingEventArgs eventArgs )
     {
-        eventArgs.Cancel = ( Options?.BackgroundCancel ?? BackgroundCancel )
-            && ( eventArgs.CloseReason == CloseReason.EscapeClosing || eventArgs.CloseReason == CloseReason.FocusLostClosing );
+        var isEscapeClosing = eventArgs.CloseReason == CloseReason.EscapeClosing;
+        var isFocusLostClosing = eventArgs.CloseReason == CloseReason.FocusLostClosing;
 
-        return Task.CompletedTask;
+        if ( isEscapeClosing && ( Options?.CloseOnEscape ?? CloseOnEscape ) )
+        {
+            await NotifyCanceled();
+
+            return;
+        }
+
+        eventArgs.Cancel = ( Options?.BackgroundCancel ?? BackgroundCancel )
+            && ( isEscapeClosing || isFocusLostClosing );
+    }
+
+    /// <summary>
+    /// Notifies that the message dialog was canceled.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    private async Task NotifyCanceled()
+    {
+        if ( IsConfirmation && Callback is not null && !Callback.Task.IsCompleted )
+        {
+            await InvokeAsync( () => Callback.SetResult( false ) );
+        }
+        else if ( IsChoice && Callback is not null && !Callback.Task.IsCompleted )
+        {
+            await InvokeAsync( () => Callback.SetResult( null ) );
+        }
+
+        await Canceled.InvokeAsync();
     }
 
     #endregion
@@ -369,6 +389,12 @@ public partial class MessageProvider : BaseComponent, IDisposable
     /// This behavior can be disabled by setting <see cref="BackgroundCancel"/> to false.
     /// </summary>
     [Parameter] public bool BackgroundCancel { get; set; } = true;
+
+    /// <summary>
+    /// If true, the message dialog will be closed when the user presses the Escape key.
+    /// Confirmation dialogs will treat Escape as a cancel action.
+    /// </summary>
+    [Parameter] public bool CloseOnEscape { get; set; }
 
     #endregion
 }

--- a/Source/Blazorise/Config.cs
+++ b/Source/Blazorise/Config.cs
@@ -104,6 +104,7 @@ public static class Config
     public static IDictionary<Type, Type> JSModuleMap => new Dictionary<Type, Type>
     {
         { typeof( IJSUtilitiesModule ), typeof( JSUtilitiesModule ) },
+        { typeof( IJSFocusTrapModule ), typeof( JSFocusTrapModule ) },
         { typeof( IJSButtonModule ), typeof( JSButtonModule ) },
         { typeof( IJSClosableModule ), typeof( JSClosableModule ) },
         { typeof( IJSBreakpointModule ), typeof( JSBreakpointModule ) },

--- a/Source/Blazorise/Interfaces/Modules/IJSFocusTrapModule.cs
+++ b/Source/Blazorise/Interfaces/Modules/IJSFocusTrapModule.cs
@@ -1,0 +1,26 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+
+namespace Blazorise.Modules;
+
+/// <summary>
+/// Contracts for the focus trap JS module.
+/// </summary>
+public interface IJSFocusTrapModule : IBaseJSModule, IJSDestroyableModule
+{
+    /// <summary>
+    /// Initializes the focus trap.
+    /// </summary>
+    /// <param name="elementRef">Reference to the rendered element.</param>
+    /// <param name="elementId">ID of the rendered element.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    ValueTask Initialize( ElementReference elementRef, string elementId );
+
+    /// <summary>
+    /// Focuses the first focusable element inside the focus trap.
+    /// </summary>
+    /// <param name="elementRef">Reference to the rendered element.</param>
+    /// <param name="elementId">ID of the rendered element.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    ValueTask Focus( ElementReference elementRef, string elementId );
+}

--- a/Source/Blazorise/Models/MessageOptions.cs
+++ b/Source/Blazorise/Models/MessageOptions.cs
@@ -156,6 +156,12 @@ public class MessageOptions
     public bool? BackgroundCancel { get; set; }
 
     /// <summary>
+    /// If defined the message dialog will be closed when the user presses the Escape key.
+    /// Confirmation dialogs will treat Escape as a cancel action.
+    /// </summary>
+    public bool? CloseOnEscape { get; set; }
+
+    /// <summary>
     /// Creates the default message options.
     /// </summary>
     /// <returns>Default message options.</returns>

--- a/Source/Blazorise/Modules/JSFocusTrapModule.cs
+++ b/Source/Blazorise/Modules/JSFocusTrapModule.cs
@@ -1,0 +1,51 @@
+#region Using directives
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
+#endregion
+
+namespace Blazorise.Modules;
+
+/// <summary>
+/// Default implementation of the focus trap JS module.
+/// </summary>
+public class JSFocusTrapModule : BaseJSModule, IJSFocusTrapModule
+{
+    #region Constructors
+
+    /// <summary>
+    /// Default module constructor.
+    /// </summary>
+    /// <param name="jsRuntime">JavaScript runtime instance.</param>
+    /// <param name="versionProvider">Version provider.</param>
+    /// <param name="options">Blazorise options.</param>
+    public JSFocusTrapModule( IJSRuntime jsRuntime, IVersionProvider versionProvider, BlazoriseOptions options )
+        : base( jsRuntime, versionProvider, options )
+    {
+    }
+
+    #endregion
+
+    #region Methods
+
+    /// <inheritdoc/>
+    public virtual ValueTask Initialize( ElementReference elementRef, string elementId )
+        => InvokeSafeVoidAsync( "initialize", elementRef, elementId );
+
+    /// <inheritdoc/>
+    public virtual ValueTask Destroy( ElementReference elementRef, string elementId )
+        => InvokeSafeVoidAsync( "destroy", elementRef, elementId );
+
+    /// <inheritdoc/>
+    public virtual ValueTask Focus( ElementReference elementRef, string elementId )
+        => InvokeSafeVoidAsync( "focus", elementRef, elementId );
+
+    #endregion
+
+    #region Properties
+
+    /// <inheritdoc/>
+    public override string ModuleFileName => $"./_content/Blazorise/focusTrap.js?v={VersionProvider.Version}";
+
+    #endregion
+}

--- a/Source/Blazorise/wwwroot/focusTrap.js
+++ b/Source/Blazorise/wwwroot/focusTrap.js
@@ -1,0 +1,137 @@
+const focusTrapHandlers = new WeakMap();
+
+const focusableSelector = [
+    "a[href]",
+    "area[href]",
+    "button:not([disabled])",
+    "input:not([disabled]):not([type='hidden'])",
+    "select:not([disabled])",
+    "textarea:not([disabled])",
+    "iframe",
+    "object",
+    "embed",
+    "audio[controls]",
+    "video[controls]",
+    "summary",
+    "[contenteditable]:not([contenteditable='false'])",
+    "[tabindex]:not([tabindex='-1'])"
+].join(",");
+
+export function initialize(element, elementId) {
+    element = resolveElement(element, elementId);
+
+    if (!element) {
+        return;
+    }
+
+    destroy(element, elementId);
+
+    const keydownHandler = (event) => {
+        if (event.key !== "Tab" || event.defaultPrevented) {
+            return;
+        }
+
+        const focusableElements = getFocusableElements(element);
+
+        if (focusableElements.length === 0) {
+            event.preventDefault();
+            focusElement(element);
+            return;
+        }
+
+        const firstFocusable = focusableElements[0];
+        const lastFocusable = focusableElements[focusableElements.length - 1];
+        const activeElement = element.ownerDocument.activeElement;
+
+        if (!element.contains(activeElement)) {
+            event.preventDefault();
+            focusElement(event.shiftKey ? lastFocusable : firstFocusable);
+        } else if (event.shiftKey && activeElement === firstFocusable) {
+            event.preventDefault();
+            focusElement(lastFocusable);
+        } else if (!event.shiftKey && activeElement === lastFocusable) {
+            event.preventDefault();
+            focusElement(firstFocusable);
+        }
+    };
+
+    element.addEventListener("keydown", keydownHandler);
+    focusTrapHandlers.set(element, keydownHandler);
+}
+
+export function destroy(element, elementId) {
+    element = resolveElement(element, elementId);
+
+    if (!element) {
+        return;
+    }
+
+    const keydownHandler = focusTrapHandlers.get(element);
+
+    if (keydownHandler) {
+        element.removeEventListener("keydown", keydownHandler);
+        focusTrapHandlers.delete(element);
+    }
+}
+
+export function focus(element, elementId) {
+    element = resolveElement(element, elementId);
+
+    if (!element) {
+        return;
+    }
+
+    const focusableElements = getFocusableElements(element);
+    focusElement(focusableElements[0] || element);
+}
+
+function getFocusableElements(element) {
+    return Array.from(element.querySelectorAll(focusableSelector))
+        .filter(isFocusable)
+        .map((focusableElement, index) => ({
+            element: focusableElement,
+            index,
+            tabIndex: focusableElement.tabIndex
+        }))
+        .sort(compareTabOrder)
+        .map((entry) => entry.element);
+}
+
+function compareTabOrder(left, right) {
+    const leftPositive = left.tabIndex > 0;
+    const rightPositive = right.tabIndex > 0;
+
+    if (leftPositive && rightPositive && left.tabIndex !== right.tabIndex) {
+        return left.tabIndex - right.tabIndex;
+    }
+
+    if (leftPositive !== rightPositive) {
+        return leftPositive ? -1 : 1;
+    }
+
+    return left.index - right.index;
+}
+
+function isFocusable(element) {
+    if (!element || element.closest("[inert]") || element.getAttribute("aria-hidden") === "true") {
+        return false;
+    }
+
+    const style = window.getComputedStyle(element);
+
+    if (style.visibility === "hidden" || style.display === "none") {
+        return false;
+    }
+
+    return element.tabIndex >= 0 && element.getClientRects().length > 0;
+}
+
+function focusElement(element) {
+    if (element && typeof element.focus === "function") {
+        element.focus({ preventScroll: true });
+    }
+}
+
+function resolveElement(element, elementId) {
+    return element || document.getElementById(elementId);
+}

--- a/Source/Blazorise/wwwroot/focusTrap.js
+++ b/Source/Blazorise/wwwroot/focusTrap.js
@@ -86,8 +86,10 @@ export function focus(element, elementId) {
 }
 
 function getFocusableElements(element) {
-    return Array.from(element.querySelectorAll(focusableSelector))
-        .filter(isFocusable)
+    const focusableElements = Array.from(element.querySelectorAll(focusableSelector));
+
+    return focusableElements
+        .filter((focusableElement) => isFocusable(focusableElement, focusableElements))
         .map((focusableElement, index) => ({
             element: focusableElement,
             index,
@@ -112,8 +114,12 @@ function compareTabOrder(left, right) {
     return left.index - right.index;
 }
 
-function isFocusable(element) {
-    if (!element || element.closest("[inert]") || element.getAttribute("aria-hidden") === "true") {
+function isFocusable(element, focusableElements) {
+    if (!element
+        || element.closest("[inert]")
+        || hasHiddenAncestor(element)
+        || isDisabled(element)
+        || !isTabbableRadio(element, focusableElements)) {
         return false;
     }
 
@@ -124,6 +130,64 @@ function isFocusable(element) {
     }
 
     return element.tabIndex >= 0 && element.getClientRects().length > 0;
+}
+
+function hasHiddenAncestor(element) {
+    for (let current = element; current; current = current.parentElement) {
+        if (current.getAttribute("aria-hidden")?.toLowerCase() === "true") {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+function isDisabled(element) {
+    if (element.disabled) {
+        return true;
+    }
+
+    const disabledFieldset = element.closest("fieldset[disabled]");
+
+    if (disabledFieldset) {
+        const firstLegend = Array.from(disabledFieldset.children).find((child) => child.tagName === "LEGEND");
+
+        if (!firstLegend || !firstLegend.contains(element)) {
+            return true;
+        }
+    }
+
+    const closedDetails = element.closest("details:not([open])");
+
+    if (closedDetails) {
+        const firstSummary = Array.from(closedDetails.children).find((child) => child.tagName === "SUMMARY");
+
+        if (!firstSummary || !firstSummary.contains(element)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+function isTabbableRadio(element, focusableElements) {
+    if (element.tagName !== "INPUT" || element.type !== "radio" || !element.name) {
+        return true;
+    }
+
+    const radioGroup = focusableElements.filter((focusableElement) =>
+        focusableElement.tagName === "INPUT"
+        && focusableElement.type === "radio"
+        && focusableElement.name === element.name
+        && focusableElement.form === element.form);
+
+    const checkedRadio = radioGroup.find((radio) => radio.checked);
+
+    if (checkedRadio) {
+        return checkedRadio === element;
+    }
+
+    return radioGroup[0] === element;
 }
 
 function focusElement(element) {

--- a/Source/Helpers/Blazorise.Tests.bUnit/Configuration.cs
+++ b/Source/Helpers/Blazorise.Tests.bUnit/Configuration.cs
@@ -46,6 +46,7 @@ public static class Configuration
         services.AddSingleton( sp => new BlazoriseOptions( sp, ( options ) => { } ) );
 
         services.AddScoped<IJSUtilitiesModule, JSUtilitiesModule>();
+        services.AddScoped<IJSFocusTrapModule, JSFocusTrapModule>();
         services.AddScoped<IJSButtonModule, JSButtonModule>();
         services.AddScoped<IJSClosableModule, JSClosableModule>();
         services.AddScoped<IJSBreakpointModule, JSBreakpointModule>();

--- a/Source/Helpers/Blazorise.Tests.bUnit/JSInterop.cs
+++ b/Source/Helpers/Blazorise.Tests.bUnit/JSInterop.cs
@@ -26,6 +26,19 @@ public static class JSInterop
         return jsInterop;
     }
 
+    public static BunitJSInterop AddBlazoriseFocusTrap( this BunitJSInterop jsInterop )
+    {
+        AddBlazoriseUtilities( jsInterop );
+
+        var module = jsInterop.SetupModule( new JSFocusTrapModule( jsInterop.JSRuntime, new MockVersionProvider(), new( null, ( Options ) => { } ) ).ModuleFileName );
+        module.SetupVoid( "import", _ => true ).SetVoidResult();
+        module.SetupVoid( "initialize", _ => true ).SetVoidResult();
+        module.SetupVoid( "destroy", _ => true ).SetVoidResult();
+        module.SetupVoid( "focus", _ => true ).SetVoidResult();
+
+        return jsInterop;
+    }
+
     public static BunitJSInterop AddBlazoriseBreakpoint( this BunitJSInterop jsInterop )
     {
         AddBlazoriseUtilities( jsInterop );
@@ -231,6 +244,7 @@ public static class JSInterop
     public static BunitJSInterop AddBlazoriseModal( this BunitJSInterop jsInterop )
     {
         AddBlazoriseUtilities( jsInterop );
+        AddBlazoriseFocusTrap( jsInterop );
 
         var module = jsInterop.SetupModule( new MockJsModalModule( jsInterop.JSRuntime, new MockVersionProvider(), new( null, ( Options ) => { } ) ).ModuleFileName );
         module.SetupVoid( "import", _ => true ).SetVoidResult();

--- a/Tests/Blazorise.Tests/Components/FocusTrapComponentTest.cs
+++ b/Tests/Blazorise.Tests/Components/FocusTrapComponentTest.cs
@@ -1,0 +1,35 @@
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using Xunit;
+
+namespace Blazorise.Tests.Components;
+
+public class FocusTrapComponentTest : BunitContext
+{
+    public FocusTrapComponentTest()
+    {
+        Services.AddBlazoriseTests().AddBootstrapProviders().AddEmptyIconProvider();
+        JSInterop
+            .AddBlazoriseButton()
+            .AddBlazoriseFocusTrap();
+    }
+
+    [Fact]
+    public void ActiveFocusTrapDoesNotRenderFocusableSentinels()
+    {
+        var component = Render( builder =>
+        {
+            builder.OpenComponent<FocusTrap>( 0 );
+            builder.AddAttribute( 1, nameof( FocusTrap.Active ), true );
+            builder.AddAttribute( 2, nameof( FocusTrap.ChildContent ), (RenderFragment)( childBuilder =>
+            {
+                childBuilder.OpenComponent<Button>( 0 );
+                childBuilder.AddAttribute( 1, nameof( Button.ChildContent ), (RenderFragment)( buttonBuilder => buttonBuilder.AddContent( 0, "OK" ) ) );
+                childBuilder.CloseComponent();
+            } ) );
+            builder.CloseComponent();
+        } );
+
+        Assert.Empty( component.FindAll( "div[tabindex='0']" ) );
+    }
+}

--- a/Tests/Blazorise.Tests/Components/MessageProviderComponentTest.cs
+++ b/Tests/Blazorise.Tests/Components/MessageProviderComponentTest.cs
@@ -42,10 +42,38 @@ public class MessageProviderComponentTest : BunitContext
         component.WaitForAssertion( () => Assert.DoesNotContain( "modal-lg", component.Find( ".modal-dialog" ).ClassName ) );
     }
 
+    [Fact]
+    public async Task ConfirmCloseOnEscapeCompletesAsCanceled()
+    {
+        var component = Render<TestMessageProvider>();
+        var messageService = Services.GetRequiredService<IMessageService>();
+        Task<bool> confirmTask = null;
+
+        await component.InvokeAsync( () =>
+        {
+            confirmTask = messageService.Confirm( "Message", "Title", options => options.CloseOnEscape = true );
+
+            return Task.CompletedTask;
+        } );
+
+        Assert.NotNull( confirmTask );
+        component.WaitForAssertion( () => Assert.Contains( "Message", component.Markup ) );
+
+        await component.InvokeAsync( () => component.Instance.InvokeModalClosing( new( false, CloseReason.EscapeClosing ) ) );
+
+        Assert.False( await confirmTask );
+    }
+
     private Task ShowInfoMessage( IRenderedComponent<MessageProvider> component, Action<MessageOptions> options = null )
     {
         var messageService = Services.GetRequiredService<IMessageService>();
 
         return component.InvokeAsync( () => messageService.Info( "Message", "Title", options ) );
+    }
+
+    private class TestMessageProvider : MessageProvider
+    {
+        public Task InvokeModalClosing( ModalClosingEventArgs eventArgs )
+            => OnModalClosing( eventArgs );
     }
 }


### PR DESCRIPTION
Closes #6575 

Implemented keyboard accessibility fixes for `MessageService` modals. 

`FocusTrap` no longer renders empty focusable sentinel `divs`; it now uses a provider-agnostic JS focus trap that cycles through real tabbable DOM elements and handles hidden, disabled, details, and radio-group edge cases. `MessageProvider` now supports `MessageOptions.CloseOnEscape`, treating Escape as Cancel for confirmations.