### PR TITLE
SvgChart: wrap legend items across rows

### DIFF
--- a/Source/Extensions/Blazorise.Charts.Svg/Components/SvgChart.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Components/SvgChart.cs
@@ -234,7 +234,7 @@ public class SvgChart<TItem> : SvgChartBase
         SvgChartTextRenderer.Render( builder, ref sequence, options, title, subtitle );
 
         if ( hasTopLegend )
-            SvgChartLegendRenderer.Render( builder, ref sequence, model, options, 48, this, ToggleSeries, ToggleDataPoint, IsDataPointHidden );
+            SvgChartLegendRenderer.Render( builder, ref sequence, model, options, legend.Position, 48, this, ToggleSeries, ToggleDataPoint, IsDataPointHidden );
 
         if ( IsBarChart( model ) )
             SvgChartAxesRenderer.RenderHorizontalGridAndAxes( builder, ref sequence, model, plot );
@@ -257,7 +257,7 @@ public class SvgChart<TItem> : SvgChartBase
             RenderCartesianSeries( builder, ref sequence, model, streamingAnimation, pluginContext, seriesRendererContext );
 
         if ( hasBottomLegend )
-            SvgChartLegendRenderer.Render( builder, ref sequence, model, options, options.Height - 30, this, ToggleSeries, ToggleDataPoint, IsDataPointHidden );
+            SvgChartLegendRenderer.Render( builder, ref sequence, model, options, legend.Position, options.Height - 30, this, ToggleSeries, ToggleDataPoint, IsDataPointHidden );
 
         RenderPlugins( builder, ref sequence, pluginContext, SvgChartRenderLayer.InteractionOverlay );
         RenderActiveTooltip( builder, ref sequence, model );

