### PR TITLE
Autocomplete: fix null value clearing and selected text dropdown sync

### DIFF
--- a/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
+++ b/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
@@ -70,6 +70,7 @@ public partial class Autocomplete<TItem, TValue>
     private bool selectedValuesParamChanged;
     private bool selectedTextsParamChanged;
     private bool dataParamChanged;
+    private bool showAllItemsOnFocus;
 
     private TValue selectedValueParam;
     private bool selectedValueParamDefined;
@@ -287,7 +288,7 @@ public partial class Autocomplete<TItem, TValue>
             }
         }
 
-        await SynchronizeSingle( selectedValueParamChanged, selectedTextParamChanged );
+        await SynchronizeSingle( selectedValueParamChanged, selectedTextParamChanged, dataParamChanged );
         await SynchronizeMultiple( selectedValuesParamChanged, selectedTextsParamChanged, dataParamChanged );
     }
 
@@ -310,7 +311,7 @@ public partial class Autocomplete<TItem, TValue>
             return new( Data.ToList(), TotalItems ?? default );
     }
 
-    private async Task SynchronizeSingle( bool selectedValueParamChanged, bool selectedTextParamChanged )
+    private async Task SynchronizeSingle( bool selectedValueParamChanged, bool selectedTextParamChanged, bool dataParamChanged )
     {
         if ( selectedTextParamChanged && !selectedValueParamChanged )
         {
@@ -349,12 +350,26 @@ public partial class Autocomplete<TItem, TValue>
             }
         }
 
-        if ( selectedValueParamChanged )
+        if ( selectedValueParamChanged || ( dataParamChanged && !IsMultiple && !SelectedValue.IsEqual( default ) ) )
         {
             var item = GetItemByValue( SelectedValue );
             if ( item is null )
             {
-                await ResetSelectedValue();
+                if ( selectedValueParamChanged )
+                {
+                    var previousSelectedText = SelectedText;
+
+                    await ResetSelectedText();
+                    DirtyFilter();
+
+                    if ( SelectedValue.IsEqual( default ) || Search.IsEqual( previousSelectedText ) )
+                    {
+                        await Task.WhenAll(
+                            ResetSelectedValue(),
+                            ResetCurrentSearch()
+                        );
+                    }
+                }
             }
             else
             {
@@ -466,6 +481,7 @@ public partial class Autocomplete<TItem, TValue>
     /// <returns>Returns awaitable task</returns>
     protected async Task OnTextChangedHandler( string text )
     {
+        showAllItemsOnFocus = false;
         DirtyFilter();
 
         //If input field is empty, clear current SelectedValue.
@@ -559,8 +575,28 @@ public partial class Autocomplete<TItem, TValue>
             return;
         }
 
-        if ( eventArgs.Code == "Escape" )
+        if ( IsEscapeKey( eventArgs ) )
         {
+            if ( MinSearchLength <= 0 && HasSingleSelectionOrSearch )
+            {
+                showAllItemsOnFocus = false;
+                DirtyFilter();
+
+                await Task.WhenAll(
+                    ResetCurrentSearch(),
+                    ResetSelected()
+                );
+
+                if ( ManualReadMode )
+                    await Reload();
+
+                await OpenDropdown();
+                await SearchTextChanged.InvokeAsync( string.Empty );
+                await Revalidate();
+                await SearchKeyDown.InvokeAsync( eventArgs );
+                return;
+            }
+
             await Close();
             await SearchKeyDown.InvokeAsync( eventArgs );
             return;
@@ -652,6 +688,14 @@ public partial class Autocomplete<TItem, TValue>
         }
 
         TextFocused = true;
+        showAllItemsOnFocus = !IsMultiple
+            && MinSearchLength <= 0
+            && !string.IsNullOrEmpty( SelectedText )
+            && Search.IsEqual( SelectedText );
+
+        if ( showAllItemsOnFocus )
+            DirtyFilter();
+
         if ( ManualReadMode || MinSearchLength <= 0 )
             await Reload();
 
@@ -709,6 +753,8 @@ public partial class Autocomplete<TItem, TValue>
 
             await OnBlurHandler( eventArgs );
             await SearchBlur.InvokeAsync( eventArgs );
+
+            showAllItemsOnFocus = false;
         }
     }
 
