### PR TITLE
Carousel: allow unbound SelectedSlide

### DIFF
--- a/Source/Blazorise.AntDesign/Components/Carousel.razor.cs
+++ b/Source/Blazorise.AntDesign/Components/Carousel.razor.cs
@@ -1,7 +1,6 @@
 ﻿#region Using directives
 using System;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading.Tasks;
 using Blazorise.Modules;
 using Blazorise.Utilities;
@@ -96,8 +95,7 @@ public partial class Carousel : Blazorise.Carousel
     {
         get
         {
-            var slideIndex = carouselSlides.IndexOf( carouselSlides.FirstOrDefault( x => x.Name == SelectedSlide ) );
-            var targetSlidePosition = slideIndex + 1;
+            var targetSlidePosition = SelectedSlideIndex + 1;
 
             if ( !suppressSlickTrackTransition && ShouldUseSlickWrapToFirstPosition )
             {

--- a/Source/Blazorise.FluentUI2/Components/Carousel.razor
+++ b/Source/Blazorise.FluentUI2/Components/Carousel.razor
@@ -36,7 +36,7 @@
             <div aria-live="off" class="fui-Carousel__itemswrapper">
                 <div role="region" aria-roledescription="carousel" aria-label="Carousel container" class="@SlidesClassNames" style="@SlidesStyleNames">
                     @{
-                        var selectedSlide = carouselSlides.FirstOrDefault( x => x.Name == SelectedSlide );
+                        var selectedSlide = GetSelectedCarouselSlide();
 
                         <div role="tabpanel" aria-hidden="false" tabindex="0" class="@selectedSlide?.ClassNames" style="@selectedSlide?.StyleNames" @attributes="@selectedSlide?.Attributes">
                             @if ( selectedSlide is not null )

--- a/Source/Blazorise/Components/Carousel/Carousel.razor.cs
+++ b/Source/Blazorise/Components/Carousel/Carousel.razor.cs
@@ -232,7 +232,7 @@ public partial class Carousel : BaseComponent<CarouselClasses, CarouselStyles>, 
     /// Gets the slide by name. Returns -1 if the slide does not exist. 
     /// </summary>
     /// <param name="slideName"></param>
-    private int FindCarouselSlideIdxByName( string slideName ) => carouselSlides.IndexOf( carouselSlides.FirstOrDefault( x => string.Compare( x.Name, slideName ) == 0 ) );
+    private int FindCarouselSlideIdxByName( string slideName ) => carouselSlides.IndexOf( carouselSlides.FirstOrDefault( x => string.Compare( x.SelectionName, slideName ) == 0 ) );
 
     /// <summary>
     /// Gets the slide by index. Returns null if no slide has been found.
@@ -243,7 +243,7 @@ public partial class Carousel : BaseComponent<CarouselClasses, CarouselStyles>, 
     /// <summary>
     /// Gets the currently selected slide by index.
     /// </summary>
-    private CarouselSlide GetSelectedCarouselSlide() => GetCarouselSlide( SelectedSlideIndex );
+    protected CarouselSlide GetSelectedCarouselSlide() => GetCarouselSlide( SelectedSlideIndex );
 
     /// <summary>
     /// Gets the slide by index.
@@ -262,7 +262,7 @@ public partial class Carousel : BaseComponent<CarouselClasses, CarouselStyles>, 
         {
             state = state with
             {
-                SelectedSlide = carouselSlides.Single().Name
+                SelectedSlide = carouselSlides.Single().SelectionName
             };
         }
 
@@ -297,7 +297,7 @@ public partial class Carousel : BaseComponent<CarouselClasses, CarouselStyles>, 
             return Task.CompletedTask;
 
         ResetTimer();
-        SelectedSlide = FindNextSlide( SelectedSlide )?.Name;
+        SelectedSlide = FindNextSlide( SelectedSlide )?.SelectionName;
 
         return RunAnimations();
     }
@@ -311,7 +311,7 @@ public partial class Carousel : BaseComponent<CarouselClasses, CarouselStyles>, 
             return Task.CompletedTask;
 
         ResetTimer();
-        SelectedSlide = FindPreviousSlide( SelectedSlide )?.Name;
+        SelectedSlide = FindPreviousSlide( SelectedSlide )?.SelectionName;
 
         return RunAnimations();
     }
@@ -407,7 +407,7 @@ public partial class Carousel : BaseComponent<CarouselClasses, CarouselStyles>, 
             return;
         }
 
-        SelectedSlide = FindNextSlide( SelectedSlide )?.Name;
+        SelectedSlide = FindNextSlide( SelectedSlide )?.SelectionName;
 
         await InvokeAsync( RunAnimations );
     }