--- a/Source/Extensions/Blazorise.Charts.Svg/Renderers/SvgChartLegendRenderer.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Renderers/SvgChartLegendRenderer.cs
@@ -14,23 +14,45 @@ internal static class SvgChartLegendRenderer
 {
     #region Members
 
-    private const double LegendItemMaxWidth = 140;
-
     private const double LegendItemSwatchWidth = 12;
 
     private const double LegendItemTextGap = 6;
 
+    private const double LegendItemGap = 16;
+
+    private const double LegendHorizontalPadding = 8;
+
     private const double LegendFontSize = 12;
+
+    private const double LegendMinRowHeight = 16;
+
+    private const double LegendTopReservedHeight = 28;
+
+    private const double LegendBottomReservedHeight = 38;
 
     #endregion
 
     #region Methods
+
+    public static double ResolveReservedHeight( SvgChartRenderModel model, SvgChartOptions options, SvgChartLegendPosition position )
+    {
+        var legendItems = ResolveItems( model, static _ => Task.CompletedTask, static ( _, _ ) => Task.CompletedTask, static ( _, _ ) => false );
+
+        if ( legendItems.Count == 0 )
+            return 0;
+
+        var rows = ResolveRows( legendItems, options );
+        var fontSize = options.Font?.Size ?? LegendFontSize;
+
+        return ResolveBaseReservedHeight( position ) + Math.Max( 0, rows.Count - 1 ) * ResolveRowHeight( fontSize );
+    }
 
     public static void Render(
         RenderTreeBuilder builder,
         ref int sequence,
         SvgChartRenderModel model,
         SvgChartOptions options,
+        SvgChartLegendPosition position,
         double y,
         object eventReceiver,
         Func<string, Task> toggleSeries,
@@ -42,54 +64,106 @@ internal static class SvgChartLegendRenderer
         if ( legendItems.Count == 0 )
             return;
 
-        var itemWidth = Math.Min( LegendItemMaxWidth, options.Width / Math.Max( legendItems.Count, 1 ) );
-        var totalWidth = itemWidth * legendItems.Count;
-        var startX = Math.Max( 8, ( options.Width - totalWidth ) / 2 );
         var fontSize = options.Font?.Size ?? LegendFontSize;
+        var rowHeight = ResolveRowHeight( fontSize );
+        var rows = ResolveRows( legendItems, options );
 
         builder.OpenElement( sequence++, "g" );
         builder.AddAttribute( sequence++, "class", "svg-chart-legend" );
 
-        for ( var i = 0; i < legendItems.Count; i++ )
+        for ( var rowIndex = 0; rowIndex < rows.Count; rowIndex++ )
         {
-            var item = legendItems[i];
-            var visibleItemWidth = ResolveVisibleItemWidth( item, itemWidth, fontSize );
-            var x = startX + itemWidth * i + Math.Max( 0, ( itemWidth - visibleItemWidth ) / 2 );
+            var row = rows[rowIndex];
+            var x = Math.Max( LegendHorizontalPadding, ( options.Width - row.Width ) / 2 );
+            var rowY = position == SvgChartLegendPosition.Bottom
+                ? y - ( rows.Count - 1 - rowIndex ) * rowHeight
+                : y + rowIndex * rowHeight;
 
-            builder.OpenElement( sequence++, "g" );
-            builder.AddAttribute( sequence++, "class", "svg-chart-legend-item" );
-            builder.AddAttribute( sequence++, "role", "button" );
-            builder.AddAttribute( sequence++, "tabindex", "0" );
-            builder.AddAttribute( sequence++, "onclick", EventCallback.Factory.Create<MouseEventArgs>( eventReceiver, item.Toggle ) );
+            foreach ( var rowItem in row.Items )
+            {
+                var item = rowItem.Item;
 
-            builder.OpenElement( sequence++, "rect" );
-            builder.AddAttribute( sequence++, "x", SvgChartRenderHelpers.Format( x ) );
-            builder.AddAttribute( sequence++, "y", SvgChartRenderHelpers.Format( y - 9 ) );
-            builder.AddAttribute( sequence++, "width", SvgChartRenderHelpers.Format( LegendItemSwatchWidth ) );
-            builder.AddAttribute( sequence++, "height", SvgChartRenderHelpers.Format( LegendItemSwatchWidth ) );
-            builder.AddAttribute( sequence++, "rx", "3" );
-            builder.AddAttribute( sequence++, "fill", item.Color );
-            builder.AddAttribute( sequence++, "opacity", item.Hidden ? "0.35" : "1" );
-            builder.CloseElement();
+                builder.OpenElement( sequence++, "g" );
+                builder.AddAttribute( sequence++, "class", "svg-chart-legend-item" );
+                builder.AddAttribute( sequence++, "role", "button" );
+                builder.AddAttribute( sequence++, "tabindex", "0" );
+                builder.AddAttribute( sequence++, "onclick", EventCallback.Factory.Create<MouseEventArgs>( eventReceiver, item.Toggle ) );
 
-            builder.OpenElement( sequence++, "text" );
-            builder.AddAttribute( sequence++, "x", SvgChartRenderHelpers.Format( x + LegendItemSwatchWidth + LegendItemTextGap ) );
-            builder.AddAttribute( sequence++, "y", SvgChartRenderHelpers.Format( y + 1 ) );
-            SvgChartTextRenderer.AddFontAttributes( builder, ref sequence, options, fallbackSize: LegendFontSize, opacity: item.Hidden ? 0.45 : 0.8 );
-            builder.AddContent( sequence++, item.Label );
-            builder.CloseElement();
+                builder.OpenElement( sequence++, "rect" );
+                builder.AddAttribute( sequence++, "x", SvgChartRenderHelpers.Format( x ) );
+                builder.AddAttribute( sequence++, "y", SvgChartRenderHelpers.Format( rowY - 9 ) );
+                builder.AddAttribute( sequence++, "width", SvgChartRenderHelpers.Format( LegendItemSwatchWidth ) );
+                builder.AddAttribute( sequence++, "height", SvgChartRenderHelpers.Format( LegendItemSwatchWidth ) );
+                builder.AddAttribute( sequence++, "rx", "3" );
+                builder.AddAttribute( sequence++, "fill", item.Color );
+                builder.AddAttribute( sequence++, "opacity", item.Hidden ? "0.35" : "1" );
+                builder.CloseElement();
 
-            builder.CloseElement();
+                builder.OpenElement( sequence++, "text" );
+                builder.AddAttribute( sequence++, "x", SvgChartRenderHelpers.Format( x + LegendItemSwatchWidth + LegendItemTextGap ) );
+                builder.AddAttribute( sequence++, "y", SvgChartRenderHelpers.Format( rowY + 1 ) );
+                SvgChartTextRenderer.AddFontAttributes( builder, ref sequence, options, fallbackSize: LegendFontSize, opacity: item.Hidden ? 0.45 : 0.8 );
+                builder.AddContent( sequence++, item.Label );
+                builder.CloseElement();
+
+                builder.CloseElement();
+
+                x += rowItem.Width + LegendItemGap;
+            }
         }
 
         builder.CloseElement();
     }
 
-    private static double ResolveVisibleItemWidth( SvgChartLegendItem item, double itemWidth, double fontSize )
+    private static List<SvgChartLegendRow> ResolveRows( IReadOnlyList<SvgChartLegendItem> legendItems, SvgChartOptions options )
+    {
+        var fontSize = options.Font?.Size ?? LegendFontSize;
+        var availableWidth = ResolveAvailableWidth( options );
+        var rows = new List<SvgChartLegendRow>();
+        var row = new SvgChartLegendRow();
+
+        foreach ( var item in legendItems )
+        {
+            var itemWidth = ResolveVisibleItemWidth( item, availableWidth, fontSize );
+            var rowWidth = row.Items.Count == 0 ? itemWidth : row.Width + LegendItemGap + itemWidth;
+
+            if ( row.Items.Count > 0 && rowWidth > availableWidth )
+            {
+                rows.Add( row );
+                row = new();
+            }
+
+            row.Add( item, itemWidth );
+        }
+
+        if ( row.Items.Count > 0 )
+            rows.Add( row );
+
+        return rows;
+    }
+
+    private static double ResolveVisibleItemWidth( SvgChartLegendItem item, double availableWidth, double fontSize )
     {
         var textWidth = SvgChartRenderHelpers.EstimateTextWidth( item.Label, fontSize );
 
-        return Math.Min( itemWidth, LegendItemSwatchWidth + LegendItemTextGap + textWidth );
+        return Math.Min( availableWidth, LegendItemSwatchWidth + LegendItemTextGap + textWidth );
+    }
+
+    private static double ResolveAvailableWidth( SvgChartOptions options )
+    {
+        return Math.Max( 1, options.Width - LegendHorizontalPadding * 2 );
+    }
+
+    private static double ResolveRowHeight( double fontSize )
+    {
+        return Math.Max( LegendMinRowHeight, fontSize + 4 );
+    }
+
+    private static double ResolveBaseReservedHeight( SvgChartLegendPosition position )
+    {
+        return position == SvgChartLegendPosition.Bottom
+            ? LegendBottomReservedHeight
+            : LegendTopReservedHeight;
     }
 
     private static List<SvgChartLegendItem> ResolveItems( SvgChartRenderModel model, Func<string, Task> toggleSeries, Func<string, int, Task> toggleDataPoint, Func<string, int, bool> isDataPointHidden )
@@ -142,6 +216,36 @@ internal static class SvgChartLegendRenderer
             ? series.PointColors[pointIndex]
             : series.RenderColor;
     }
