### PR TITLE
MessageProvider: support separate modal instances

### DIFF
--- a/Source/Blazorise/Components/MessageProvider/MessageProvider.razor
+++ b/Source/Blazorise/Components/MessageProvider/MessageProvider.razor
@@ -1,68 +1,71 @@
 ﻿@namespace Blazorise
 @inherits BaseComponent
-<Modal @ref="@ModalRef" @bind-Visible="@ModalVisible" Closing="@OnModalClosing" Centered="@CenterMessage" Scrollable="@ScrollableMessage" Size="@Size">
-    <ModalContent>
-        <ModalHeader>
-            <ModalTitle Class="@TitleClass">
-                @Title
-            </ModalTitle>
-            @if ( ShowCloseButton )
-            {
-                <CloseButton Clicked="@OnCancelClicked" />
-            }
-        </ModalHeader>
-        <ModalBody TextAlignment="TextAlignment.Center">
-            @if ( ShowMessageIcon )
-            {
-                <Heading Size="HeadingSize.Is2" TextAlignment="TextAlignment.Center">
-                    <Icon Name="@MessageIcon" TextColor="@MessageIconColor" />
-                </Heading>
-            }
-            <Text TextAlignment="TextAlignment.Center" Class="@MessageClass">
-                @Message
-            </Text>
-        </ModalBody>
-        <ModalFooter>
-            @if ( IsConfirmation )
-            {
-                <Button Color="@CancelButtonColor" Class="@CancelButtonClass" Padding="@CancelButtonPadding" Clicked="@OnCancelClicked">
-                    @if ( Options?.CancelButtonIcon is not null )
-                    {
-                        <Icon Name="@Options.CancelButtonIcon" TextColor="@(Options.CancelButtonIconColor ?? TextColor.Default)" Margin="Blazorise.Margin.Is2.FromEnd" />
-                    }
-                    @CancelButtonText
-                </Button>
-                <Button Color="@ConfirmButtonColor" Class="@ConfirmButtonClass" Padding="@ConfirmButtonPadding" Clicked="@OnConfirmClicked">
-                    @if ( Options?.ConfirmButtonIcon is not null )
-                    {
-                        <Icon Name="@Options.ConfirmButtonIcon" TextColor="@(Options.ConfirmButtonIconColor ?? TextColor.Default)" Margin="Blazorise.Margin.Is2.FromEnd" />
-                    }
-                    @ConfirmButtonText
-                </Button>
-            }
-            else if ( IsChoice )
-            {
-                @foreach ( var choice in Choices )
+@foreach ( var message in Messages )
+{
+    <Modal @key="@message.Id" @ref="@message.ModalRef" @bind-Visible="@message.Visible" Closing="@(( eventArgs ) => OnModalClosing( message, eventArgs ))" Closed="@(() => OnModalClosed( message ))" Centered="@GetCenterMessage( message )" Scrollable="@GetScrollableMessage( message )" Size="@GetSize( message )">
+        <ModalContent>
+            <ModalHeader>
+                <ModalTitle Class="@GetTitleClass( message )">
+                    @message.Title
+                </ModalTitle>
+                @if ( GetShowCloseButton( message ) )
                 {
-                    <Button @key="@choice.Key" Color="@choice.Color" Class="@choice.Class" Padding="@choice.Padding" Clicked="@(() => OnChoiceClicked( choice ))">
-                        @if ( choice.Icon is not null )
+                    <CloseButton Clicked="@(() => OnCancelClicked( message ))" />
+                }
+            </ModalHeader>
+            <ModalBody TextAlignment="TextAlignment.Center">
+                @if ( GetShowMessageIcon( message ) )
+                {
+                    <Heading Size="HeadingSize.Is2" TextAlignment="TextAlignment.Center">
+                        <Icon Name="@GetMessageIcon( message )" TextColor="@GetMessageIconColor( message )" />
+                    </Heading>
+                }
+                <Text TextAlignment="TextAlignment.Center" Class="@GetMessageClass( message )">
+                    @message.Message
+                </Text>
+            </ModalBody>
+            <ModalFooter>
+                @if ( IsConfirmationMessage( message ) )
+                {
+                    <Button Color="@GetCancelButtonColor( message )" Class="@GetCancelButtonClass( message )" Padding="@GetCancelButtonPadding( message )" Clicked="@(() => OnCancelClicked( message ))">
+                        @if ( message.Options?.CancelButtonIcon is not null )
                         {
-                            <Icon Name="@choice.Icon" TextColor="@(choice.IconColor ?? TextColor.Default)" Margin="Blazorise.Margin.Is2.FromEnd" />
+                            <Icon Name="@message.Options.CancelButtonIcon" TextColor="@(message.Options.CancelButtonIconColor ?? TextColor.Default)" Margin="Blazorise.Margin.Is2.FromEnd" />
                         }
-                        @choice.Text
+                        @GetCancelButtonText( message )
+                    </Button>
+                    <Button Color="@GetConfirmButtonColor( message )" Class="@GetConfirmButtonClass( message )" Padding="@GetConfirmButtonPadding( message )" Clicked="@(() => OnConfirmClicked( message ))">
+                        @if ( message.Options?.ConfirmButtonIcon is not null )
+                        {
+                            <Icon Name="@message.Options.ConfirmButtonIcon" TextColor="@(message.Options.ConfirmButtonIconColor ?? TextColor.Default)" Margin="Blazorise.Margin.Is2.FromEnd" />
+                        }
+                        @GetConfirmButtonText( message )
                     </Button>
                 }
-            }
-            else
-            {
-                <Button Color="@OkButtonColor" Class="@OkButtonClass" Padding="@OkButtonPadding" Clicked="@OnOkClicked">
-                    @if ( Options?.OkButtonIcon is not null )
+                else if ( IsChoiceMessage( message ) )
+                {
+                    @foreach ( var choice in GetChoices( message ) )
                     {
-                        <Icon Name="@Options.OkButtonIcon" TextColor="@(Options.OkButtonIconColor ?? TextColor.Default)" Margin="Blazorise.Margin.Is2.FromEnd" />
+                        <Button @key="@choice.Key" Color="@choice.Color" Class="@choice.Class" Padding="@choice.Padding" Clicked="@(() => OnChoiceClicked( message, choice ))">
+                            @if ( choice.Icon is not null )
+                            {
+                                <Icon Name="@choice.Icon" TextColor="@(choice.IconColor ?? TextColor.Default)" Margin="Blazorise.Margin.Is2.FromEnd" />
+                            }
+                            @choice.Text
+                        </Button>
                     }
-                    @OkButtonText
-                </Button>
-            }
-        </ModalFooter>
-    </ModalContent>
-</Modal>
+                }
+                else
+                {
+                    <Button Color="@GetOkButtonColor( message )" Class="@GetOkButtonClass( message )" Padding="@GetOkButtonPadding( message )" Clicked="@(() => OnOkClicked( message ))">
+                        @if ( message.Options?.OkButtonIcon is not null )
+                        {
+                            <Icon Name="@message.Options.OkButtonIcon" TextColor="@(message.Options.OkButtonIconColor ?? TextColor.Default)" Margin="Blazorise.Margin.Is2.FromEnd" />
+                        }
+                        @GetOkButtonText( message )
+                    </Button>
+                }
+            </ModalFooter>
+        </ModalContent>
+    </Modal>
+}