@@ -440,7 +440,7 @@ public partial class Carousel : BaseComponent<CarouselClasses, CarouselStyles>, 
         if ( selectedSlide is null )
             return;
 
-        if ( slide.Name == selectedSlide.Name )
+        if ( slide.SelectionName == selectedSlide.SelectionName )
         {
             AnimationRunning = false;
 
@@ -562,7 +562,15 @@ public partial class Carousel : BaseComponent<CarouselClasses, CarouselStyles>, 
     /// <param name="slideName">Slide name.</param>
     /// <returns>An index of slide.</returns>
     public int SlideIndex( string slideName )
-        => carouselSlides.IndexOf( carouselSlides.FirstOrDefault( x => x.Name == slideName ) );
+        => carouselSlides.IndexOf( carouselSlides.FirstOrDefault( x => x.SelectionName == slideName ) );
+
+    /// <summary>
+    /// Indicates whether the slide is currently selected.
+    /// </summary>
+    /// <param name="slide">Slide to check.</param>
+    /// <returns>True if the slide is selected; otherwise false.</returns>
+    internal bool IsSelectedSlide( CarouselSlide slide )
+        => slide?.SelectionName == state.SelectedSlide;
 
     /// <summary>
     /// Creates the render fragment for a slide content and optional caption.
@@ -760,13 +768,13 @@ public partial class Carousel : BaseComponent<CarouselClasses, CarouselStyles>, 
     /// Gets the index of the current active slide.
     /// </summary>
     public int SelectedSlideIndex
-        => carouselSlides.IndexOf( carouselSlides.FirstOrDefault( x => x.Name == state.SelectedSlide ) );
+        => carouselSlides.IndexOf( carouselSlides.FirstOrDefault( x => x.SelectionName == state.SelectedSlide ) );
 
     /// <summary>
     /// Gets the index of the previously active slide.
     /// </summary>
     public int PreviouslySelectedSlideIndex
-        => carouselSlides.IndexOf( carouselSlides.FirstOrDefault( x => x.Name == state.PreviouslySelectedSlide ) );
+        => carouselSlides.IndexOf( carouselSlides.FirstOrDefault( x => x.SelectionName == state.PreviouslySelectedSlide ) );
 
     /// <summary>
     /// Indicates if slide animation is currently running.

--- a/Source/Blazorise/Components/Carousel/CarouselSlide.razor.cs
+++ b/Source/Blazorise/Components/Carousel/CarouselSlide.razor.cs
@@ -25,6 +25,7 @@ public partial class CarouselSlide : BaseComponent<CarouselSlideClasses, Carouse
     private bool right;
     private bool prev;
     private bool next;
+    private readonly string selectionName = IdGenerator.Generate;
 
     #endregion
 
@@ -50,7 +51,7 @@ public partial class CarouselSlide : BaseComponent<CarouselSlideClasses, Carouse
         {
             ParentCarousel.AddSlide( this );
 
-            Active = Name == ParentCarousel.SelectedSlide;
+            Active = ParentCarousel.IsSelectedSlide( this );
         }
 
         base.OnInitialized();
@@ -71,7 +72,7 @@ public partial class CarouselSlide : BaseComponent<CarouselSlideClasses, Carouse
     {
         builder.Append( ClassProvider.CarouselSlide() );
         builder.Append( ClassProvider.CarouselSlideActive( Active ) );
-        builder.Append( ClassProvider.CarouselSlideIndex( ParentCarousel.SelectedSlideIndex, ParentCarousel.SlideIndex( Name ), ParentCarousel.NumberOfSlides ) );
+        builder.Append( ClassProvider.CarouselSlideIndex( ParentCarousel.SelectedSlideIndex, ParentCarousel.SlideIndex( SelectionName ), ParentCarousel.NumberOfSlides ) );
         builder.Append( ClassProvider.CarouselSlideSlidingLeft( Left ) );
         builder.Append( ClassProvider.CarouselSlideSlidingRight( Right ) );
         builder.Append( ClassProvider.CarouselSlideSlidingPrev( Prev ) );
@@ -121,7 +122,7 @@ public partial class CarouselSlide : BaseComponent<CarouselSlideClasses, Carouse
     {
         DirtyClasses();
 
-        return ParentCarousel.Select( Name );
+        return ParentCarousel.Select( SelectionName );
     }
 
     internal void Clean()
@@ -220,6 +221,14 @@ public partial class CarouselSlide : BaseComponent<CarouselSlideClasses, Carouse
             DirtyClasses();
         }
     }
