### PR TITLE
SvgChart: improve point colors and null-safe data handling

### DIFF
--- a/Documentation/Blazorise.Docs/Models/Snippets.generated.cs
+++ b/Documentation/Blazorise.Docs/Models/Snippets.generated.cs
@@ -15508,6 +15508,63 @@ builder.Services
     }
 }";
 
+        public const string SvgBarChartPointColorsExample = @"<SvgBarChart TItem=""TaskState""
+             Items=""@states""
+             Options=""@options"">
+    <SvgChartTooltip Enabled=""false"" />
+    <SvgChartCategoryAxis Value=""@( item => item.Name )"" />
+    <SvgChartValueAxis BeginAtZero
+                       TickCount=""5""
+                       LabelsOptions=""@( new SvgChartAxisLabelsOptions { Visible = false } )"" />
+    <SvgChartDataLabels Visible
+                        Position=""SvgChartDataLabelPosition.End""
+                        BackgroundColor='@((Color)""#ffffff"")'
+                        Border=""@( new SvgChartBorderOptions { Color = Color.Primary, Width = 1, Radius = 4 } )"" />
+
+    <SvgBarSeries Value=""@( item => item.Value )""
+                  Colors=""@stateColors""
+                  BorderRadius=""4"" />
+</SvgBarChart>
+
+@code {
+    private readonly SvgChartOptions options = new()
+    {
+        Height = 150,
+        PlotAreaPadding = new()
+        {
+            Top = 8,
+            End = 12,
+            Bottom = 8,
+        },
+        Legend = new() { Visible = false },
+        Title = new() { Visible = false },
+        Subtitle = new() { Visible = false },
+    };
+
+    private readonly IReadOnlyList<Color> stateColors =
+    [
+        Color.Secondary,
+        Color.Info,
+        Color.Success,
+        Color.Danger,
+    ];
+
+    private readonly List<TaskState> states =
+    [
+        new() { Name = ""Disabled"", Value = 10 },
+        new() { Name = ""Active"", Value = 18 },
+        new() { Name = ""Completed"", Value = 33 },
+        new() { Name = ""Deleted"", Value = 4 },
+    ];
+
+    private sealed class TaskState
+    {
+        public string Name { get; set; }
+
+        public double Value { get; set; }
+    }
+}";
+
         public const string SvgBubbleChartExample = @"<SvgBubbleChart TItem=""StoreVolume""
                 Items=""@stores""
                 Options=""@options"">

--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/SvgChart/Code/SvgBarChartPointColorsExampleCode.html
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/SvgChart/Code/SvgBarChartPointColorsExampleCode.html
@@ -1,0 +1,61 @@
+<div class="blazorise-codeblock">
+<div class="html"><pre>
+<span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">SvgBarChart</span> <span class="htmlAttributeName">TItem</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">TaskState</span><span class="quot">&quot;</span>
+             <span class="htmlAttributeName">Items</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="sharpVariable"><span class="atSign">&#64;</span>states</span><span class="quot">&quot;</span>
+             <span class="htmlAttributeName">Options</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="sharpVariable"><span class="atSign">&#64;</span>options</span><span class="quot">&quot;</span><span class="htmlTagDelimiter">&gt;</span>
+    <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">SvgChartTooltip</span> <span class="htmlAttributeName">Enabled</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="keyword">false</span><span class="quot">&quot;</span> <span class="htmlTagDelimiter">/&gt;</span>
+    <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">SvgChartCategoryAxis</span> <span class="htmlAttributeName">Value</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue"><span class="atSign">&#64;</span>( item =&gt; item.Name )</span><span class="quot">&quot;</span> <span class="htmlTagDelimiter">/&gt;</span>
+    <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">SvgChartValueAxis</span> <span class="htmlAttributeName">BeginAtZero</span>
+                       <span class="htmlAttributeName">TickCount</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">5</span><span class="quot">&quot;</span>
+                       <span class="htmlAttributeName">LabelsOptions</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue"><span class="atSign">&#64;</span>( new SvgChartAxisLabelsOptions { Visible = false } )</span><span class="quot">&quot;</span> <span class="htmlTagDelimiter">/&gt;</span>
+    <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">SvgChartDataLabels</span> <span class="htmlAttributeName">Visible</span>
+                        <span class="htmlAttributeName">Position</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="enum">SvgChartDataLabelPosition</span><span class="enumValue">.End</span><span class="quot">&quot;</span>
+                        <span class="htmlAttributeName">BackgroundColor</span><span class="htmlOperator">=</span><span class="htmlAttributeValue">&#39;<span class="atSign">&#64;</span>((Color)&quot;#ffffff&quot;)&#39;</span>
+                        <span class="htmlAttributeName">Border</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue"><span class="atSign">&#64;</span>( new SvgChartBorderOptions { Color = Color.Primary, Width = 1, Radius = 4 } )</span><span class="quot">&quot;</span> <span class="htmlTagDelimiter">/&gt;</span>
+
+    <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">SvgBarSeries</span> <span class="htmlAttributeName">Value</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue"><span class="atSign">&#64;</span>( item =&gt; item.Value )</span><span class="quot">&quot;</span>
+                  <span class="htmlAttributeName">Colors</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="sharpVariable"><span class="atSign">&#64;</span>stateColors</span><span class="quot">&quot;</span>
+                  <span class="htmlAttributeName">BorderRadius</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">4</span><span class="quot">&quot;</span> <span class="htmlTagDelimiter">/&gt;</span>
+<span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">SvgBarChart</span><span class="htmlTagDelimiter">&gt;</span>
+</pre></div>
+<div class="csharp"><pre>
+<span class="atSign">&#64;</span>code {
+    <span class="keyword">private</span> <span class="keyword">readonly</span> SvgChartOptions options = <span class="keyword">new</span>()
+    {
+        Height = <span class="number">150</span>,
+        PlotAreaPadding = <span class="keyword">new</span>()
+        {
+            Top = <span class="number">8</span>,
+            End = <span class="number">12</span>,
+            Bottom = <span class="number">8</span>,
+        },
+        Legend = <span class="keyword">new</span>() { Visible = <span class="keyword">false</span> },
+        Title = <span class="keyword">new</span>() { Visible = <span class="keyword">false</span> },
+        Subtitle = <span class="keyword">new</span>() { Visible = <span class="keyword">false</span> },
+    };
+
+    <span class="keyword">private</span> <span class="keyword">readonly</span> IReadOnlyList&lt;Color&gt; stateColors =
+    [
+        Color.Secondary,
+        Color.Info,
+        Color.Success,
+        Color.Danger,
+    ];
+
+    <span class="keyword">private</span> <span class="keyword">readonly</span> List&lt;TaskState&gt; states =
+    [
+        <span class="keyword">new</span>() { Name = <span class="string">&quot;Disabled&quot;</span>, Value = <span class="number">10</span> },
+        <span class="keyword">new</span>() { Name = <span class="string">&quot;Active&quot;</span>, Value = <span class="number">18</span> },
+        <span class="keyword">new</span>() { Name = <span class="string">&quot;Completed&quot;</span>, Value = <span class="number">33</span> },
+        <span class="keyword">new</span>() { Name = <span class="string">&quot;Deleted&quot;</span>, Value = <span class="number">4</span> },
+    ];
+
+    <span class="keyword">private</span> <span class="keyword">sealed</span> <span class="keyword">class</span> TaskState
+    {
+        <span class="keyword">public</span> <span class="keyword">string</span> Name { <span class="keyword">get</span>; <span class="keyword">set</span>; }
+
+        <span class="keyword">public</span> <span class="keyword">double</span> Value { <span class="keyword">get</span>; <span class="keyword">set</span>; }
+    }
+}
+</pre></div>
+</div>

--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/SvgChart/Examples/SvgBarChartPointColorsExample.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/SvgChart/Examples/SvgBarChartPointColorsExample.razor
@@ -1,0 +1,58 @@
+@namespace Blazorise.Docs.Docs.Examples
+
+<SvgBarChart TItem="TaskState"
+             Items="@states"
+             Options="@options">
+    <SvgChartTooltip Enabled="false" />
+    <SvgChartCategoryAxis Value="@( item => item.Name )" />
+    <SvgChartValueAxis BeginAtZero
+                       TickCount="5"
+                       LabelsOptions="@( new SvgChartAxisLabelsOptions { Visible = false } )" />
+    <SvgChartDataLabels Visible
+                        Position="SvgChartDataLabelPosition.End"
+                        BackgroundColor='@((Color)"#ffffff")'
+                        Border="@( new SvgChartBorderOptions { Color = Color.Primary, Width = 1, Radius = 4 } )" />
+
+    <SvgBarSeries Value="@( item => item.Value )"
+                  Colors="@stateColors"
+                  BorderRadius="4" />
+</SvgBarChart>
+
+@code {
+    private readonly SvgChartOptions options = new()
+    {
+        Height = 150,
+        PlotAreaPadding = new()
+        {
+            Top = 8,
+            End = 12,
+            Bottom = 8,
+        },
+        Legend = new() { Visible = false },
+        Title = new() { Visible = false },
+        Subtitle = new() { Visible = false },
+    };
+
+    private readonly IReadOnlyList<Color> stateColors =
+    [
+        Color.Secondary,
+        Color.Info,
+        Color.Success,
+        Color.Danger,
+    ];
+
+    private readonly List<TaskState> states =
+    [
+        new() { Name = "Disabled", Value = 10 },
+        new() { Name = "Active", Value = 18 },
+        new() { Name = "Completed", Value = 33 },
+        new() { Name = "Deleted", Value = 4 },
+    ];
+
+    private sealed class TaskState
+    {
+        public string Name { get; set; }
+
+        public double Value { get; set; }
+    }
+}

--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/SvgChart/SvgChartPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/SvgChart/SvgChartPage.razor
@@ -84,6 +84,15 @@
 </DocsPageSection>
 
 <DocsPageSection>
