### PR TITLE
SvgChart: Respect visible axis range for column and bar baselines

### DIFF
--- a/Source/Extensions/Blazorise.Charts.Svg/Components/SvgChart.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Components/SvgChart.cs
@@ -414,6 +414,8 @@ public class SvgChart<TItem> : SvgChartBase
             IsRadialChart( model ),
             model.Min,
             model.Max,
+            valueAxisId => ResolveValueAxis( model, valueAxisId ).Min,
+            valueAxisId => ResolveValueAxis( model, valueAxisId ).Max,
             GetCategorySlotCount( model ),
             model.CategoryScaleKind,
             this,

--- a/Source/Extensions/Blazorise.Charts.Svg/Contexts/SvgChartPluginRenderContext.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Contexts/SvgChartPluginRenderContext.cs
@@ -23,6 +23,10 @@ public sealed class SvgChartPluginRenderContext
 
     private readonly Func<double, string, double> projectY;
 
+    private readonly Func<string, double> getValueMin;
+
+    private readonly Func<string, double> getValueMax;
+
     private readonly Func<double?, double, double> projectAnnotationX;
 
     private readonly Func<double?, string, double, double> projectAnnotationY;
@@ -56,6 +60,8 @@ public sealed class SvgChartPluginRenderContext
         bool radial,
         double valueMin,
         double valueMax,
+        Func<string, double> getValueMin,
+        Func<string, double> getValueMax,
         int categorySlotCount,
         SvgChartAxisScaleKind categoryScaleKind,
         object eventReceiver,
@@ -83,6 +89,8 @@ public sealed class SvgChartPluginRenderContext
         IsRadial = radial;
         ValueMin = valueMin;
         ValueMax = valueMax;
+        this.getValueMin = getValueMin;
+        this.getValueMax = getValueMax;
         CategorySlotCount = categorySlotCount;
         CategoryScaleKind = categoryScaleKind;
         ContinuousCategoryAxis = categoryScaleKind == SvgChartAxisScaleKind.Continuous;
@@ -184,6 +192,26 @@ public sealed class SvgChartPluginRenderContext
     public double ProjectY( double value, string valueAxisId = null )
     {
         return projectY( value, valueAxisId );
+    }
+
+    /// <summary>
+    /// Gets the resolved minimum for a value axis.
+    /// </summary>
+    /// <param name="valueAxisId">The optional value axis identifier.</param>
+    /// <returns>The resolved axis minimum.</returns>
+    public double GetValueMin( string valueAxisId = null )
+    {
+        return getValueMin( valueAxisId );
+    }
+
+    /// <summary>
+    /// Gets the resolved maximum for a value axis.
+    /// </summary>
+    /// <param name="valueAxisId">The optional value axis identifier.</param>
+    /// <returns>The resolved axis maximum.</returns>
+    public double GetValueMax( string valueAxisId = null )
+    {
+        return getValueMax( valueAxisId );
     }
 
     /// <summary>

--- a/Source/Extensions/Blazorise.Charts.Svg/Plugins/SvgChartDataLabels.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Plugins/SvgChartDataLabels.cs
@@ -175,7 +175,8 @@ public class SvgChartDataLabels : SvgChartPluginBase
         var categoryWidth = GetCategoryWidth( context );
         var groupWidth = categoryWidth * 0.72;
         var barWidth = Math.Max( 1, groupWidth / visibleColumnSeries.Count );