+
+    /// <summary>
+    /// Gets the name used internally to identify this slide.
+    /// </summary>
+    internal string SelectionName
+        => string.IsNullOrEmpty( Name )
+            ? selectionName
+            : Name;
 
     /// <summary>
     /// Specifies the interval (in milliseconds) after which this item will automatically slide.

--- a/Tests/Blazorise.Tests/Components/CarouselComponentTest.cs
+++ b/Tests/Blazorise.Tests/Components/CarouselComponentTest.cs
@@ -1,0 +1,51 @@
+#region Using directives
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using Xunit;
+#endregion
+
+namespace Blazorise.Tests.Components;
+
+public class CarouselComponentTest : BunitContext
+{
+    public CarouselComponentTest()
+    {
+        Services.AddBlazoriseTests().AddBootstrapProviders().AddEmptyIconProvider().AddTestData();
+    }
+
+    [Fact]
+    public void UnboundSelectedSlide_ShouldDefaultToFirstSlide()
+    {
+        // setup
+        var selectedSlideChangedCount = 0;
+
+        // test
+        var comp = Render<Carousel>( parameters => parameters
+            .Add( x => x.Interval, 0 )
+            .Add( x => x.SelectedSlideChanged, ( string _ ) => selectedSlideChangedCount++ )
+            .AddChildContent( CreateUnnamedSlides() ) );
+
+        // validate
+        comp.WaitForAssertion( () =>
+        {
+            var slides = comp.FindAll( ".carousel-item" );
+
+            Assert.Equal( 2, slides.Count );
+            Assert.Contains( "active", slides[0].GetAttribute( "class" ) );
+            Assert.DoesNotContain( "active", slides[1].GetAttribute( "class" ) );
+            Assert.Equal( 0, selectedSlideChangedCount );
+        } );
+    }
+
+    private static RenderFragment CreateUnnamedSlides()
+        => builder =>
+        {
+            builder.OpenComponent<CarouselSlide>( 0 );
+            builder.AddAttribute( 1, nameof( CarouselSlide.ChildContent ), (RenderFragment)( slideBuilder => slideBuilder.AddContent( 0, "First slide" ) ) );
+            builder.CloseComponent();
+
+            builder.OpenComponent<CarouselSlide>( 2 );
+            builder.AddAttribute( 3, nameof( CarouselSlide.ChildContent ), (RenderFragment)( slideBuilder => slideBuilder.AddContent( 0, "Second slide" ) ) );
+            builder.CloseComponent();
+        };
+}


### PR DESCRIPTION
Closes #6671

This fixes `Carousel` so it can render and navigate correctly when `SelectedSlide` is not bound by the consumer. The component now assigns an internal slide identity when a `CarouselSlide` has no `Name`, allowing the first slide fallback and subsequent navigation to work without requiring external state.