+    <DocsPageSectionHeader Title="Point colors">
+        Use <Code>Colors</Code> to assign colors by data point index. The first color is used for the first resolved value, the second color for the second value, and so on. If the color belongs to the item itself, use <Code>PointColor</Code> instead so the color follows the item when the data changes.
+    </DocsPageSectionHeader>
+    <DocsPageSectionContent Code="SvgBarChartPointColorsExample" Outlined FullWidth>
+        <SvgBarChartPointColorsExample />
+    </DocsPageSectionContent>
+</DocsPageSection>
+
+<DocsPageSection>
     <DocsPageSectionHeader Title="Line chart">
         Use a line chart to show a trend across ordered categories.
     </DocsPageSectionHeader>

--- a/Documentation/Blazorise.Docs/Resources/docs-index.json
+++ b/Documentation/Blazorise.Docs/Resources/docs-index.json
@@ -1,5 +1,5 @@
 ﻿{
-  "generatedUtc": "2026-05-30T11:07:47.9559075Z",
+  "generatedUtc": "2026-06-01T11:05:37.3695854Z",
   "pages": [
     {
       "route": "/docs",
@@ -7656,6 +7656,14 @@
           "content": "<SvgBarChart TItem=\"RegionalRevenue\"\r\n             Items=\"@revenue\"\r\n             Options=\"@options\">\r\n    <SvgChartTitle Title='@(\"Regional revenue\")' Subtitle='@(\"Horizontal grouped bars\")' />\r\n    <SvgChartLegend Position=\"SvgChartLegendPosition.Bottom\" />\r\n    <SvgChartTooltip Enabled />\r\n    <SvgChartCategoryAxis Value=\"@( item => item.Region )\" />\r\n    <SvgChartValueAxis BeginAtZero TickCount=\"6\" />\r\n\r\n    <SvgBarSeries Name=\"Online\" Value=\"@( item => item.Online )\" Color=\"Color.Primary\" BorderRadius=\"4\" />\r\n    <SvgBarSeries Name=\"Retail\" Value=\"@( item => item.Retail )\" Color=\"Color.Success\" BorderRadius=\"4\" />\r\n</SvgBarChart>\r\n\r\n@code {\r\n    private readonly SvgChartOptions options = new()\r\n    {\r\n        Height = 360,\r\n        Legend = new() { Position = SvgChartLegendPosition.Bottom },\r\n    };\r\n\r\n    private readonly List<RegionalRevenue> revenue =\r\n    [\r\n        new() { Region = \"North\", Online = 72, Retail = 54 },\r\n        new() { Region = \"South\", Online = 84, Retail = 66 },\r\n        new() { Region = \"East\", Online = 93, Retail = 71 },\r\n        new() { Region = \"West\", Online = 78, Retail = 64 },\r\n    ];\r\n\r\n    private sealed class RegionalRevenue\r\n    {\r\n        public string Region { get; set; }\r\n\r\n        public double Online { get; set; }\r\n\r\n        public double Retail { get; set; }\r\n    }\r\n}",
           "title": "Bar chart",
           "description": "Use a bar chart to compare category values horizontally."
+        },
+        {
+          "code": "SvgBarChartPointColorsExample",
+          "kind": "razor",
+          "sourcePath": "Pages/Docs/Extensions/SvgChart/Examples/SvgBarChartPointColorsExample.razor",
+          "content": "<SvgBarChart TItem=\"TaskState\"\r\n             Items=\"@states\"\r\n             Options=\"@options\">\r\n    <SvgChartTooltip Enabled=\"false\" />\r\n    <SvgChartCategoryAxis Value=\"@( item => item.Name )\" />\r\n    <SvgChartValueAxis BeginAtZero\r\n                       TickCount=\"5\"\r\n                       LabelsOptions=\"@( new SvgChartAxisLabelsOptions { Visible = false } )\" />\r\n    <SvgChartDataLabels Visible\r\n                        Position=\"SvgChartDataLabelPosition.End\"\r\n                        BackgroundColor='@((Color)\"#ffffff\")'\r\n                        Border=\"@( new SvgChartBorderOptions { Color = Color.Primary, Width = 1, Radius = 4 } )\" />\r\n\r\n    <SvgBarSeries Value=\"@( item => item.Value )\"\r\n                  Colors=\"@stateColors\"\r\n                  BorderRadius=\"4\" />\r\n</SvgBarChart>\r\n\r\n@code {\r\n    private readonly SvgChartOptions options = new()\r\n    {\r\n        Height = 150,\r\n        PlotAreaPadding = new()\r\n        {\r\n            Top = 8,\r\n            End = 12,\r\n            Bottom = 8,\r\n        },\r\n        Legend = new() { Visible = false },\r\n        Title = new() { Visible = false },\r\n        Subtitle = new() { Visible = false },\r\n    };\r\n\r\n    private readonly IReadOnlyList<Color> stateColors =\r\n    [\r\n        Color.Secondary,\r\n        Color.Info,\r\n        Color.Success,\r\n        Color.Danger,\r\n    ];\r\n\r\n    private readonly List<TaskState> states =\r\n    [\r\n        new() { Name = \"Disabled\", Value = 10 },\r\n        new() { Name = \"Active\", Value = 18 },\r\n        new() { Name = \"Completed\", Value = 33 },\r\n        new() { Name = \"Deleted\", Value = 4 },\r\n    ];\r\n\r\n    private sealed class TaskState\r\n    {\r\n        public string Name { get; set; }\r\n\r\n        public double Value { get; set; }\r\n    }\r\n}",
+          "title": "Point colors",
+          "description": "Use Colors to assign colors by data point index. The first color is used for the first resolved value, the second color for the second value, and so on. If the color belongs to the item itself, use PointColor instead so the color follows the item when the data changes."
         },
         {
           "code": "SvgLineChartExample",

--- a/Source/Extensions/Blazorise.Charts.Svg/Axes/SvgChartValueAxis.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Axes/SvgChartValueAxis.cs
@@ -73,6 +73,11 @@ public class SvgChartValueAxis : SvgChartComponentBase
     [Parameter] public SvgChartGridLinesOptions GridLines { get; set; } = new();
 
     /// <summary>
+    /// Defines label options for this value axis.
+    /// </summary>
+    [Parameter] public SvgChartAxisLabelsOptions LabelsOptions { get; set; }
+
+    /// <summary>
     /// Defines the axis title.
     /// </summary>
     [Parameter] public string Title { get; set; }

--- a/Source/Extensions/Blazorise.Charts.Svg/Components/SvgChart.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Components/SvgChart.cs
@@ -1219,7 +1219,7 @@ public class SvgChart<TItem> : SvgChartBase
 
     private static string ResolvePointColor( SvgChartRenderSeries series, int pointIndex )
     {
-        return pointIndex >= 0 && pointIndex < series.PointColors.Count && !string.IsNullOrWhiteSpace( series.PointColors[pointIndex] )
+        return pointIndex >= 0 && pointIndex < ( series.PointColors?.Count ?? 0 ) && !string.IsNullOrWhiteSpace( series.PointColors[pointIndex] )
             ? series.PointColors[pointIndex]
             : series.RenderColor;
     }
@@ -1521,7 +1521,7 @@ public class SvgChart<TItem> : SvgChartBase
     /// <returns>A task that represents the asynchronous operation.</returns>
     public Task SetData( SvgChartData<double?> data )
     {
-        internalChartData = data;
+        internalChartData = NormalizeData( data );
         StateHasChanged();
 
         return Task.CompletedTask;
@@ -1547,7 +1547,8 @@ public class SvgChart<TItem> : SvgChartBase
     /// <returns>A task that represents the asynchronous operation.</returns>
     public Task AddLabel( object label )
     {
-        EnsureInternalData().Labels.Add( label );
+        var data = EnsureInternalData();
+        data.Labels.Add( label );
         StateHasChanged();
 
         return Task.CompletedTask;
@@ -1560,7 +1561,11 @@ public class SvgChart<TItem> : SvgChartBase
     /// <returns>A task that represents the asynchronous operation.</returns>
     public Task AddSeries( SvgChartSeriesData<double?> series )
     {
-        EnsureInternalData().Series.Add( series );
+        if ( series is null )
+            return Task.CompletedTask;
+
+        var data = EnsureInternalData();
+        data.Series.Add( NormalizeSeries( series ) );
         StateHasChanged();
 
         return Task.CompletedTask;
@@ -1588,10 +1593,12 @@ public class SvgChart<TItem> : SvgChartBase
     /// <returns>A task that represents the asynchronous operation.</returns>
     public Task AddValue( string seriesName, double? value )
     {
-        var series = EnsureInternalData().Series.FirstOrDefault( x => x.Name == seriesName );
+        var data = EnsureInternalData();
+        var series = data.Series.FirstOrDefault( x => x.Name == seriesName );
 
         if ( series is not null )
         {
+            NormalizeSeries( series );
             series.Values.Add( value );
             StateHasChanged();
         }
@@ -1635,6 +1642,8 @@ public class SvgChart<TItem> : SvgChartBase
 
         foreach ( var series in data.Series )
         {
+            NormalizeSeries( series );
+
             while ( series.Values.Count < previousCount )
                 series.Values.Add( null );
         }
@@ -1707,10 +1716,15 @@ public class SvgChart<TItem> : SvgChartBase
     {
         var series = EnsureInternalData().Series.FirstOrDefault( x => x.Name == seriesName );
 
-        if ( series is not null && index >= 0 && index < series.Values.Count )
+        if ( series is not null )
         {
-            series.Values[index] = value;
-            StateHasChanged();
+            NormalizeSeries( series );
+
+            if ( index >= 0 && index < series.Values.Count )
+            {
+                series.Values[index] = value;
+                StateHasChanged();
+            }
         }
 
         return Task.CompletedTask;
@@ -1900,10 +1914,13 @@ public class SvgChart<TItem> : SvgChartBase
 
         foreach ( var series in data.Series )
         {
+            NormalizeSeries( series );
+
             series.Values.Clear();
-            series.XValues?.Clear();
-            series.YValues?.Clear();
-            series.RadiusValues?.Clear();
+            series.XValues.Clear();
+            series.YValues.Clear();
+            series.RadiusValues.Clear();
+            series.Colors.Clear();
         }
 
         hiddenSeries.Clear();
@@ -2002,11 +2019,11 @@ public class SvgChart<TItem> : SvgChartBase
     private SvgChartData<double?> EnsureInternalData()
     {
         if ( internalChartData is not null )
-            return internalChartData;
+            return NormalizeData( internalChartData );
 
         if ( Data is not null )
         {
-            internalChartData = Data;
+            internalChartData = NormalizeData( Data );
             return internalChartData;
         }
 
@@ -2026,16 +2043,18 @@ public class SvgChart<TItem> : SvgChartBase
                 CategoryAxisId = x.CategoryAxisId,
                 ValueAxisId = x.ValueAxisId,
                 Color = x.Color,
-                Colors = x.PointColors.Select( color => (Color)color ).ToList(),
+                Colors = x.PointColors?.Select( color => (Color)color ).ToList() ?? [],
                 Hidden = x.Hidden
             } ).ToList()
         };
 
-        return internalChartData;
+        return NormalizeData( internalChartData );
     }
 
     private static SvgChartSeriesData<double?> EnsureSeries( SvgChartData<double?> data, string seriesName, int valueCount )
     {
+        data = NormalizeData( data );
+
         var series = data.Series.FirstOrDefault( x => x.Name == seriesName );
 
         if ( series is null )
@@ -2048,8 +2067,37 @@ public class SvgChart<TItem> : SvgChartBase
             data.Series.Add( series );
         }
 
+        NormalizeSeries( series );
+
         while ( series.Values.Count < valueCount )
             series.Values.Add( null );
+
+        return series;
+    }
+
+    private static SvgChartData<double?> NormalizeData( SvgChartData<double?> data )
+    {
+        data ??= new();
+        data.Labels ??= [];
+        data.Series ??= [];
+        data.Series.RemoveAll( x => x is null );
+
+        foreach ( var series in data.Series )
+            NormalizeSeries( series );
+
+        return data;
+    }
+
+    private static SvgChartSeriesData<double?> NormalizeSeries( SvgChartSeriesData<double?> series )
+    {
+        if ( series is null )
+            return null;
+
+        series.Values ??= [];
+        series.XValues ??= [];
+        series.YValues ??= [];
+        series.RadiusValues ??= [];
+        series.Colors ??= [];
 
         return series;
     }
@@ -2078,6 +2126,8 @@ public class SvgChart<TItem> : SvgChartBase
 
     private static void RemoveDataPoint( SvgChartData<double?> data, int index )
     {
+        data = NormalizeData( data );
+
         if ( index >= 0 && index < data.Labels.Count )
             data.Labels.RemoveAt( index );
 
@@ -2092,7 +2142,7 @@ public class SvgChart<TItem> : SvgChartBase
 
     private static void RemoveAt<TValue>( List<TValue> values, int index )
     {
-        if ( index >= 0 && index < values.Count )
+        if ( values is not null && index >= 0 && index < values.Count )
             values.RemoveAt( index );
     }
 

--- a/Source/Extensions/Blazorise.Charts.Svg/Components/SvgChart.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Components/SvgChart.cs
@@ -168,7 +168,7 @@ public class SvgChart<TItem> : SvgChartBase
         var subtitle = ResolveSubtitleOptions( options, titleComponents );
         var hasTopLegend = legend.Visible && legend.Position == SvgChartLegendPosition.Top;
         var hasBottomLegend = legend.Visible && legend.Position == SvgChartLegendPosition.Bottom;
-        var plot = BuildPlotArea( options, title, subtitle, hasTopLegend, hasBottomLegend );
+        var plot = BuildPlotArea( options, title, subtitle, hasTopLegend, hasBottomLegend, model );
         var streamingAnimation = ResolveStreamingAnimation( model, plot );
         var chartAnimation = ResolveAnimation( options, streamingAnimation.Enabled );
         var currentAnimationPointBounds = new Dictionary<string, SvgChartPointBounds>();
@@ -395,6 +395,7 @@ public class SvgChart<TItem> : SvgChartBase
                 YValues = x.YValues,
                 RadiusValues = x.RadiusValues,
                 Color = x.RenderColor,
+                PointColors = x.PointColors,
                 Hidden = x.Hidden,
                 Order = x.Order,
                 CategoryAxisId = x.CategoryAxisId,
@@ -1198,7 +1199,7 @@ public class SvgChart<TItem> : SvgChartBase
             PointIndex = pointIndex,
             Category = category,
             Value = value,
-            Color = series.RenderColor,
+            Color = ResolvePointColor( series, pointIndex ),
             Point = new()
             {
                 SeriesName = series.Name,
@@ -1214,6 +1215,13 @@ public class SvgChart<TItem> : SvgChartBase
     private static string GetPointLabel( SvgChartPointEventArgs point )
     {
         return $"{point.Category}, {point.Value}. {point.SeriesName}.";
+    }
+
+    private static string ResolvePointColor( SvgChartRenderSeries series, int pointIndex )
+    {
+        return pointIndex >= 0 && pointIndex < series.PointColors.Count && !string.IsNullOrWhiteSpace( series.PointColors[pointIndex] )
+            ? series.PointColors[pointIndex]
+            : series.RenderColor;
     }
 
     private static string ResolveTooltipStyle( SvgChartOptions options, SvgChartTooltipContext context )
@@ -1316,7 +1324,7 @@ public class SvgChart<TItem> : SvgChartBase
         var title = ResolveTitleOptions( options, titleComponents );
         var subtitle = ResolveSubtitleOptions( options, titleComponents );
 
-        return BuildPlotArea( options, title, subtitle, legend.Visible && legend.Position == SvgChartLegendPosition.Top, legend.Visible && legend.Position == SvgChartLegendPosition.Bottom );
+        return BuildPlotArea( options, title, subtitle, legend.Visible && legend.Position == SvgChartLegendPosition.Top, legend.Visible && legend.Position == SvgChartLegendPosition.Bottom, model );
     }
 
     private static bool IsInsidePlot( double x, double y, SvgChartPlotArea plot )
@@ -2018,6 +2026,7 @@ public class SvgChart<TItem> : SvgChartBase
                 CategoryAxisId = x.CategoryAxisId,
                 ValueAxisId = x.ValueAxisId,
                 Color = x.Color,
+                Colors = x.PointColors.Select( color => (Color)color ).ToList(),
                 Hidden = x.Hidden
             } ).ToList()
         };

--- a/Source/Extensions/Blazorise.Charts.Svg/Contexts/SvgChartPluginSeries.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Contexts/SvgChartPluginSeries.cs
@@ -113,7 +113,7 @@ public sealed class SvgChartPluginSeries
     /// <returns>The resolved point color.</returns>
     public string GetPointColor( int pointIndex )
     {
-        return pointIndex >= 0 && pointIndex < PointColors.Count && !string.IsNullOrWhiteSpace( PointColors[pointIndex] )
+        return pointIndex >= 0 && pointIndex < ( PointColors?.Count ?? 0 ) && !string.IsNullOrWhiteSpace( PointColors[pointIndex] )
             ? PointColors[pointIndex]
             : Color;
     }

--- a/Source/Extensions/Blazorise.Charts.Svg/Contexts/SvgChartPluginSeries.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Contexts/SvgChartPluginSeries.cs
@@ -47,6 +47,11 @@ public sealed class SvgChartPluginSeries
     public string Color { get; init; }
 
     /// <summary>
+    /// Gets the resolved colors for individual data points.
+    /// </summary>
+    public IReadOnlyList<string> PointColors { get; init; } = [];
+
+    /// <summary>
     /// Gets whether the series is hidden.
     /// </summary>
     public bool Hidden { get; init; }
@@ -100,6 +105,18 @@ public sealed class SvgChartPluginSeries
     /// Gets the resolved area fill opacity.
     /// </summary>
     public double FillOpacity { get; init; }
+
+    /// <summary>
+    /// Gets the resolved color for a data point.
+    /// </summary>
+    /// <param name="pointIndex">The point index.</param>
+    /// <returns>The resolved point color.</returns>
+    public string GetPointColor( int pointIndex )
+    {
+        return pointIndex >= 0 && pointIndex < PointColors.Count && !string.IsNullOrWhiteSpace( PointColors[pointIndex] )
+            ? PointColors[pointIndex]
+            : Color;
+    }
 
     #endregion
 }

--- a/Source/Extensions/Blazorise.Charts.Svg/Data/SvgChartSeriesData.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Data/SvgChartSeriesData.cs
@@ -58,6 +58,11 @@ public class SvgChartSeriesData<TValue>
     public Color Color { get; set; }
 
     /// <summary>
+    /// Defines explicit colors for individual data points.
+    /// </summary>
+    public List<Color> Colors { get; set; } = [];
+
+    /// <summary>
     /// Defines whether the series is hidden.
     /// </summary>
     public bool Hidden { get; set; }

--- a/Source/Extensions/Blazorise.Charts.Svg/Infrastructure/SvgChartModelBuilder.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Infrastructure/SvgChartModelBuilder.cs
@@ -174,6 +174,10 @@ internal sealed class SvgChartModelBuilder<TItem>
             for ( var i = 0; i < chartData.Series.Count; i++ )
             {
                 var dataSeries = chartData.Series[i];
+
+                if ( dataSeries is null )
+                    continue;
+
                 var name = string.IsNullOrWhiteSpace( dataSeries.Name ) ? $"Series {i + 1}" : dataSeries.Name;
                 var values = dataSeries.Values?.ToList() ?? [];
                 var yValues = dataSeries.YValues?.Count > 0 ? dataSeries.YValues.ToList() : values.ToList();

--- a/Source/Extensions/Blazorise.Charts.Svg/Infrastructure/SvgChartModelBuilder.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Infrastructure/SvgChartModelBuilder.cs
@@ -190,6 +190,7 @@ internal sealed class SvgChartModelBuilder<TItem>
                     Values = values,
                     Color = dataSeries.Color,
                     RenderColor = SvgChartRenderHelpers.ResolveColor( dataSeries.Color, i ),
+                    PointColors = ResolvePointColors( dataSeries.Colors, values.Count, dataSeries.Color, i, IsRadialChart( Type ) ),
                     Hidden = dataSeries.Hidden || hiddenSeries.Contains( name ),
                     Order = dataSeries.Order,
                     CategoryAxisId = dataSeries.CategoryAxisId,
@@ -230,6 +231,7 @@ internal sealed class SvgChartModelBuilder<TItem>
                 RadiusValues = radiusValues,
                 Color = child.Color,
                 RenderColor = SvgChartRenderHelpers.ResolveColor( child.Color, series.Count ),
+                PointColors = ResolvePointColors( child.Colors, child.PointColor is null ? null : items.Select( child.PointColor ).ToList(), labelCount, child.Color, series.Count, IsRadialChart( child.ChartType ) ),
                 Hidden = child.Hidden || hiddenSeries.Contains( name ),
                 Order = child.Order,
                 CategoryAxisId = child.CategoryAxisId,
@@ -266,6 +268,33 @@ internal sealed class SvgChartModelBuilder<TItem>
         ApplyStacking( series, ResolveStackedValueAxisIds( series ) );
 
         return series;
+    }
+
+    private static List<string> ResolvePointColors( IReadOnlyList<Color> colors, int count, Color seriesColor, int seriesIndex, bool usePalettePerPoint )
+    {
+        return ResolvePointColors( colors, null, count, seriesColor, seriesIndex, usePalettePerPoint );
+    }
+
+    private static List<string> ResolvePointColors( IReadOnlyList<Color> colors, IReadOnlyList<Color> selectedColors, int count, Color seriesColor, int seriesIndex, bool usePalettePerPoint )
+    {
+        var result = new List<string>();
+        var seriesFallback = SvgChartRenderHelpers.ResolveColor( seriesColor, seriesIndex );
+        var palettePerPoint = usePalettePerPoint && SvgChartRenderHelpers.IsDefaultColor( seriesColor );
+
+        for ( var i = 0; i < count; i++ )
+        {
+            var color = i < ( selectedColors?.Count ?? 0 )
+                ? selectedColors[i]
+                : i < ( colors?.Count ?? 0 )
+                    ? colors[i]
+                    : null;
+
+            result.Add( SvgChartRenderHelpers.IsDefaultColor( color )
+                ? ( palettePerPoint ? SvgChartRenderHelpers.ResolveColor( null, i ) : seriesFallback )
+                : SvgChartRenderHelpers.ResolveColor( color, i ) );
+        }
+
+        return result;
     }
 
     private HashSet<string> ResolveStackedValueAxisIds( List<SvgChartRenderSeries> series )
@@ -708,6 +737,7 @@ internal sealed class SvgChartModelBuilder<TItem>
                 Id = axis.Id,
                 Position = axis.Position,
                 GridLines = axis.GridLines,
+                Labels = axis.Labels,
                 TickFormatter = axis.TickFormatter,
                 Stacked = axis.Stacked,
                 Min = scale.Min,

--- a/Source/Extensions/Blazorise.Charts.Svg/Infrastructure/SvgChartOptionsMapper.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Infrastructure/SvgChartOptionsMapper.cs
@@ -6,6 +6,8 @@ internal static class SvgChartOptionsMapper
 
     public static SvgChartAxisOptions CreateValueAxisOptions( SvgChartAxisOptions axis )
     {
+        axis ??= new();
+
         return new()
         {
             Id = axis.Id,
@@ -24,6 +26,9 @@ internal static class SvgChartOptionsMapper
 
     public static SvgChartAxisOptions CreateValueAxisOptions( SvgChartValueAxis axis )
     {
+        if ( axis is null )
+            return CreateValueAxisOptions( new SvgChartAxisOptions() );
+
         return new()
         {
             Id = axis.Id,
@@ -42,6 +47,8 @@ internal static class SvgChartOptionsMapper
 
     public static SvgChartAxisOptions CreateCategoryAxisOptions<TItem>( SvgChartAxisOptions options, SvgChartCategoryAxis<TItem> axis )
     {
+        options ??= new();
+
         if ( axis is null )
             return CreateValueAxisOptions( options );
 

--- a/Source/Extensions/Blazorise.Charts.Svg/Infrastructure/SvgChartOptionsMapper.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Infrastructure/SvgChartOptionsMapper.cs
@@ -35,7 +35,7 @@ internal static class SvgChartOptionsMapper
             Stacked = axis.Stacked,
             TickFormatter = axis.TickFormatter,
             GridLines = CreateGridLinesOptions( axis.GridLines ),
-            Labels = new(),
+            Labels = CreateLabelsOptions( new() { Offset = 24 }, axis.LabelsOptions ),
             Title = axis.Title
         };
     }
@@ -70,7 +70,8 @@ internal static class SvgChartOptionsMapper
         {
             Visible = labels.Visible,
             Step = labels.Step,
-            Offset = labels.Offset
+            Offset = labels.Offset,
+            MaxWidth = labels.MaxWidth
         };
     }
 
@@ -83,7 +84,8 @@ internal static class SvgChartOptionsMapper
         {
             Visible = overrides.Visible,
             Step = overrides.Step,
-            Offset = overrides.Offset
+            Offset = overrides.Offset,
+            MaxWidth = overrides.MaxWidth ?? options?.MaxWidth
         };
     }
 

--- a/Source/Extensions/Blazorise.Charts.Svg/Models/SvgChartRenderSeries.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Models/SvgChartRenderSeries.cs
@@ -24,6 +24,8 @@ internal sealed class SvgChartRenderSeries
 
     public string RenderColor { get; init; }
 
+    public List<string> PointColors { get; init; } = [];
+
     public bool Hidden { get; init; }
 
     public int? Order { get; init; }

--- a/Source/Extensions/Blazorise.Charts.Svg/Models/SvgChartRenderValueAxis.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Models/SvgChartRenderValueAxis.cs
@@ -15,6 +15,8 @@ internal sealed class SvgChartRenderValueAxis
 
     public SvgChartGridLinesOptions GridLines { get; init; }
 
+    public SvgChartAxisLabelsOptions Labels { get; init; }
+
     public Func<SvgChartAxisTickContext, string> TickFormatter { get; init; }
 
     public bool Stacked { get; init; }

--- a/Source/Extensions/Blazorise.Charts.Svg/Options/SvgChartAxisLabelsOptions.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Options/SvgChartAxisLabelsOptions.cs
@@ -22,5 +22,10 @@ public class SvgChartAxisLabelsOptions
     /// </summary>
     public double Offset { get; set; } = 24;
 
+    /// <summary>
+    /// Defines the maximum label width in SVG units. Longer labels are shortened.
+    /// </summary>
+    public double? MaxWidth { get; set; }
+
     #endregion
 }

--- a/Source/Extensions/Blazorise.Charts.Svg/Options/SvgChartOptions.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Options/SvgChartOptions.cs
@@ -32,6 +32,11 @@ public class SvgChartOptions
     public SvgChartFontOptions Font { get; set; } = new();
 
     /// <summary>
+    /// Defines custom plot area padding. When null, the chart uses its default plot padding.
+    /// </summary>
+    public SvgChartPlotAreaPadding PlotAreaPadding { get; set; }
+
+    /// <summary>
     /// Defines the chart title options.
     /// </summary>
     public SvgChartTextOptions Title { get; set; } = new()

--- a/Source/Extensions/Blazorise.Charts.Svg/Options/SvgChartPlotAreaPadding.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Options/SvgChartPlotAreaPadding.cs
@@ -1,0 +1,31 @@
+namespace Blazorise.Charts.Svg;
+
+/// <summary>
+/// Defines logical plot area padding for a native SVG chart.
+/// </summary>
+public class SvgChartPlotAreaPadding
+{
+    #region Properties
+
+    /// <summary>
+    /// Defines the top plot area padding.
+    /// </summary>
+    public double? Top { get; set; }
+
+    /// <summary>
+    /// Defines the end plot area padding.
+    /// </summary>
+    public double? End { get; set; }
+
+    /// <summary>
+    /// Defines the bottom plot area padding.
+    /// </summary>
+    public double? Bottom { get; set; }
+
+    /// <summary>
+    /// Defines the start plot area padding.
+    /// </summary>
+    public double? Start { get; set; }
+
+    #endregion
+}

--- a/Source/Extensions/Blazorise.Charts.Svg/Plugins/SvgChartDataLabels.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Plugins/SvgChartDataLabels.cs
@@ -192,7 +192,7 @@ public class SvgChartDataLabels : SvgChartPluginBase
             var rectWidth = Math.Max( 1, barWidth * 0.8 );
             var bounds = new SvgChartPointBounds { X = x, Y = rectY, Width = rectWidth, Height = height };
 
-            points.Add( (context.CreatePoint( series, pointIndex, value.Value, bounds ), series.Color, series.Type) );
+            points.Add( (context.CreatePoint( series, pointIndex, value.Value, bounds ), series.GetPointColor( pointIndex ), series.Type) );
         }
     }
 