--- a/Source/Blazorise/Components/MessageProvider/MessageProvider.razor.cs
+++ b/Source/Blazorise/Components/MessageProvider/MessageProvider.razor.cs
@@ -16,6 +16,8 @@ public partial class MessageProvider : BaseComponent, IDisposable
 {
     #region Members
 
+    private const int MessageRemovalDelayMilliseconds = 5000;
+
     private readonly List<MessageInstance> messages = [];
 
     private int messageSequence;
@@ -63,14 +65,39 @@ public partial class MessageProvider : BaseComponent, IDisposable
 
     private Task OnModalClosed( MessageInstance message )
     {
+        ScheduleMessageRemoval( message );
+
+        return Task.CompletedTask;
+    }
+
+    private void ScheduleMessageRemoval( MessageInstance message )
+    {
+        if ( message.Removing )
+            return;
+
+        message.Removing = true;
+
         ExecuteAfterRender( async () =>
         {
+            await Task.Delay( MessageRemovalDelayMilliseconds );
+
             messages.Remove( message );
 
             await InvokeAsync( StateHasChanged );
         } );
 
-        return InvokeAsync( StateHasChanged );
+        InvokeAsync( StateHasChanged );
+    }
+
+    private void HideMessage( MessageInstance message )
+    {
+        if ( message.Closing )
+            return;
+
+        message.Closing = true;
+
+        _ = message.ModalRef.Hide();
+        ScheduleMessageRemoval( message );
     }
 
     /// <summary>
@@ -83,7 +110,7 @@ public partial class MessageProvider : BaseComponent, IDisposable
         {
             await Okayed.InvokeAsync();
 
-            await message.ModalRef.Hide();
+            HideMessage( message );
         } );
     }
 