@@ -846,7 +892,7 @@ public partial class Autocomplete<TItem, TValue>
 
             if ( !cancellationTokenSource.Token.IsCancellationRequested && IsTextSearchable )
             {
-                await ReadData.InvokeAsync( new( Search, cancellationToken: cancellationTokenSource.Token ) );
+                await ReadData.InvokeAsync( new( FilterSearch, cancellationToken: cancellationTokenSource.Token ) );
                 await Task.Yield(); // rebind Data after ReadData
             }
         }
@@ -878,7 +924,7 @@ public partial class Autocomplete<TItem, TValue>
 
             if ( !cancellationToken.IsCancellationRequested )
             {
-                await ReadData.InvokeAsync( new( Search, startIdx, count, cancellationToken ) );
+                await ReadData.InvokeAsync( new( FilterSearch, startIdx, count, cancellationToken ) );
                 await Task.Yield(); // rebind Data after ReadData
             }
         }
@@ -966,6 +1012,12 @@ public partial class Autocomplete<TItem, TValue>
         ActiveItemIndex = -1;
         return Task.CompletedTask;
     }
+
+    private static bool IsEscapeKey( KeyboardEventArgs eventArgs )
+        => eventArgs?.Code == "Escape" || eventArgs?.Key == "Escape" || eventArgs?.Key == "Esc";
+
+    private bool HasSingleSelectionOrSearch
+        => !IsMultiple && ( FreeTyping || !string.IsNullOrEmpty( Search ) || !string.IsNullOrEmpty( SelectedText ) || !SelectedValue.IsEqual( default ) );
 
     private async Task AddMultipleValue( TValue value )
     {
@@ -1104,21 +1156,21 @@ public partial class Autocomplete<TItem, TValue>
             {
                 query = from q in query
                         where q != null
-                        where CustomFilter( q, Search )
+                        where CustomFilter( q, FilterSearch )
                         select q;
             }
             else if ( Filter == AutocompleteFilter.Contains )
             {
                 query = from q in query
                         let text = GetItemText( q )
-                        where text.IndexOf( Search, 0, StringComparison.OrdinalIgnoreCase ) >= 0
+                        where text.IndexOf( FilterSearch, 0, StringComparison.OrdinalIgnoreCase ) >= 0
                         select q;
             }
             else
             {
                 query = from q in query
                         let text = GetItemText( q )
-                        where text.StartsWith( Search, StringComparison.OrdinalIgnoreCase )
+                        where text.StartsWith( FilterSearch, StringComparison.OrdinalIgnoreCase )
                         select q;
             }
         }
@@ -1593,7 +1645,15 @@ public partial class Autocomplete<TItem, TValue>
     /// True if the text complies to the search requirements
     /// </summary>
     protected bool IsTextSearchable
-        => Search?.Length >= MinSearchLength;
+        => FilterSearch?.Length >= MinSearchLength;
+
+    /// <summary>
+    /// Gets the current text used for filtering and manual data reads.
+    /// </summary>
+    protected string FilterSearch
+        => showAllItemsOnFocus
+            ? string.Empty
+            : Search;
 
     /// <summary>
     /// True if the filtered data exists