@@ -224,7 +224,7 @@ public class SvgChartDataLabels : SvgChartPluginBase
             var rectHeight = Math.Max( 1, barHeight * 0.8 );
             var bounds = new SvgChartPointBounds { X = rectX, Y = y, Width = width, Height = rectHeight };
 
-            points.Add( (context.CreatePoint( series, pointIndex, value.Value, bounds ), series.Color, series.Type) );
+            points.Add( (context.CreatePoint( series, pointIndex, value.Value, bounds ), series.GetPointColor( pointIndex ), series.Type) );
         }
     }
 
@@ -246,7 +246,7 @@ public class SvgChartDataLabels : SvgChartPluginBase
             var y = context.ProjectY( value.Value, series.ValueAxisId );
             var bounds = new SvgChartPointBounds { X = x - markerRadius, Y = y - markerRadius, Width = markerRadius * 2, Height = markerRadius * 2 };
 
-            points.Add( (context.CreatePoint( series, pointIndex, value.Value, bounds ), series.Color, series.Type) );
+            points.Add( (context.CreatePoint( series, pointIndex, value.Value, bounds ), series.GetPointColor( pointIndex ), series.Type) );
         }
     }
 
@@ -279,7 +279,7 @@ public class SvgChartDataLabels : SvgChartPluginBase
                 Bounds = bounds
             };
 