@@ -111,7 +138,7 @@ public partial class MessageProvider : BaseComponent, IDisposable
     {
         return InvokeAsync( async () =>
         {
-            await message.ModalRef.Hide();
+            HideMessage( message );
 
             if ( IsConfirmationMessage( message ) && message.Callback is not null && !message.Callback.Task.IsCompleted )
             {
@@ -146,7 +173,8 @@ public partial class MessageProvider : BaseComponent, IDisposable
     {
         return InvokeAsync( async () =>
         {
-            await message.ModalRef.Hide();
+            HideMessage( message );
+
             await NotifyCanceled( message );
         } );
     }
@@ -177,7 +205,7 @@ public partial class MessageProvider : BaseComponent, IDisposable
     {
         return InvokeAsync( async () =>
         {
-            await message.ModalRef.Hide();
+            HideMessage( message );
 
             if ( IsChoiceMessage( message ) && message.Callback is not null && !message.Callback.Task.IsCompleted )
             {
@@ -647,6 +675,16 @@ public partial class MessageProvider : BaseComponent, IDisposable
         /// Gets or sets whether the message modal is visible.
         /// </summary>
         public bool Visible { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether the message modal has started closing.
+        /// </summary>
+        public bool Closing { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether the message modal has been scheduled for removal.
+        /// </summary>
+        public bool Removing { get; set; }
 
         /// <summary>
         /// Gets or sets the <see cref="Modal"/> reference.

--- a/Source/Blazorise/Components/MessageProvider/MessageProvider.razor.cs
+++ b/Source/Blazorise/Components/MessageProvider/MessageProvider.razor.cs
@@ -16,8 +16,6 @@ public partial class MessageProvider : BaseComponent, IDisposable
 {
     #region Members
 
-    private const int MessageRemovalDelayMilliseconds = 5000;
-
     private readonly List<MessageInstance> messages = [];
 
     private int messageSequence;
@@ -77,27 +75,27 @@ public partial class MessageProvider : BaseComponent, IDisposable
 
         message.Removing = true;
 
-        ExecuteAfterRender( async () =>
+        ExecuteAfterRender( () =>
         {
-            await Task.Delay( MessageRemovalDelayMilliseconds );
-
             messages.Remove( message );
 
-            await InvokeAsync( StateHasChanged );
+            return InvokeAsync( StateHasChanged );
         } );
 
         InvokeAsync( StateHasChanged );
     }
 
-    private void HideMessage( MessageInstance message )
+    private Task HideMessage( MessageInstance message )
     {
         if ( message.Closing )
-            return;
+            return Task.CompletedTask;
 
         message.Closing = true;
+        message.Visible = false;
 
         _ = message.ModalRef.Hide();
-        ScheduleMessageRemoval( message );
+
+        return Task.CompletedTask;
     }
 
     /// <summary>
@@ -110,7 +108,7 @@ public partial class MessageProvider : BaseComponent, IDisposable
         {
             await Okayed.InvokeAsync();
 
-            HideMessage( message );
+            await HideMessage( message );
         } );
     }
 
@@ -138,7 +136,7 @@ public partial class MessageProvider : BaseComponent, IDisposable
     {
         return InvokeAsync( async () =>
         {
-            HideMessage( message );
+            await HideMessage( message );
 
             if ( IsConfirmationMessage( message ) && message.Callback is not null && !message.Callback.Task.IsCompleted )
             {
@@ -173,7 +171,7 @@ public partial class MessageProvider : BaseComponent, IDisposable
     {
         return InvokeAsync( async () =>
         {
-            HideMessage( message );
+            await HideMessage( message );
 
             await NotifyCanceled( message );
         } );
@@ -205,7 +203,7 @@ public partial class MessageProvider : BaseComponent, IDisposable
     {
         return InvokeAsync( async () =>
         {
-            HideMessage( message );
+            await HideMessage( message );
 
             if ( IsChoiceMessage( message ) && message.Callback is not null && !message.Callback.Task.IsCompleted )
             {

--- a/Source/Blazorise/Components/MessageProvider/MessageProvider.razor.cs
+++ b/Source/Blazorise/Components/MessageProvider/MessageProvider.razor.cs
@@ -14,6 +14,14 @@ namespace Blazorise;
 /// </summary>
 public partial class MessageProvider : BaseComponent, IDisposable
 {
+    #region Members
+
+    private readonly List<MessageInstance> messages = [];
+
+    private int messageSequence;
+
+    #endregion
+
     #region Methods
 
     /// <inheritdoc/>
@@ -42,14 +50,40 @@ public partial class MessageProvider : BaseComponent, IDisposable
     {
         await InvokeAsync( () =>
         {
-            MessageType = e.MessageType;
-            Message = e.Message;
-            Title = e.Title;
-            Options = e.Options;
-            Callback = e.Callback;
-            ModalVisible = true;
+            ShowMessage( e );
+        } );
+    }
 
-            StateHasChanged();
+    private void ShowMessage( MessageEventArgs e )
+    {
+        messages.Add( new( ++messageSequence, e ) );
+
+        StateHasChanged();
+    }
+
+    private Task OnModalClosed( MessageInstance message )
+    {
+        ExecuteAfterRender( async () =>
+        {
+            messages.Remove( message );
+
+            await InvokeAsync( StateHasChanged );
+        } );
+
+        return InvokeAsync( StateHasChanged );
+    }
+
+    /// <summary>
+    /// Handles the OK button click event.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    protected Task OnOkClicked( MessageInstance message )
+    {
+        return InvokeAsync( async () =>
+        {
+            await Okayed.InvokeAsync();
+
+            await message.ModalRef.Hide();
         } );
     }
 
@@ -59,11 +93,32 @@ public partial class MessageProvider : BaseComponent, IDisposable
     /// <returns>A task that represents the asynchronous operation.</returns>
     protected Task OnOkClicked()
     {
+        var message = LastMessage;
+
+        if ( message is null )
+        {
+            return Task.CompletedTask;
+        }
+
+        return OnOkClicked( message );
+    }
+
+    /// <summary>
+    /// Handles the Confirm button click event.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    protected Task OnConfirmClicked( MessageInstance message )
+    {
         return InvokeAsync( async () =>
         {
-            await Okayed.InvokeAsync();
+            await message.ModalRef.Hide();
 
-            await ModalRef.Hide();
+            if ( IsConfirmationMessage( message ) && message.Callback is not null && !message.Callback.Task.IsCompleted )
+            {
+                await InvokeAsync( () => message.Callback.SetResult( true ) );
+            }
+
+            await Confirmed.InvokeAsync();
         } );
     }
 
@@ -73,16 +128,26 @@ public partial class MessageProvider : BaseComponent, IDisposable
     /// <returns>A task that represents the asynchronous operation.</returns>
     protected Task OnConfirmClicked()
     {
+        var message = LastMessage;
+
+        if ( message is null )
+        {
+            return Task.CompletedTask;
+        }
+
+        return OnConfirmClicked( message );
+    }
+
+    /// <summary>
+    /// Handles the Cancel button click event.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    protected Task OnCancelClicked( MessageInstance message )
+    {
         return InvokeAsync( async () =>
         {
-            await ModalRef.Hide();
-
-            if ( IsConfirmation && Callback is not null && !Callback.Task.IsCompleted )
-            {
-                await InvokeAsync( () => Callback.SetResult( true ) );
-            }
-
-            await Confirmed.InvokeAsync();
+            await message.ModalRef.Hide();
+            await NotifyCanceled( message );
         } );
     }
 
@@ -92,10 +157,34 @@ public partial class MessageProvider : BaseComponent, IDisposable
     /// <returns>A task that represents the asynchronous operation.</returns>
     protected Task OnCancelClicked()
     {
+        var message = LastMessage;
+
+        if ( message is null )
+        {
+            return Task.CompletedTask;
+        }
+
+        return OnCancelClicked( message );
+    }
+
+    /// <summary>
+    /// Handles the event when a choice button is clicked, hiding the modal and invoking callbacks as necessary.
+    /// </summary>
+    /// <param name="message">Message instance that owns the choice.</param>
+    /// <param name="choice">Represents the button that was clicked, providing its key for further processing.</param>
+    /// <returns>Returns a task that represents the asynchronous operation of handling the button click.</returns>
+    protected Task OnChoiceClicked( MessageInstance message, MessageOptionsChoice choice )
+    {
         return InvokeAsync( async () =>
         {
-            await ModalRef.Hide();
-            await NotifyCanceled();
+            await message.ModalRef.Hide();
+
+            if ( IsChoiceMessage( message ) && message.Callback is not null && !message.Callback.Task.IsCompleted )
+            {
+                await InvokeAsync( () => message.Callback.SetResult( choice.Key ) );
+            }
+
+            await Confirmed.InvokeAsync();
         } );
     }
 
@@ -106,17 +195,35 @@ public partial class MessageProvider : BaseComponent, IDisposable
     /// <returns>Returns a task that represents the asynchronous operation of handling the button click.</returns>
     protected Task OnChoiceClicked( MessageOptionsChoice choice )
     {
-        return InvokeAsync( async () =>
+        var message = LastMessage;
+
+        if ( message is null )
         {
-            await ModalRef.Hide();
+            return Task.CompletedTask;
+        }
 
-            if ( IsChoice && Callback is not null && !Callback.Task.IsCompleted )
-            {
-                await InvokeAsync( () => Callback.SetResult( choice.Key ) );
-            }
+        return OnChoiceClicked( message, choice );
+    }
 
-            await Confirmed.InvokeAsync();
-        } );
+    /// <summary>
+    /// Handles the <see cref="Modal"/> closing event.
+    /// </summary>
+    /// <param name="message">Message instance that owns the modal.</param>
+    /// <param name="eventArgs">Provides the data for the modal closing event.</param>
+    protected virtual async Task OnModalClosing( MessageInstance message, ModalClosingEventArgs eventArgs )
+    {
+        var isEscapeClosing = eventArgs.CloseReason == CloseReason.EscapeClosing;
+        var isFocusLostClosing = eventArgs.CloseReason == CloseReason.FocusLostClosing;
+
+        if ( isEscapeClosing && ( message.Options?.CloseOnEscape ?? CloseOnEscape ) )
+        {
+            await NotifyCanceled( message );
+
+            return;
+        }
+
+        eventArgs.Cancel = ( message.Options?.BackgroundCancel ?? BackgroundCancel )
+            && ( isEscapeClosing || isFocusLostClosing );
     }
 
     /// <summary>
@@ -125,51 +232,136 @@ public partial class MessageProvider : BaseComponent, IDisposable
     /// <param name="eventArgs">Provides the data for the modal closing event.</param>
     protected virtual async Task OnModalClosing( ModalClosingEventArgs eventArgs )
     {
-        var isEscapeClosing = eventArgs.CloseReason == CloseReason.EscapeClosing;
-        var isFocusLostClosing = eventArgs.CloseReason == CloseReason.FocusLostClosing;
+        var message = LastMessage;
 
-        if ( isEscapeClosing && ( Options?.CloseOnEscape ?? CloseOnEscape ) )
+        if ( message is not null )
         {
-            await NotifyCanceled();
-
-            return;
+            await OnModalClosing( message, eventArgs );
         }
-
-        eventArgs.Cancel = ( Options?.BackgroundCancel ?? BackgroundCancel )
-            && ( isEscapeClosing || isFocusLostClosing );
     }
 
     /// <summary>
     /// Notifies that the message dialog was canceled.
     /// </summary>
+    /// <param name="message">Message instance that was canceled.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
-    private async Task NotifyCanceled()
+    private async Task NotifyCanceled( MessageInstance message )
     {
-        if ( IsConfirmation && Callback is not null && !Callback.Task.IsCompleted )
+        if ( IsConfirmationMessage( message ) && message.Callback is not null && !message.Callback.Task.IsCompleted )
         {
-            await InvokeAsync( () => Callback.SetResult( false ) );
+            await InvokeAsync( () => message.Callback.SetResult( false ) );
         }
-        else if ( IsChoice && Callback is not null && !Callback.Task.IsCompleted )
+        else if ( IsChoiceMessage( message ) && message.Callback is not null && !message.Callback.Task.IsCompleted )
         {
-            await InvokeAsync( () => Callback.SetResult( null ) );
+            await InvokeAsync( () => message.Callback.SetResult( null ) );
         }
 
         await Canceled.InvokeAsync();
     }
+
+    private static bool IsConfirmationMessage( MessageInstance message )
+        => message.MessageType == MessageType.Confirmation;
+
+    private static bool IsChoiceMessage( MessageInstance message )
+        => message.MessageType == MessageType.Choice;
+
+    private bool GetCenterMessage( MessageInstance message )
+        => GetSize( message ) == ModalSize.Fullscreen ? false : message.Options?.CenterMessage ?? true;
+
+    private bool GetScrollableMessage( MessageInstance message )
+        => GetSize( message ) == ModalSize.Fullscreen ? false : message.Options?.ScrollableMessage ?? true;
+
+    private static bool GetShowMessageIcon( MessageInstance message )
+        => message.Options?.ShowMessageIcon ?? true;
+
+    private static bool GetShowCloseButton( MessageInstance message )
+        => message.Options?.ShowCloseButton ?? false;
+
+    private static object GetMessageIcon( MessageInstance message )
+        => message.Options?.MessageIcon ?? message.MessageType switch
+        {
+            MessageType.Info => IconName.Info,
+            MessageType.Success => IconName.Check,
+            MessageType.Warning => IconName.Exclamation,
+            MessageType.Error => IconName.Times,
+            MessageType.Confirmation => IconName.QuestionCircle,
+            _ => null,
+        };
+
+    private static TextColor GetMessageIconColor( MessageInstance message )
+        => message.Options?.MessageIconColor ?? message.MessageType switch
+        {
+            MessageType.Info => TextColor.Info,
+            MessageType.Success => TextColor.Success,
+            MessageType.Warning => TextColor.Warning,
+            MessageType.Error => TextColor.Danger,
+            MessageType.Confirmation => TextColor.Secondary,
+            _ => TextColor.Default,
+        };
+
+    private string GetOkButtonText( MessageInstance message )
+        => message.Options?.OkButtonText ?? Localizer["OK"] ?? "OK";
+
+    private static Color GetOkButtonColor( MessageInstance message )
+        => message.Options?.OkButtonColor ?? Color.Primary;
+
+    private static string GetOkButtonClass( MessageInstance message )
+        => message.Options?.OkButtonClass;
+
+    private static string GetTitleClass( MessageInstance message )
+        => message.Options?.TitleClass;
+
+    private static string GetMessageClass( MessageInstance message )
+        => message.Options?.MessageClass;
+
+    private string GetConfirmButtonText( MessageInstance message )
+        => message.Options?.ConfirmButtonText ?? Localizer["Confirm"] ?? "Confirm";
+
+    private static Color GetConfirmButtonColor( MessageInstance message )
+        => message.Options?.ConfirmButtonColor ?? Color.Primary;
+
+    private static string GetConfirmButtonClass( MessageInstance message )
+        => message.Options?.ConfirmButtonClass;
+
+    private string GetCancelButtonText( MessageInstance message )
+        => message.Options?.CancelButtonText ?? Localizer["Cancel"] ?? "Cancel";
+
+    private static Color GetCancelButtonColor( MessageInstance message )
+        => message.Options?.CancelButtonColor ?? Color.Secondary;
+
+    private static string GetCancelButtonClass( MessageInstance message )
+        => message.Options?.CancelButtonClass;
+
+    private static IFluentSpacing GetOkButtonPadding( MessageInstance message )
+        => message.Options?.OkButtonPadding ?? Blazorise.Padding.Is2.OnX;
+
+    private static IFluentSpacing GetCancelButtonPadding( MessageInstance message )
+        => message.Options?.CancelButtonPadding ?? Blazorise.Padding.Is2.OnX;
+
+    private static IFluentSpacing GetConfirmButtonPadding( MessageInstance message )
+        => message.Options?.ConfirmButtonPadding ?? Blazorise.Padding.Is2.OnX;
+
+    private static ModalSize GetSize( MessageInstance message )
+        => message.Options?.Size ?? ModalSize.Default;
+
+    private static IEnumerable<MessageOptionsChoice> GetChoices( MessageInstance message )
+        => message.Options?.Choices ?? [];
 
     #endregion
 
     #region Properties
 
     /// <summary>
-    /// Gets or sets the <see cref="Modal"/> reference.
+    /// Gets the active message instances.
     /// </summary>
-    protected Modal ModalRef { get; set; }
+    protected IEnumerable<MessageInstance> Messages
+        => messages;
 
     /// <summary>
-    /// Gets or sets whether the message modal is visible.
+    /// Gets the latest message instance.
     /// </summary>
-    protected bool ModalVisible { get; set; }
+    protected MessageInstance LastMessage
+        => messages.LastOrDefault();
 
     /// <summary>
     /// If true, modal will act as a prompt dialog.
@@ -395,6 +587,72 @@ public partial class MessageProvider : BaseComponent, IDisposable
     /// Confirmation dialogs will treat Escape as a cancel action.
     /// </summary>
     [Parameter] public bool CloseOnEscape { get; set; }
+
+    #endregion
+
+    #region Classes
+
+    /// <summary>
+    /// Represents a single message dialog instance.
+    /// </summary>
+    protected sealed class MessageInstance
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MessageInstance"/> class based on the provided message event arguments.    
+        /// </summary>
+        /// <param name="id">The unique identifier for the message instance.</param>
+        /// <param name="messageEventArgs">The message event arguments.</param>
+        public MessageInstance( int id, MessageEventArgs messageEventArgs )
+        {
+            Id = id;
+            MessageType = messageEventArgs.MessageType;
+            Message = messageEventArgs.Message;
+            Title = messageEventArgs.Title;
+            Options = messageEventArgs.Options;
+            Callback = messageEventArgs.Callback;
+            Visible = true;
+        }
+
+        /// <summary>
+        /// Gets the unique message instance id.
+        /// </summary>
+        public int Id { get; }
+
+        /// <summary>
+        /// Gets the message type.
+        /// </summary>
+        public MessageType MessageType { get; }
+
+        /// <summary>
+        /// Gets the message title.
+        /// </summary>
+        public string Title { get; }
+
+        /// <summary>
+        /// Gets the message content.
+        /// </summary>
+        public MarkupString Message { get; }
+
+        /// <summary>
+        /// Gets the custom message options.
+        /// </summary>
+        public MessageOptions Options { get; }
+
+        /// <summary>
+        /// Gets the callback that completes when the user responds.
+        /// </summary>
+        public TaskCompletionSource<object> Callback { get; }
+
+        /// <summary>
+        /// Gets or sets whether the message modal is visible.
+        /// </summary>
+        public bool Visible { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="Modal"/> reference.
+        /// </summary>
+        public Modal ModalRef { get; set; }
+    }
 
     #endregion
 }

--- a/Tests/Blazorise.Tests/Components/MessageProviderComponentTest.cs
+++ b/Tests/Blazorise.Tests/Components/MessageProviderComponentTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Bunit;
 using Microsoft.Extensions.DependencyInjection;
@@ -24,7 +25,7 @@ public class MessageProviderComponentTest : BunitContext
 
         await ShowInfoMessage( component, options => options.Size = ModalSize.Large );
 
-        component.WaitForAssertion( () => Assert.Contains( "modal-lg", component.Find( ".modal-dialog" ).ClassName ) );
+        component.WaitForAssertion( () => Assert.Contains( "modal-lg", FindLatestModalDialog( component ).ClassName ) );
     }
 
     [Fact]
@@ -33,13 +34,13 @@ public class MessageProviderComponentTest : BunitContext
         var component = Render<MessageProvider>();
 
         await ShowInfoMessage( component, options => options.Size = ModalSize.Large );
-        component.WaitForAssertion( () => Assert.Contains( "modal-lg", component.Find( ".modal-dialog" ).ClassName ) );
+        component.WaitForAssertion( () => Assert.Contains( "modal-lg", FindLatestModalDialog( component ).ClassName ) );
 
         await component.Find( "button" ).ClickAsync();
 
         await ShowInfoMessage( component );
 
-        component.WaitForAssertion( () => Assert.DoesNotContain( "modal-lg", component.Find( ".modal-dialog" ).ClassName ) );
+        component.WaitForAssertion( () => Assert.DoesNotContain( "modal-lg", FindLatestModalDialog( component ).ClassName ) );
     }
 
     [Fact]
@@ -62,6 +63,61 @@ public class MessageProviderComponentTest : BunitContext
         await component.InvokeAsync( () => component.Instance.InvokeModalClosing( new( false, CloseReason.EscapeClosing ) ) );
 
         Assert.False( await confirmTask );
+    }
+
+    [Fact]
+    public async Task ConfirmCanBeChainedFromCancelContinuation()
+    {
+        var component = Render<MessageProvider>();
+        var messageService = Services.GetRequiredService<IMessageService>();
+        Task flowTask = null;
+        Task<bool> secondConfirmTask = null;
+
+        async Task ShowMessages()
+        {
+            if ( await messageService.Confirm( "Confirm1", "Title" ) )
+            {
+                return;
+            }
+
+            secondConfirmTask = messageService.Confirm( "Confirm2", "Title" );
+
+            await secondConfirmTask;
+        }
+
+        await component.InvokeAsync( () =>
+        {
+            flowTask = ShowMessages();
+
+            return Task.CompletedTask;
+        } );
+
+        component.WaitForAssertion( () => Assert.Contains( "Confirm1", component.Markup ) );
+
+        await ClickLatestCancelButton( component );
+
+        component.WaitForAssertion( () => Assert.Contains( "Confirm2", component.Markup ) );
+        Assert.NotNull( secondConfirmTask );
+        Assert.False( secondConfirmTask.IsCompleted );
+
+        await ClickLatestCancelButton( component );
+        await flowTask;
+
+        Assert.False( await secondConfirmTask );
+    }
+
+    private static Task ClickLatestCancelButton( IRenderedComponent<MessageProvider> component )
+    {
+        var buttons = component.FindAll( "button" );
+
+        return buttons[buttons.Count - 2].ClickAsync();
+    }
+
+    private static AngleSharp.Dom.IElement FindLatestModalDialog( IRenderedComponent<MessageProvider> component )
+    {
+        var modalDialogs = component.FindAll( ".modal-dialog" );
+
+        return modalDialogs.Last();
     }
 
     private Task ShowInfoMessage( IRenderedComponent<MessageProvider> component, Action<MessageOptions> options = null )


### PR DESCRIPTION
Closes #6619 

- Updated `MessageProvider` to support multiple active message modal instances.
- Prevented async message callbacks from reusing the same modal instance while a previous message is still closing.
- Kept closing message instances mounted until the modal Closed event, so close animations can complete.
- Synchronized message visibility when closing starts to avoid rerenders, reopening a closing modal.