### PR TITLE
BarDropdown: fix the closing of current dropdown menu

### DIFF
--- a/Source/Blazorise/Components/Bar/BarDropdown.razor.cs
+++ b/Source/Blazorise/Components/Bar/BarDropdown.razor.cs
@@ -142,6 +142,18 @@ public partial class BarDropdown : BaseComponent, IAsyncDisposable
         if ( ParentBarDropdown is not null && ( ParentBarDropdown.ShouldClose || hideAll ) )
             await ParentBarDropdown.Hide( hideAll );
 
+        await HideCurrent();
+    }
+
+    /// <summary>
+    /// Hides only the current dropdown menu without affecting its parent dropdown menus.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    private async Task HideCurrent()
+    {
+        if ( !IsVisible )
+            return;
+
         await SetVisibleState( false );
 
         await InvokeAsync( StateHasChanged );
@@ -270,7 +282,7 @@ public partial class BarDropdown : BaseComponent, IAsyncDisposable
         await Task.Delay( Math.Max( 0, CloseDelay ) );
 
         if ( ShouldClose && closeVersion == mouseLeaveCloseVersion )
-            await Hide();
+            await HideCurrent();
     }
 
     /// <summary>


### PR DESCRIPTION
- Fixed Bar submenu hover behavior so a delayed child submenu mouseleave only closes the child dropdown.
- Preserved parent dropdown visibility when the pointer moves back into the parent menu during the child close delay.