-            points.Add( (point, series.Color, series.Type) );
+            points.Add( (point, series.GetPointColor( pointIndex ), series.Type) );
         }
     }
 
@@ -333,7 +333,7 @@ public class SvgChartDataLabels : SvgChartPluginBase
                 Bounds = labelBounds
             };
 
-            points.Add( (point, SvgChartRenderHelpers.ResolveColor( null, pointIndex ), series.Type) );
+            points.Add( (point, series.GetPointColor( pointIndex ), series.Type) );
 
             startAngle += sweep;
         }
@@ -368,7 +368,7 @@ public class SvgChartDataLabels : SvgChartPluginBase
                 Height = markerRadius * 2
             };
 
-            points.Add( (context.CreatePoint( series, pointIndex, value.Value, bounds ), series.Color, series.Type) );
+            points.Add( (context.CreatePoint( series, pointIndex, value.Value, bounds ), series.GetPointColor( pointIndex ), series.Type) );
         }
     }
 

--- a/Source/Extensions/Blazorise.Charts.Svg/Renderers/SvgChartAreaSeriesRenderer.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Renderers/SvgChartAreaSeriesRenderer.cs
@@ -92,17 +92,18 @@ internal sealed class SvgChartAreaSeriesRenderer : ISvgChartSeriesRenderer
                 };
                 var point = chart.CreatePoint( item, renderedPoint.Index, renderedPoint.Value, bounds );
                 var animationKey = context.TrackPointBounds( item, renderedPoint.Index, bounds );