-        var baseline = context.ProjectY( 0, series.ValueAxisId );
+        var baselineValue = Math.Clamp( 0, context.GetValueMin( series.ValueAxisId ), context.GetValueMax( series.ValueAxisId ) );
+        var baseline = context.ProjectY( baselineValue, series.ValueAxisId );
 
         for ( var pointIndex = 0; pointIndex < context.Labels.Count && pointIndex < series.Values.Count; pointIndex++ )
         {
@@ -207,7 +208,8 @@ public class SvgChartDataLabels : SvgChartPluginBase
         var categoryHeight = context.PlotArea.Height / context.Labels.Count;
         var groupHeight = categoryHeight * 0.72;
         var barHeight = Math.Max( 1, groupHeight / visibleBarSeries.Count );
-        var baseline = context.ProjectX( 0, series.ValueAxisId );
+        var baselineValue = Math.Clamp( 0, context.GetValueMin( series.ValueAxisId ), context.GetValueMax( series.ValueAxisId ) );
+        var baseline = context.ProjectX( baselineValue, series.ValueAxisId );
 
         for ( var pointIndex = 0; pointIndex < context.Labels.Count && pointIndex < series.Values.Count; pointIndex++ )
         {

--- a/Source/Extensions/Blazorise.Charts.Svg/Renderers/SvgChartBarSeriesRenderer.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Renderers/SvgChartBarSeriesRenderer.cs
@@ -41,7 +41,8 @@ internal sealed class SvgChartBarSeriesRenderer : ISvgChartSeriesRenderer
         foreach ( var item in renderSeries )
         {
             var seriesIndex = stackGroups.IndexOf( ResolveStackGroup( item ) );
-            var baseline = chart.ProjectValueX( 0, item.ValueAxisId );
+            var baselineValue = Math.Clamp( 0, chart.GetValueMin( item.ValueAxisId ), chart.GetValueMax( item.ValueAxisId ) );
+            var baseline = chart.ProjectValueX( baselineValue, item.ValueAxisId );
 
             for ( var pointIndex = 0; pointIndex < chart.Labels.Count && pointIndex < item.Values.Count; pointIndex++ )
             {
@@ -51,7 +52,7 @@ internal sealed class SvgChartBarSeriesRenderer : ISvgChartSeriesRenderer
                     continue;
 
                 var categoryStart = chart.PlotArea.Top + categoryHeight * pointIndex + ( categoryHeight - groupHeight ) / 2;
-                var startValue = ResolveStackValue( item.StackBaseValues, pointIndex, 0 );
+                var startValue = ResolveStackValue( item.StackBaseValues, pointIndex, baselineValue );
                 var endValue = ResolveStackValue( item.StackEndValues, pointIndex, value.Value );
                 var startX = chart.ProjectValueX( startValue, item.ValueAxisId );
                 var endX = chart.ProjectValueX( endValue, item.ValueAxisId );

--- a/Source/Extensions/Blazorise.Charts.Svg/Renderers/SvgChartColumnSeriesRenderer.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Renderers/SvgChartColumnSeriesRenderer.cs
@@ -41,7 +41,8 @@ internal sealed class SvgChartColumnSeriesRenderer : ISvgChartSeriesRenderer
         foreach ( var item in renderSeries )
         {
             var seriesIndex = stackGroups.IndexOf( ResolveStackGroup( item ) );
-            var baseline = chart.ProjectY( 0, item.ValueAxisId );
+            var baselineValue = Math.Clamp( 0, chart.GetValueMin( item.ValueAxisId ), chart.GetValueMax( item.ValueAxisId ) );
+            var baseline = chart.ProjectY( baselineValue, item.ValueAxisId );
 
             for ( var pointIndex = 0; pointIndex < chart.Labels.Count && pointIndex < item.Values.Count; pointIndex++ )
             {
@@ -52,7 +53,7 @@ internal sealed class SvgChartColumnSeriesRenderer : ISvgChartSeriesRenderer
 
                 var categoryStart = chart.ProjectCategoryBoundary( pointIndex ) + ( categoryWidth - groupWidth ) / 2;
                 var x = categoryStart + barWidth * seriesIndex + barWidth * 0.1;
-                var startValue = ResolveStackValue( item.StackBaseValues, pointIndex, 0 );
+                var startValue = ResolveStackValue( item.StackBaseValues, pointIndex, baselineValue );
                 var endValue = ResolveStackValue( item.StackEndValues, pointIndex, value.Value );
                 var startY = chart.ProjectY( startValue, item.ValueAxisId );
                 var endY = chart.ProjectY( endValue, item.ValueAxisId );


### PR DESCRIPTION
Closes #6673

Fixes column and bar SVG chart rendering when the value axis does not include zero, such as `BeginAtZero="false"` with values clustered around 96-100.

Previously, non-stacked column/bar series always used 0 as the baseline. When zero was outside the resolved axis range, projected rectangles could extend far outside the plot area and paint beyond the chart.

This change:

- clamps the column/bar baseline to the resolved visible value-axis range
- supports named value axes when resolving min/max
- keeps zero as the baseline when zero is visible
- aligns data-label bounds with the corrected baseline behavior