+
+    #endregion
+
+    #region Classes
+
+    private sealed class SvgChartLegendRow
+    {
+        #region Properties
+
+        public List<SvgChartLegendRowItem> Items { get; } = [];
+
+        public double Width { get; private set; }
+
+        #endregion
+
+        #region Methods
+
+        public void Add( SvgChartLegendItem item, double width )
+        {
+            if ( Items.Count > 0 )
+                Width += LegendItemGap;
+
+            Items.Add( new( item, width ) );
+            Width += width;
+        }
+
+        #endregion
+    }
+
+    private sealed record SvgChartLegendRowItem( SvgChartLegendItem Item, double Width );
 
     #endregion
 }

--- a/Source/Extensions/Blazorise.Charts.Svg/Renderers/SvgChartTextRenderer.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Renderers/SvgChartTextRenderer.cs
@@ -58,9 +58,9 @@ internal static class SvgChartTextRenderer
         var top = topPadding + GetTopTextHeight( title ) + GetTopTextHeight( subtitle );
 
         if ( hasTopLegend )
-            top += 28;
+            top += SvgChartLegendRenderer.ResolveReservedHeight( model, options, SvgChartLegendPosition.Top );
 
-        var bottom = options.Height - bottomPadding - ( hasBottomLegend ? 38 : 0 ) - GetBottomTextHeight( title ) - GetBottomTextHeight( subtitle );
+        var bottom = options.Height - bottomPadding - ( hasBottomLegend ? SvgChartLegendRenderer.ResolveReservedHeight( model, options, SvgChartLegendPosition.Bottom ) : 0 ) - GetBottomTextHeight( title ) - GetBottomTextHeight( subtitle );
         var left = startPadding + GetStartTextWidth( title ) + GetStartTextWidth( subtitle );
         var right = options.Width - endPadding - GetEndTextWidth( title ) - GetEndTextWidth( subtitle );
 


### PR DESCRIPTION
Closes #6674

- Added row wrapping for `SvgChartLegend` items when their measured width exceeds the available chart width.
- Centered each wrapped legend row independently.
- Updated plot-area spacing so wrapped top and bottom legends reserve enough vertical room and avoid overlapping chart content.