+                var color = item.GetPointColor( renderedPoint.Index );
 
                 builder.OpenElement( sequence++, "circle" );
                 builder.AddAttribute( sequence++, "class", "svg-chart-point svg-chart-area-marker" );
                 builder.AddAttribute( sequence++, "cx", SvgChartRenderHelpers.Format( renderedPoint.X ) );
                 builder.AddAttribute( sequence++, "cy", SvgChartRenderHelpers.Format( renderedPoint.Y ) );
                 builder.AddAttribute( sequence++, "r", SvgChartRenderHelpers.Format( markerRadius ) );
-                builder.AddAttribute( sequence++, "fill", item.Color );
+                builder.AddAttribute( sequence++, "fill", color );
                 builder.AddAttribute( sequence++, "stroke", "var(--bs-body-bg, #fff)" );
                 builder.AddAttribute( sequence++, "stroke-width", "1.5" );
                 context.AddAnimatedStyleAttribute( builder, ref sequence );
-                context.AddPointInteractionAttributes( builder, ref sequence, point, item.Color );
+                context.AddPointInteractionAttributes( builder, ref sequence, point, color );
                 context.RenderPointBoundsAttributeAnimation( builder, ref sequence, animationKey, "cx", SvgChartRenderHelpers.Format( renderedPoint.X ), SvgChartRenderHelpers.Format( renderedPoint.X ), bounds => SvgChartRenderHelpers.Format( bounds.X + bounds.Width / 2 ) );
                 context.RenderPointBoundsAttributeAnimation( builder, ref sequence, animationKey, "cy", SvgChartRenderHelpers.Format( renderedPoint.Y ), SvgChartRenderHelpers.Format( renderedPoint.Y ), bounds => SvgChartRenderHelpers.Format( bounds.Y + bounds.Height / 2 ) );
                 context.RenderPointBoundsAttributeAnimation( builder, ref sequence, animationKey, "r", "0", SvgChartRenderHelpers.Format( markerRadius ), bounds => SvgChartRenderHelpers.Format( bounds.Width / 2 ) );

--- a/Source/Extensions/Blazorise.Charts.Svg/Renderers/SvgChartAxesRenderer.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Renderers/SvgChartAxesRenderer.cs
@@ -39,18 +39,23 @@ internal static class SvgChartAxesRenderer
         else
             RenderCategoryAxisGridLines( builder, ref sequence, model, plot, streamingAnimation, plotClipPathId );
 
-        for ( var i = 0; i < primaryAxis.Ticks.Count; i++ )
-        {
-            var tick = primaryAxis.Ticks[i];
-            var y = SvgChartGeometry.GetY( tick, plot, primaryAxis );
+        var primaryLabels = primaryAxis.Labels ?? new();
 
-            builder.OpenElement( sequence++, "text" );
-            builder.AddAttribute( sequence++, "x", SvgChartRenderHelpers.Format( plot.Left - 10 ) );
-            builder.AddAttribute( sequence++, "y", SvgChartRenderHelpers.Format( y + 4 ) );
-            builder.AddAttribute( sequence++, "text-anchor", "end" );
-            SvgChartTextRenderer.AddFontAttributes( builder, ref sequence, model.Options, opacity: 0.68 );
-            builder.AddContent( sequence++, FormatValueTick( primaryAxis, tick, i ) );
-            builder.CloseElement();
+        if ( primaryLabels.Visible )
+        {
+            for ( var i = 0; i < primaryAxis.Ticks.Count; i++ )
+            {
+                var tick = primaryAxis.Ticks[i];
+                var y = SvgChartGeometry.GetY( tick, plot, primaryAxis );
+
+                builder.OpenElement( sequence++, "text" );
+                builder.AddAttribute( sequence++, "x", SvgChartRenderHelpers.Format( plot.Left - 10 ) );
+                builder.AddAttribute( sequence++, "y", SvgChartRenderHelpers.Format( y + 4 ) );
+                builder.AddAttribute( sequence++, "text-anchor", "end" );
+                SvgChartTextRenderer.AddFontAttributes( builder, ref sequence, model.Options, opacity: 0.68 );
+                builder.AddContent( sequence++, FormatAxisLabel( FormatValueTick( primaryAxis, tick, i ), primaryLabels, model.Options ) );
+                builder.CloseElement();
+            }
         }
 
         builder.OpenElement( sequence++, "line" );
@@ -119,7 +124,7 @@ internal static class SvgChartAxesRenderer
             builder.AddAttribute( sequence++, "y", SvgChartRenderHelpers.Format( plot.Bottom + labels.Offset ) );
             builder.AddAttribute( sequence++, "text-anchor", "middle" );
             SvgChartTextRenderer.AddFontAttributes( builder, ref sequence, model.Options, opacity: 0.72 );
-            builder.AddContent( sequence++, FormatCategoryTick( model, model.Labels[i], labelIndex ) );
+            builder.AddContent( sequence++, FormatAxisLabel( FormatCategoryTick( model, model.Labels[i], labelIndex ), labels, model.Options ) );
             builder.CloseElement();
         }
 
@@ -133,6 +138,8 @@ internal static class SvgChartAxesRenderer
     {
         builder.OpenElement( sequence++, "g" );
         builder.AddAttribute( sequence++, "class", "svg-chart-grid" );
+
+        var valueLabels = model.PrimaryValueAxis.Labels ?? new();
 
         for ( var i = 0; i < model.Ticks.Count; i++ )
         {
@@ -151,13 +158,16 @@ internal static class SvgChartAxesRenderer
                 builder.CloseElement();
             }
 
-            builder.OpenElement( sequence++, "text" );
-            builder.AddAttribute( sequence++, "x", SvgChartRenderHelpers.Format( x ) );
-            builder.AddAttribute( sequence++, "y", SvgChartRenderHelpers.Format( plot.Bottom + 24 ) );
-            builder.AddAttribute( sequence++, "text-anchor", "middle" );
-            SvgChartTextRenderer.AddFontAttributes( builder, ref sequence, model.Options, opacity: 0.68 );
-            builder.AddContent( sequence++, FormatValueTick( model.PrimaryValueAxis, tick, i ) );
-            builder.CloseElement();
+            if ( valueLabels.Visible )
+            {
+                builder.OpenElement( sequence++, "text" );
+                builder.AddAttribute( sequence++, "x", SvgChartRenderHelpers.Format( x ) );
+                builder.AddAttribute( sequence++, "y", SvgChartRenderHelpers.Format( plot.Bottom + valueLabels.Offset ) );
+                builder.AddAttribute( sequence++, "text-anchor", "middle" );
+                SvgChartTextRenderer.AddFontAttributes( builder, ref sequence, model.Options, opacity: 0.68 );
+                builder.AddContent( sequence++, FormatAxisLabel( FormatValueTick( model.PrimaryValueAxis, tick, i ), valueLabels, model.Options ) );
+                builder.CloseElement();
+            }
         }
 
         builder.OpenElement( sequence++, "line" );
@@ -169,17 +179,22 @@ internal static class SvgChartAxesRenderer
         builder.AddAttribute( sequence++, "stroke-opacity", "0.22" );
         builder.CloseElement();
 
