### PR TITLE
Gap: Fix FluentUI2 gap size

### DIFF
--- a/Source/Blazorise.FluentUI2/Providers/FluentUI2ClassProvider.cs
+++ b/Source/Blazorise.FluentUI2/Providers/FluentUI2ClassProvider.cs
@@ -1553,7 +1553,7 @@ public class FluentUI2ClassProvider : ClassProvider
     public override string Gap( GapSize gapSize, GapSide gapSide )
     {
         var side = gapSide != GapSide.None && gapSide != GapSide.All
-            ? $"-{ToGapSide( gapSide )}-"
+            ? $"-{ToGapSide( gapSide )}"
             : null;
 
         return $"fui-Gap{side}-{ToGapSize( gapSize )}";


### PR DESCRIPTION
## Description

Fixes a problem in the Fluent UI 2 Provider where `Gap="Gap.Is5.OnX.Is2.OnY"` is rendered `fui-Gap-x--5 fui-Gap-y--2` instead of  `fui-Gap-x-5 fui-Gap-y-2` . 

## How Has This Been Tested?

I temporarily added `Gap="Gap.Is5.OnX.Is2.OnY"` to a flexbox on the Demo `FlexPage` and ran the `Blazorise.Demo.FluentUI2` project.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] The PR is submitted to the correct branch (`master` for dev, `rel-1.x` for maintenance).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