--- a/Tests/BasicTestApp.Client/AutocompleteCustomTextReadDataComponent.razor
+++ b/Tests/BasicTestApp.Client/AutocompleteCustomTextReadDataComponent.razor
@@ -1,0 +1,47 @@
+<Autocomplete @ref="AutoCompleteRef"
+              TItem="Country"
+              TValue="string"
+              Data="@ReadDataCountries"
+              ReadData="@OnHandleReadData"
+              TextField="@(( item ) => $"{item.Iso} - {item.Name}")"
+              ValueField="@(( item ) => item.Iso)"
+              @bind-SelectedValue="SelectedValue"
+              @bind-SelectedText="SelectedText"
+              Placeholder="Search..."
+              MinSearchLength="0">
+    <NotFoundTemplate> Sorry... @context was not found! :( </NotFoundTemplate>
+</Autocomplete>
+
+@code {
+    [Inject] public CountryData CountryData { get; set; }
+
+    public IEnumerable<Country> Countries;
+
+    public IEnumerable<Country> ReadDataCountries;
+
+    public Autocomplete<Country, string> AutoCompleteRef { get; set; }
+
+    public string LastReadDataSearchValue { get; set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        Countries = await CountryData.GetDataAsync();
+        await base.OnInitializedAsync();
+    }
+
+    public string SelectedValue { get; set; }
+
+    public string SelectedText { get; set; }
+
+    private Task OnHandleReadData( AutocompleteReadDataEventArgs autocompleteReadDataEventArgs )
+    {
+        LastReadDataSearchValue = autocompleteReadDataEventArgs.SearchValue;
+
+        if ( !autocompleteReadDataEventArgs.CancellationToken.IsCancellationRequested )
+        {
+            ReadDataCountries = Countries.Where( x => x.Name.StartsWith( autocompleteReadDataEventArgs.SearchValue, StringComparison.InvariantCultureIgnoreCase ) );
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/Tests/Blazorise.Tests/Components/AutoCompleteComponentTest.cs
+++ b/Tests/Blazorise.Tests/Components/AutoCompleteComponentTest.cs
@@ -520,6 +520,36 @@ public class AutocompleteComponentTest : AutocompleteBaseComponentTest
     }
 
     [Fact]
+    public async Task Escape_WithMinSearchLength0AndSearchText_ShouldClearAndShowOptions()
+    {
+        var items = new List<string> { "1", "2" };
+
+        var comp = Render<Autocomplete<string, string>>( parameters => parameters
+            .Add( x => x.Data, items )
+            .Add( x => x.TextField, x => x )
+            .Add( x => x.ValueField, x => x )
+            .Add( x => x.FreeTyping, true )
+            .Add( x => x.MinSearchLength, 0 ) );
+
+        var autoComplete = comp.Find( ".b-is-autocomplete input" );
+
+        await autoComplete.FocusAsync( new() );
+        await autoComplete.InputAsync( "Test1" );
+        await autoComplete.BlurAsync( new() );
+        await autoComplete.FocusAsync( new() );
+        await autoComplete.KeyDownAsync( new Microsoft.AspNetCore.Components.Web.KeyboardEventArgs
+        {
+            Key = "Escape"
+        } );
+
+        comp.WaitForAssertion( () =>
+        {
+            Assert.Empty( comp.Find( ".b-is-autocomplete input" ).GetAttribute( "value" ) );
+            Assert.Equal( 2, comp.FindAll( ".b-is-autocomplete-suggestion" ).Count );
+        }, TestExtensions.WaitTime );
+    }
+
+    [Fact]
     public Task MinSearchLength_BiggerThen0_ShouldNotShowOptions_OnFocus()
     {
         return TestMinSearchLengthBiggerThen0DoesNotShowOptions<AutocompleteComponent>();
@@ -532,5 +562,40 @@ public class AutocompleteComponentTest : AutocompleteBaseComponentTest
     public Task ProgramaticallySetSelectedValue_ShouldSet_SelectedText( string selectedValue, string expectedSelectedText )
     {
         return TestProgramaticallySetSelectedValue<AutocompleteComponent>( ( comp ) => comp.Instance.SelectedText, selectedValue, expectedSelectedText );
+    }
+
+    [Fact]
+    public void ProgramaticallySetSelectedValue_Null_ShouldClear_SelectedTextAndSearch()
+    {
+        var countries = new List<Country>
+        {
+            new( "Portugal", "PT", "Lisbon" ),
+            new( "Croatia", "HR", "Zagreb" )
+        };
+        string selectedValue = "PT";
+        string selectedText = null;
+
+        var comp = Render<Autocomplete<Country, string>>( parameters => parameters
+            .Add( x => x.Data, countries )
+            .Add( x => x.TextField, x => x.Name )
+            .Add( x => x.ValueField, x => x.Iso )
+            .Add( x => x.SelectedValue, selectedValue )
+            .Add( x => x.SelectedValueChanged, value => selectedValue = value )
+            .Add( x => x.SelectedText, selectedText )
+            .Add( x => x.SelectedTextChanged, text => selectedText = text ) );
+
+        comp.WaitForAssertion( () => Assert.Equal( "Portugal", comp.Find( ".b-is-autocomplete input" ).GetAttribute( "value" ) ), TestExtensions.WaitTime );
+        Assert.Equal( "Portugal", selectedText );
+
+        selectedValue = null;
+        comp.Render( parameters => parameters
+            .Add( x => x.SelectedValue, selectedValue )
+            .Add( x => x.SelectedText, selectedText ) );
+
+        comp.WaitForAssertion( () =>
+        {
+            Assert.Null( selectedText );
+            Assert.Empty( comp.Find( ".b-is-autocomplete input" ).GetAttribute( "value" ) );
+        }, TestExtensions.WaitTime );
     }
 }

--- a/Tests/Blazorise.Tests/Components/AutocompleteReadDataComponentTest.cs
+++ b/Tests/Blazorise.Tests/Components/AutocompleteReadDataComponentTest.cs
@@ -1,5 +1,6 @@
 ﻿#region Using directives
 using System.Threading.Tasks;
+using Bunit;
 using Xunit;
 #endregion
 
@@ -82,5 +83,29 @@ public class AutocompleteReadDataComponentTest : AutocompleteBaseComponentTest
     public Task MinSearchLength_BiggerThen0_ShouldNotShowOptions_OnFocus()
     {
         return TestMinSearchLengthBiggerThen0DoesNotShowOptions<AutocompleteReadDataComponent>();
+    }
+
+    [Fact]
+    public async Task MinSearchLength_0_WithCustomTextField_ShouldShowOptionsAfterSelection_OnFocus()
+    {
+        var comp = Render<AutocompleteCustomTextReadDataComponent>();
+
+        var autoComplete = comp.Find( ".b-is-autocomplete input" );
+
+        await autoComplete.FocusAsync( new() );
+        await autoComplete.InputAsync( "Portugal" );
+
+        WaitAndClickfirstOption( comp, "PT - Portugal", true );
+
+        autoComplete = comp.Find( ".b-is-autocomplete input" );
+        await autoComplete.BlurAsync( new() );
+        await autoComplete.FocusAsync( new() );
+
+        comp.WaitForAssertion( () =>
+        {
+            Assert.Equal( string.Empty, comp.Instance.LastReadDataSearchValue );
+            Assert.NotEmpty( comp.FindAll( ".b-is-autocomplete-suggestion" ) );
+            Assert.DoesNotContain( "Sorry...", comp.Markup );
+        }, TestExtensions.WaitTime );
     }
 }


### PR DESCRIPTION
- Clear visible input/search when a single selected value is externally set to null.
- Preserve non-null selected values while data is not loaded, then resync text when data arrives.
- Avoid filtering/read-data by selected display text when reopening MinSearchLength=0 dropdowns.
- Handle Escape clear behavior for single FreeTyping MinSearchLength=0 scenarios.
- Added bUnit regression coverage for null clearing and custom TextField/read-data reopen behavior.