-        for ( var i = 0; i < model.Labels.Count; i++ )
-        {
-            var y = plot.Top + plot.Height * ( i + 0.5 ) / Math.Max( model.Labels.Count, 1 );
+        var categoryLabels = model.CategoryAxis?.Labels ?? new();
 
-            builder.OpenElement( sequence++, "text" );
-            builder.AddAttribute( sequence++, "x", SvgChartRenderHelpers.Format( plot.Left - 10 ) );
-            builder.AddAttribute( sequence++, "y", SvgChartRenderHelpers.Format( y + 4 ) );
-            builder.AddAttribute( sequence++, "text-anchor", "end" );
-            SvgChartTextRenderer.AddFontAttributes( builder, ref sequence, model.Options, opacity: 0.72 );
-            builder.AddContent( sequence++, FormatCategoryTick( model, model.Labels[i], i ) );
-            builder.CloseElement();
+        if ( categoryLabels.Visible )
+        {
+            for ( var i = 0; i < model.Labels.Count; i++ )
+            {
+                var y = plot.Top + plot.Height * ( i + 0.5 ) / Math.Max( model.Labels.Count, 1 );
+
+                builder.OpenElement( sequence++, "text" );
+                builder.AddAttribute( sequence++, "x", SvgChartRenderHelpers.Format( plot.Left - 10 ) );
+                builder.AddAttribute( sequence++, "y", SvgChartRenderHelpers.Format( y + 4 ) );
+                builder.AddAttribute( sequence++, "text-anchor", "end" );
+                SvgChartTextRenderer.AddFontAttributes( builder, ref sequence, model.Options, opacity: 0.72 );
+                builder.AddContent( sequence++, FormatAxisLabel( FormatCategoryTick( model, model.Labels[i], i ), categoryLabels, model.Options, Math.Max( 1, plot.Left - 14 ) ) );
+                builder.CloseElement();
+            }
         }
 
         builder.CloseElement();
@@ -285,7 +300,7 @@ internal static class SvgChartAxesRenderer
             builder.AddAttribute( sequence++, "y", SvgChartRenderHelpers.Format( plot.Bottom + labels.Offset ) );
             builder.AddAttribute( sequence++, "text-anchor", labelPlacement.TextAnchor );
             SvgChartTextRenderer.AddFontAttributes( builder, ref sequence, model.Options, opacity: 0.72 );
-            builder.AddContent( sequence++, FormatCategoryTick( model, tick, i ) );
+            builder.AddContent( sequence++, FormatAxisLabel( FormatCategoryTick( model, tick, i ), labels, model.Options ) );
             builder.CloseElement();
         }
 
@@ -309,6 +324,8 @@ internal static class SvgChartAxesRenderer
     {
         foreach ( var axis in model.ValueAxes.Where( x => x != primaryAxis && x.Position == SvgChartAxisPosition.Right ) )
         {
+            var labels = axis.Labels ?? new();
+
             builder.OpenElement( sequence++, "g" );
             builder.AddAttribute( sequence++, "class", "svg-chart-axis svg-chart-value-axis-right" );
 
@@ -321,18 +338,21 @@ internal static class SvgChartAxesRenderer
             builder.AddAttribute( sequence++, "stroke-opacity", "0.22" );
             builder.CloseElement();
 
-            for ( var i = 0; i < axis.Ticks.Count; i++ )
+            if ( labels.Visible )
             {
-                var tick = axis.Ticks[i];
-                var y = SvgChartGeometry.GetY( tick, plot, axis );
+                for ( var i = 0; i < axis.Ticks.Count; i++ )
+                {
+                    var tick = axis.Ticks[i];
+                    var y = SvgChartGeometry.GetY( tick, plot, axis );
 
-                builder.OpenElement( sequence++, "text" );
-                builder.AddAttribute( sequence++, "x", SvgChartRenderHelpers.Format( plot.Right + 10 ) );
-                builder.AddAttribute( sequence++, "y", SvgChartRenderHelpers.Format( y + 4 ) );
-                builder.AddAttribute( sequence++, "text-anchor", "start" );
-                SvgChartTextRenderer.AddFontAttributes( builder, ref sequence, model.Options, opacity: 0.68 );
-                builder.AddContent( sequence++, FormatValueTick( axis, tick, i ) );
-                builder.CloseElement();
+                    builder.OpenElement( sequence++, "text" );
+                    builder.AddAttribute( sequence++, "x", SvgChartRenderHelpers.Format( plot.Right + 10 ) );
+                    builder.AddAttribute( sequence++, "y", SvgChartRenderHelpers.Format( y + 4 ) );
+                    builder.AddAttribute( sequence++, "text-anchor", "start" );
+                    SvgChartTextRenderer.AddFontAttributes( builder, ref sequence, model.Options, opacity: 0.68 );
+                    builder.AddContent( sequence++, FormatAxisLabel( FormatValueTick( axis, tick, i ), labels, model.Options ) );
+                    builder.CloseElement();
+                }
             }
 
             builder.CloseElement();
@@ -387,6 +407,28 @@ internal static class SvgChartAxesRenderer
             CategoryAxis = false,
             AxisId = axis.Id
         } ) ?? SvgChartRenderHelpers.FormatTick( value );
+    }
+
+    private static string FormatAxisLabel( string label, SvgChartAxisLabelsOptions labels, SvgChartOptions options, double? autoMaxWidth = null )
+    {
+        var maxWidth = labels?.MaxWidth ?? autoMaxWidth;
+
+        if ( string.IsNullOrEmpty( label ) || !maxWidth.HasValue )
+            return label;
+
+        var fontSize = options.Font?.Size ?? 11;
+
+        if ( SvgChartRenderHelpers.EstimateTextWidth( label, fontSize ) <= maxWidth.Value )
+            return label;
+
+        var maxCharacters = Math.Max( 1, (int)Math.Floor( maxWidth.Value / ( fontSize * 0.58 ) ) );
+
+        if ( label.Length <= maxCharacters )
+            return label;
+
+        return maxCharacters <= 3
+            ? label[..maxCharacters]
+            : label[..( maxCharacters - 3 )] + "...";
     }
 
     #endregion

--- a/Source/Extensions/Blazorise.Charts.Svg/Renderers/SvgChartAxesRenderer.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Renderers/SvgChartAxesRenderer.cs
@@ -118,13 +118,14 @@ internal static class SvgChartAxesRenderer
                 continue;
 
             var x = SvgChartGeometry.GetCategoryX( i, plot, model );
+            var label = i < model.Labels.Count ? model.Labels[i] : i + 1;
 
             builder.OpenElement( sequence++, "text" );
             builder.AddAttribute( sequence++, "x", SvgChartRenderHelpers.Format( x ) );
             builder.AddAttribute( sequence++, "y", SvgChartRenderHelpers.Format( plot.Bottom + labels.Offset ) );
             builder.AddAttribute( sequence++, "text-anchor", "middle" );
             SvgChartTextRenderer.AddFontAttributes( builder, ref sequence, model.Options, opacity: 0.72 );
-            builder.AddContent( sequence++, FormatAxisLabel( FormatCategoryTick( model, model.Labels[i], labelIndex ), labels, model.Options ) );
+            builder.AddContent( sequence++, FormatAxisLabel( FormatCategoryTick( model, label, labelIndex ), labels, model.Options ) );
             builder.CloseElement();
         }
 
@@ -416,7 +417,7 @@ internal static class SvgChartAxesRenderer
         if ( string.IsNullOrEmpty( label ) || !maxWidth.HasValue )
             return label;
 
-        var fontSize = options.Font?.Size ?? 11;
+        var fontSize = options?.Font?.Size ?? 11;
 
         if ( SvgChartRenderHelpers.EstimateTextWidth( label, fontSize ) <= maxWidth.Value )
             return label;

--- a/Source/Extensions/Blazorise.Charts.Svg/Renderers/SvgChartBarSeriesRenderer.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Renderers/SvgChartBarSeriesRenderer.cs
@@ -62,6 +62,7 @@ internal sealed class SvgChartBarSeriesRenderer : ISvgChartSeriesRenderer
                 var bounds = new SvgChartPointBounds { X = rectX, Y = y, Width = width, Height = rectHeight };
                 var point = chart.CreatePoint( item, pointIndex, value.Value, bounds );
                 var animationKey = context.TrackPointBounds( item, pointIndex, bounds );
+                var color = item.GetPointColor( pointIndex );
 
                 builder.OpenElement( sequence++, "rect" );
                 builder.AddAttribute( sequence++, "class", "svg-chart-point svg-chart-bar" );
@@ -70,9 +71,9 @@ internal sealed class SvgChartBarSeriesRenderer : ISvgChartSeriesRenderer
                 builder.AddAttribute( sequence++, "width", SvgChartRenderHelpers.Format( width ) );
                 builder.AddAttribute( sequence++, "height", SvgChartRenderHelpers.Format( rectHeight ) );
                 builder.AddAttribute( sequence++, "rx", SvgChartRenderHelpers.Format( item.BorderRadius ) );
-                builder.AddAttribute( sequence++, "fill", item.Color );
+                builder.AddAttribute( sequence++, "fill", color );
                 context.AddAnimatedStyleAttribute( builder, ref sequence );
-                context.AddPointInteractionAttributes( builder, ref sequence, point, item.Color );
+                context.AddPointInteractionAttributes( builder, ref sequence, point, color );
                 context.RenderPointBoundsAttributeAnimation( builder, ref sequence, animationKey, "x", SvgChartRenderHelpers.Format( baseline ), SvgChartRenderHelpers.Format( rectX ), bounds => SvgChartRenderHelpers.Format( bounds.X ) );
                 context.RenderPointBoundsAttributeAnimation( builder, ref sequence, animationKey, "y", SvgChartRenderHelpers.Format( y ), SvgChartRenderHelpers.Format( y ), bounds => SvgChartRenderHelpers.Format( bounds.Y ) );
                 context.RenderPointBoundsAttributeAnimation( builder, ref sequence, animationKey, "width", "0", SvgChartRenderHelpers.Format( width ), bounds => SvgChartRenderHelpers.Format( bounds.Width ) );

--- a/Source/Extensions/Blazorise.Charts.Svg/Renderers/SvgChartColumnSeriesRenderer.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Renderers/SvgChartColumnSeriesRenderer.cs
@@ -62,6 +62,7 @@ internal sealed class SvgChartColumnSeriesRenderer : ISvgChartSeriesRenderer
                 var bounds = new SvgChartPointBounds { X = x, Y = rectY, Width = rectWidth, Height = height };
                 var point = chart.CreatePoint( item, pointIndex, value.Value, bounds );
                 var animationKey = context.TrackPointBounds( item, pointIndex, bounds );
+                var color = item.GetPointColor( pointIndex );
 
                 builder.OpenElement( sequence++, "rect" );
                 builder.AddAttribute( sequence++, "class", "svg-chart-point svg-chart-column" );
@@ -70,9 +71,9 @@ internal sealed class SvgChartColumnSeriesRenderer : ISvgChartSeriesRenderer
                 builder.AddAttribute( sequence++, "width", SvgChartRenderHelpers.Format( rectWidth ) );
                 builder.AddAttribute( sequence++, "height", SvgChartRenderHelpers.Format( height ) );
                 builder.AddAttribute( sequence++, "rx", SvgChartRenderHelpers.Format( item.BorderRadius ) );
-                builder.AddAttribute( sequence++, "fill", item.Color );
+                builder.AddAttribute( sequence++, "fill", color );
                 context.AddAnimatedStyleAttribute( builder, ref sequence );
-                context.AddPointInteractionAttributes( builder, ref sequence, point, item.Color );
+                context.AddPointInteractionAttributes( builder, ref sequence, point, color );
                 context.RenderPointBoundsAttributeAnimation( builder, ref sequence, animationKey, "x", SvgChartRenderHelpers.Format( x ), SvgChartRenderHelpers.Format( x ), bounds => SvgChartRenderHelpers.Format( bounds.X ) );
                 context.RenderPointBoundsAttributeAnimation( builder, ref sequence, animationKey, "y", SvgChartRenderHelpers.Format( baseline ), SvgChartRenderHelpers.Format( rectY ), bounds => SvgChartRenderHelpers.Format( bounds.Y ) );
                 context.RenderPointBoundsAttributeAnimation( builder, ref sequence, animationKey, "width", SvgChartRenderHelpers.Format( rectWidth ), SvgChartRenderHelpers.Format( rectWidth ), bounds => SvgChartRenderHelpers.Format( bounds.Width ) );

--- a/Source/Extensions/Blazorise.Charts.Svg/Renderers/SvgChartLegendRenderer.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Renderers/SvgChartLegendRenderer.cs
@@ -117,7 +117,7 @@ internal static class SvgChartLegendRenderer
 
     private static string ResolvePointColor( SvgChartRenderSeries series, int pointIndex )
     {
-        return pointIndex >= 0 && pointIndex < series.PointColors.Count && !string.IsNullOrWhiteSpace( series.PointColors[pointIndex] )
+        return pointIndex >= 0 && pointIndex < ( series.PointColors?.Count ?? 0 ) && !string.IsNullOrWhiteSpace( series.PointColors[pointIndex] )
             ? series.PointColors[pointIndex]
             : series.RenderColor;
     }

--- a/Source/Extensions/Blazorise.Charts.Svg/Renderers/SvgChartLegendRenderer.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Renderers/SvgChartLegendRenderer.cs
@@ -106,13 +106,20 @@ internal static class SvgChartLegendRenderer
             result.Add( new()
             {
                 Label = category?.ToString() ?? string.Empty,
-                Color = SvgChartRenderHelpers.ResolveColor( null, i ),
+                Color = ResolvePointColor( series, i ),
                 Hidden = series.Hidden || isDataPointHidden( series.Name, pointIndex ),
                 Toggle = () => toggleDataPoint( series.Name, pointIndex )
             } );
         }
 
         return result;
+    }
+
+    private static string ResolvePointColor( SvgChartRenderSeries series, int pointIndex )
+    {
+        return pointIndex >= 0 && pointIndex < series.PointColors.Count && !string.IsNullOrWhiteSpace( series.PointColors[pointIndex] )
+            ? series.PointColors[pointIndex]
+            : series.RenderColor;
     }
 
     #endregion

--- a/Source/Extensions/Blazorise.Charts.Svg/Renderers/SvgChartLineSeriesRenderer.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Renderers/SvgChartLineSeriesRenderer.cs
@@ -71,17 +71,18 @@ internal sealed class SvgChartLineSeriesRenderer : ISvgChartSeriesRenderer
                 };
                 var point = chart.CreatePoint( item, renderedPoint.Index, renderedPoint.Value, bounds );
                 var animationKey = context.TrackPointBounds( item, renderedPoint.Index, bounds );
+                var color = item.GetPointColor( renderedPoint.Index );
 
                 builder.OpenElement( sequence++, "circle" );
                 builder.AddAttribute( sequence++, "class", "svg-chart-point svg-chart-marker" );
                 builder.AddAttribute( sequence++, "cx", SvgChartRenderHelpers.Format( renderedPoint.X ) );
                 builder.AddAttribute( sequence++, "cy", SvgChartRenderHelpers.Format( renderedPoint.Y ) );
                 builder.AddAttribute( sequence++, "r", SvgChartRenderHelpers.Format( item.MarkerRadius ) );
-                builder.AddAttribute( sequence++, "fill", item.Color );
+                builder.AddAttribute( sequence++, "fill", color );
                 builder.AddAttribute( sequence++, "stroke", "var(--bs-body-bg, #fff)" );
                 builder.AddAttribute( sequence++, "stroke-width", "1.5" );
                 context.AddAnimatedStyleAttribute( builder, ref sequence );
-                context.AddPointInteractionAttributes( builder, ref sequence, point, item.Color );
+                context.AddPointInteractionAttributes( builder, ref sequence, point, color );
                 context.RenderPointBoundsAttributeAnimation( builder, ref sequence, animationKey, "cx", SvgChartRenderHelpers.Format( renderedPoint.X ), SvgChartRenderHelpers.Format( renderedPoint.X ), bounds => SvgChartRenderHelpers.Format( bounds.X + bounds.Width / 2 ) );
                 context.RenderPointBoundsAttributeAnimation( builder, ref sequence, animationKey, "cy", SvgChartRenderHelpers.Format( renderedPoint.Y ), SvgChartRenderHelpers.Format( renderedPoint.Y ), bounds => SvgChartRenderHelpers.Format( bounds.Y + bounds.Height / 2 ) );
                 context.RenderPointBoundsAttributeAnimation( builder, ref sequence, animationKey, "r", "0", SvgChartRenderHelpers.Format( item.MarkerRadius ), bounds => SvgChartRenderHelpers.Format( bounds.Width / 2 ) );

--- a/Source/Extensions/Blazorise.Charts.Svg/Renderers/SvgChartPointSeriesRenderer.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Renderers/SvgChartPointSeriesRenderer.cs
@@ -53,16 +53,17 @@ internal sealed class SvgChartPointSeriesRenderer : ISvgChartSeriesRenderer
                     : xValue.Value;
                 var point = chart.CreatePoint( item, pointIndex, category, yValue.Value, bounds );
                 var animationKey = context.TrackPointBounds( item, pointIndex, bounds );
+                var color = item.GetPointColor( pointIndex );
 
                 builder.OpenElement( sequence++, "circle" );
                 builder.AddAttribute( sequence++, "class", $"svg-chart-point svg-chart-{item.Type.ToString().ToLowerInvariant()}" );
                 builder.AddAttribute( sequence++, "cx", SvgChartRenderHelpers.Format( x ) );
                 builder.AddAttribute( sequence++, "cy", SvgChartRenderHelpers.Format( y ) );
                 builder.AddAttribute( sequence++, "r", SvgChartRenderHelpers.Format( radius ) );
-                builder.AddAttribute( sequence++, "fill", item.Color );
+                builder.AddAttribute( sequence++, "fill", color );
                 builder.AddAttribute( sequence++, "opacity", item.Type == SvgChartType.Bubble ? "0.72" : "1" );
                 context.AddAnimatedStyleAttribute( builder, ref sequence );
-                context.AddPointInteractionAttributes( builder, ref sequence, point, item.Color );
+                context.AddPointInteractionAttributes( builder, ref sequence, point, color );
                 context.RenderPointBoundsAttributeAnimation( builder, ref sequence, animationKey, "cx", SvgChartRenderHelpers.Format( x ), SvgChartRenderHelpers.Format( x ), bounds => SvgChartRenderHelpers.Format( bounds.X + bounds.Width / 2 ) );
                 context.RenderPointBoundsAttributeAnimation( builder, ref sequence, animationKey, "cy", SvgChartRenderHelpers.Format( y ), SvgChartRenderHelpers.Format( y ), bounds => SvgChartRenderHelpers.Format( bounds.Y + bounds.Height / 2 ) );
                 context.RenderPointBoundsAttributeAnimation( builder, ref sequence, animationKey, "r", "0", SvgChartRenderHelpers.Format( radius ), bounds => SvgChartRenderHelpers.Format( bounds.Width / 2 ) );

--- a/Source/Extensions/Blazorise.Charts.Svg/Renderers/SvgChartRadarSeriesRenderer.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Renderers/SvgChartRadarSeriesRenderer.cs
@@ -83,17 +83,18 @@ internal sealed class SvgChartRadarSeriesRenderer : ISvgChartSeriesRenderer
                 };
                 var point = chart.CreatePoint( item, pointIndex, value.Value, bounds );
                 var animationKey = context.TrackPointBounds( item, pointIndex, bounds );
+                var color = item.GetPointColor( pointIndex );
 
                 builder.OpenElement( sequence++, "circle" );
                 builder.AddAttribute( sequence++, "class", "svg-chart-point svg-chart-radar-marker" );
                 builder.AddAttribute( sequence++, "cx", SvgChartRenderHelpers.Format( renderedPoint.X ) );
                 builder.AddAttribute( sequence++, "cy", SvgChartRenderHelpers.Format( renderedPoint.Y ) );
                 builder.AddAttribute( sequence++, "r", SvgChartRenderHelpers.Format( markerRadius ) );
-                builder.AddAttribute( sequence++, "fill", item.Color );
+                builder.AddAttribute( sequence++, "fill", color );
                 builder.AddAttribute( sequence++, "stroke", "var(--bs-body-bg, #fff)" );
                 builder.AddAttribute( sequence++, "stroke-width", "1.5" );
                 context.AddAnimatedStyleAttribute( builder, ref sequence );
-                context.AddPointInteractionAttributes( builder, ref sequence, point, item.Color );
+                context.AddPointInteractionAttributes( builder, ref sequence, point, color );
                 context.RenderPointBoundsAttributeAnimation( builder, ref sequence, animationKey, "cx", SvgChartRenderHelpers.Format( renderedPoint.X ), SvgChartRenderHelpers.Format( renderedPoint.X ), bounds => SvgChartRenderHelpers.Format( bounds.X + bounds.Width / 2 ) );
                 context.RenderPointBoundsAttributeAnimation( builder, ref sequence, animationKey, "cy", SvgChartRenderHelpers.Format( renderedPoint.Y ), SvgChartRenderHelpers.Format( renderedPoint.Y ), bounds => SvgChartRenderHelpers.Format( bounds.Y + bounds.Height / 2 ) );
                 context.RenderPointBoundsAttributeAnimation( builder, ref sequence, animationKey, "r", "0", SvgChartRenderHelpers.Format( markerRadius ), bounds => SvgChartRenderHelpers.Format( bounds.Width / 2 ) );

--- a/Source/Extensions/Blazorise.Charts.Svg/Renderers/SvgChartRadialSeriesRenderer.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Renderers/SvgChartRadialSeriesRenderer.cs
@@ -60,7 +60,7 @@ internal sealed class SvgChartRadialSeriesRenderer : ISvgChartSeriesRenderer
             var endAngle = startAngle + sweep;
             var pointRadius = item.Type == SvgChartType.PolarArea ? radius * Math.Sqrt( value / Math.Max( max, 1 ) ) : radius;
             var innerRadius = item.Type == SvgChartType.Doughnut ? radius * 0.58 : 0;
-            var color = context.ResolveColor( pointIndex );
+            var color = item.GetPointColor( pointIndex );
             var category = pointIndex < chart.Labels.Count ? chart.Labels[pointIndex] : pointIndex + 1;
             var bounds = new SvgChartPointBounds { X = centerX - pointRadius, Y = centerY - pointRadius, Width = pointRadius * 2, Height = pointRadius * 2 };
             var point = chart.CreatePoint( item, pointIndex, category, value, bounds );

--- a/Source/Extensions/Blazorise.Charts.Svg/Renderers/SvgChartTextRenderer.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Renderers/SvgChartTextRenderer.cs
@@ -46,16 +46,21 @@ internal static class SvgChartTextRenderer
         return resolved;
     }
 
-    public static SvgChartPlotArea BuildPlotArea( SvgChartOptions options, SvgChartTextOptions title, SvgChartTextOptions subtitle, bool hasTopLegend, bool hasBottomLegend )
+    public static SvgChartPlotArea BuildPlotArea( SvgChartOptions options, SvgChartTextOptions title, SvgChartTextOptions subtitle, bool hasTopLegend, bool hasBottomLegend, SvgChartRenderModel model = null )
     {
-        var top = 24d + GetTopTextHeight( title ) + GetTopTextHeight( subtitle );
+        var padding = options.PlotAreaPadding;
+        var topPadding = padding?.Top ?? 24d;
+        var endPadding = padding?.End ?? 18d;
+        var bottomPadding = ResolveBottomPadding( model, padding?.Bottom );
+        var startPadding = ResolveStartPadding( options, model, padding?.Start );
+        var top = topPadding + GetTopTextHeight( title ) + GetTopTextHeight( subtitle );
 
         if ( hasTopLegend )
             top += 28;
 
-        var bottom = options.Height - 42 - ( hasBottomLegend ? 38 : 0 ) - GetBottomTextHeight( title ) - GetBottomTextHeight( subtitle );
-        var left = 52d + GetStartTextWidth( title ) + GetStartTextWidth( subtitle );
-        var right = options.Width - 18 - GetEndTextWidth( title ) - GetEndTextWidth( subtitle );
+        var bottom = options.Height - bottomPadding - ( hasBottomLegend ? 38 : 0 ) - GetBottomTextHeight( title ) - GetBottomTextHeight( subtitle );
+        var left = startPadding + GetStartTextWidth( title ) + GetStartTextWidth( subtitle );
+        var right = options.Width - endPadding - GetEndTextWidth( title ) - GetEndTextWidth( subtitle );
 
         return new()
         {
@@ -196,6 +201,50 @@ internal static class SvgChartTextRenderer
         return IsTextVisible( text ) && text.Position == SvgChartTextPosition.End
             ? GetTextBlockWidth( text )
             : 0;
+    }
+
+    private static double ResolveStartPadding( SvgChartOptions options, SvgChartRenderModel model, double? padding )
+    {
+        if ( padding.HasValue )
+            return padding.Value;
+
+        const double fallback = 52d;
+
+        if ( model?.Type != SvgChartType.Bar || model.CategoryAxis?.Labels?.Visible == false )
+            return fallback;
+
+        var fontSize = options.Font?.Size ?? 11;
+        var maxLabelWidth = model.Labels
+            .Select( ( label, index ) => FormatCategoryLabel( model, label, index ) )
+            .DefaultIfEmpty( string.Empty )
+            .Max( label => SvgChartRenderHelpers.EstimateTextWidth( label, fontSize ) );
+
+        return Math.Max( fallback, Math.Min( maxLabelWidth + 14, options.Width * 0.45 ) );
+    }
+
+    private static double ResolveBottomPadding( SvgChartRenderModel model, double? padding )
+    {
+        if ( padding.HasValue )
+            return padding.Value;
+
+        if ( model?.Type == SvgChartType.Bar && model.PrimaryValueAxis?.Labels?.Visible == false )
+            return 18d;
+
+        if ( model is not null && model.Type != SvgChartType.Bar && model.CategoryAxis?.Labels?.Visible == false )
+            return 18d;
+
+        return 42d;
+    }
+
+    private static string FormatCategoryLabel( SvgChartRenderModel model, object value, int index )
+    {
+        return model.CategoryTickFormatter?.Invoke( new()
+        {
+            Value = value,
+            Index = index,
+            CategoryAxis = true,
+            AxisId = model.CategoryAxis?.Id
+        } ) ?? SvgChartRenderHelpers.FormatDataLabelValue( value );
     }
 
     private static double GetTextBlockHeight( SvgChartTextOptions text )

--- a/Source/Extensions/Blazorise.Charts.Svg/Renderers/SvgChartTextRenderer.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Renderers/SvgChartTextRenderer.cs
@@ -24,8 +24,8 @@ internal static class SvgChartTextRenderer
 
     public static SvgChartTextOptions ResolveTitleOptions( SvgChartOptions options, IReadOnlyList<SvgChartTitle> titleComponents )
     {
-        var titleComponent = titleComponents.LastOrDefault();
-        var resolved = SvgChartOptionsMapper.CreateTextOptions( CreateDefaultTitleOptions(), options.Title );
+        var titleComponent = titleComponents?.LastOrDefault();
+        var resolved = SvgChartOptionsMapper.CreateTextOptions( CreateDefaultTitleOptions(), options?.Title );
         var componentOptions = titleComponent?.Title;
 
         if ( componentOptions is not null )
@@ -36,8 +36,8 @@ internal static class SvgChartTextRenderer
 
     public static SvgChartTextOptions ResolveSubtitleOptions( SvgChartOptions options, IReadOnlyList<SvgChartTitle> titleComponents )
     {
-        var titleComponent = titleComponents.LastOrDefault();
-        var resolved = SvgChartOptionsMapper.CreateTextOptions( CreateDefaultSubtitleOptions(), options.Subtitle );
+        var titleComponent = titleComponents?.LastOrDefault();
+        var resolved = SvgChartOptionsMapper.CreateTextOptions( CreateDefaultSubtitleOptions(), options?.Subtitle );
         var componentOptions = titleComponent?.Subtitle;
 
         if ( componentOptions is not null )
@@ -48,6 +48,8 @@ internal static class SvgChartTextRenderer
 
     public static SvgChartPlotArea BuildPlotArea( SvgChartOptions options, SvgChartTextOptions title, SvgChartTextOptions subtitle, bool hasTopLegend, bool hasBottomLegend, SvgChartRenderModel model = null )
     {
+        options ??= new();
+
         var padding = options.PlotAreaPadding;
         var topPadding = padding?.Top ?? 24d;
         var endPadding = padding?.End ?? 18d;
@@ -213,7 +215,7 @@ internal static class SvgChartTextRenderer
         if ( model?.Type != SvgChartType.Bar || model.CategoryAxis?.Labels?.Visible == false )
             return fallback;
 
-        var fontSize = options.Font?.Size ?? 11;
+        var fontSize = options?.Font?.Size ?? 11;
         var maxLabelWidth = model.Labels
             .Select( ( label, index ) => FormatCategoryLabel( model, label, index ) )
             .DefaultIfEmpty( string.Empty )

--- a/Source/Extensions/Blazorise.Charts.Svg/Series/SvgChartSeries.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Series/SvgChartSeries.cs
@@ -80,6 +80,16 @@ public abstract class SvgChartSeries<TItem> : SvgChartComponentBase
     [Parameter] public Color Color { get; set; }
 
     /// <summary>
+    /// Defines explicit colors for individual data points.
+    /// </summary>
+    [Parameter] public IReadOnlyList<Color> Colors { get; set; }
+
+    /// <summary>
+    /// Defines a selector used to read colors for individual data points from chart items.
+    /// </summary>
+    [Parameter] public Func<TItem, Color> PointColor { get; set; }
+
+    /// <summary>
     /// Defines whether the series is hidden.
     /// </summary>
     [Parameter] public bool Hidden { get; set; }


### PR DESCRIPTION
Closes #6609

Adds per-point color support for SVG chart series through `Colors` and `PointColor`, including renderers, data labels, legends, and tooltips. Also improves axis label controls and plot-area padding for compact charts, adds a docs example explaining index-based color mapping, and hardens chart data/options handling so null user-provided collections do not throw at runtime.