### PR TITLE
Charts.Svg: fix component option precedence

### DIFF
--- a/Source/Extensions/Blazorise.Charts.Svg/Axes/SvgChartCategoryAxis.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Axes/SvgChartCategoryAxis.cs
@@ -1,6 +1,8 @@
 #region Using directives
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
+using Blazorise.Extensions;
 using Microsoft.AspNetCore.Components;
 #endregion
 
@@ -12,7 +14,36 @@ namespace Blazorise.Charts.Svg;
 /// <typeparam name="TItem">The chart item type.</typeparam>
 public class SvgChartCategoryAxis<TItem> : SvgChartComponentBase
 {
+    #region Members
+
+    private ComponentParameterInfo<string> paramId;
+
+    private ComponentParameterInfo<SvgChartAxisPosition> paramPosition;
+
+    private ComponentParameterInfo<string> paramTitle;
+
+    private ComponentParameterInfo<Func<SvgChartAxisTickContext, string>> paramTickFormatter;
+
+    private ComponentParameterInfo<SvgChartGridLinesOptions> paramGridLines;
+
+    private ComponentParameterInfo<SvgChartAxisLabelsOptions> paramLabelsOptions;
+
+    #endregion
+
     #region Methods
+
+    /// <inheritdoc/>
+    public override Task SetParametersAsync( ParameterView parameters )
+    {
+        parameters.TryGetParameter( Id, out paramId );
+        parameters.TryGetParameter( Position, out paramPosition );
+        parameters.TryGetParameter( Title, out paramTitle );
+        parameters.TryGetParameter( TickFormatter, out paramTickFormatter );
+        parameters.TryGetParameter( GridLines, out paramGridLines );
+        parameters.TryGetParameter( LabelsOptions, out paramLabelsOptions );
+
+        return base.SetParametersAsync( parameters );
+    }
 
     protected override void Register()
     {
@@ -23,6 +54,26 @@ public class SvgChartCategoryAxis<TItem> : SvgChartComponentBase
     protected override void Unregister()
     {
         RegisteredParent?.UnregisterCategoryAxis( this );
+    }
+
+    internal SvgChartAxisOptions ResolveOptions( SvgChartAxisOptions fallback )
+    {
+        fallback ??= new();
+
+        return new()
+        {
+            Id = paramId.GetValueOrDefault( fallback.Id ),
+            Position = paramPosition.GetValueOrDefault( fallback.Position ),
+            BeginAtZero = fallback.BeginAtZero,
+            Min = fallback.Min,
+            Max = fallback.Max,
+            TickCount = fallback.TickCount,
+            Stacked = fallback.Stacked,
+            TickFormatter = paramTickFormatter.GetValueOrDefault( fallback.TickFormatter ),
+            GridLines = SvgChartOptionsMapper.CreateGridLinesOptions( fallback.GridLines, paramGridLines ),
+            Labels = SvgChartOptionsMapper.CreateLabelsOptions( fallback.Labels, paramLabelsOptions ),
+            Title = paramTitle.GetValueOrDefault( fallback.Title )
+        };
     }
 
     #endregion

--- a/Source/Extensions/Blazorise.Charts.Svg/Axes/SvgChartValueAxis.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Axes/SvgChartValueAxis.cs
@@ -1,5 +1,7 @@
 #region Using directives
 using System;
+using System.Threading.Tasks;
+using Blazorise.Extensions;
 using Microsoft.AspNetCore.Components;
 #endregion
 
@@ -10,7 +12,51 @@ namespace Blazorise.Charts.Svg;
 /// </summary>
 public class SvgChartValueAxis : SvgChartComponentBase
 {
+    #region Members
+
+    private ComponentParameterInfo<string> paramId;
+
+    private ComponentParameterInfo<SvgChartAxisPosition> paramPosition;
+
+    private ComponentParameterInfo<bool> paramBeginAtZero;
+
+    private ComponentParameterInfo<double?> paramMin;
+
+    private ComponentParameterInfo<double?> paramMax;
+
+    private ComponentParameterInfo<int> paramTickCount;
+
+    private ComponentParameterInfo<bool> paramStacked;
+
+    private ComponentParameterInfo<Func<SvgChartAxisTickContext, string>> paramTickFormatter;
+
+    private ComponentParameterInfo<SvgChartGridLinesOptions> paramGridLines;
+
+    private ComponentParameterInfo<SvgChartAxisLabelsOptions> paramLabelsOptions;
+
+    private ComponentParameterInfo<string> paramTitle;
+
+    #endregion
+
     #region Methods
+
+    /// <inheritdoc/>
+    public override Task SetParametersAsync( ParameterView parameters )
+    {
+        parameters.TryGetParameter( Id, out paramId );
+        parameters.TryGetParameter( Position, out paramPosition );
+        parameters.TryGetParameter( BeginAtZero, out paramBeginAtZero );
+        parameters.TryGetParameter( Min, out paramMin );
+        parameters.TryGetParameter( Max, out paramMax );
+        parameters.TryGetParameter( TickCount, out paramTickCount );
+        parameters.TryGetParameter( Stacked, out paramStacked );
+        parameters.TryGetParameter( TickFormatter, out paramTickFormatter );
+        parameters.TryGetParameter( GridLines, out paramGridLines );
+        parameters.TryGetParameter( LabelsOptions, out paramLabelsOptions );
+        parameters.TryGetParameter( Title, out paramTitle );
+
+        return base.SetParametersAsync( parameters );
+    }
 
     protected override void Register()
     {
@@ -21,6 +67,26 @@ public class SvgChartValueAxis : SvgChartComponentBase
     protected override void Unregister()
     {
         RegisteredParent?.UnregisterValueAxis( this );
+    }
+
+    internal SvgChartAxisOptions ResolveOptions( SvgChartAxisOptions fallback )
+    {
+        fallback ??= new();
+
+        return new()
+        {
+            Id = paramId.GetValueOrDefault( fallback.Id ),
+            Position = paramPosition.GetValueOrDefault( fallback.Position ),
+            BeginAtZero = paramBeginAtZero.GetValueOrDefault( fallback.BeginAtZero ),
+            Min = paramMin.GetValueOrDefault( fallback.Min ),
+            Max = paramMax.GetValueOrDefault( fallback.Max ),
+            TickCount = paramTickCount.GetValueOrDefault( fallback.TickCount ),
+            Stacked = paramStacked.GetValueOrDefault( fallback.Stacked ),
+            TickFormatter = paramTickFormatter.GetValueOrDefault( fallback.TickFormatter ),
+            GridLines = SvgChartOptionsMapper.CreateGridLinesOptions( fallback.GridLines, paramGridLines ),
+            Labels = SvgChartOptionsMapper.CreateLabelsOptions( fallback.Labels, paramLabelsOptions ),
+            Title = paramTitle.GetValueOrDefault( fallback.Title )
+        };
     }
 
     #endregion

--- a/Source/Extensions/Blazorise.Charts.Svg/Components/SvgChart.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Components/SvgChart.cs
@@ -481,7 +481,9 @@ public class SvgChart<TItem> : SvgChartBase
         if ( options.DataLabels?.Visible == true && !pluginComponents.OfType<SvgChartDataLabels>().Any() )
             result.Add( SvgChartDataLabels.Create( options.DataLabels ) );
 
-        result.AddRange( pluginComponents );
+        result.AddRange( pluginComponents.Select( plugin => plugin is SvgChartDataLabels dataLabels
+            ? SvgChartDataLabels.Create( options.DataLabels, dataLabels )
+            : plugin ) );
 
         return result;
     }
@@ -699,9 +701,8 @@ public class SvgChart<TItem> : SvgChartBase
     private bool ShouldRunAnimations()
     {
         var animationComponent = pluginComponents.OfType<SvgChartAnimation>().LastOrDefault();
-        var animation = animationComponent is null
-            ? Animation ?? ResolveOptions().Animation
-            : CreateAnimationOptions( animationComponent );
+        var animationOptions = Animation ?? ResolveOptions().Animation ?? new();
+        var animation = CreateAnimationOptions( animationComponent?.ResolveOptions( animationOptions ) ?? animationOptions );
 
         return animation?.Enabled == true && IsAnyAnimationTargetEnabled( animation );
     }
@@ -710,9 +711,7 @@ public class SvgChart<TItem> : SvgChartBase
     {
         var animationComponent = pluginComponents.OfType<SvgChartAnimation>().LastOrDefault();
         var animationOptions = Animation ?? options.Animation ?? new();
-        var animation = animationComponent is null
-            ? CreateAnimationOptions( animationOptions )
-            : CreateAnimationOptions( animationComponent );
+        var animation = CreateAnimationOptions( animationComponent?.ResolveOptions( animationOptions ) ?? animationOptions );
 
         if ( streamingAnimationEnabled
              || !animation.Enabled
@@ -807,27 +806,6 @@ public class SvgChart<TItem> : SvgChartBase
             Stroke = CreateStrokeAnimationOptions( options.Stroke ),
             Transform = CreateTransformAnimationOptions( options.Transform ),
             Path = CreatePathAnimationOptions( options.Path )
-        };
-    }
-
-    private static SvgChartAnimationOptions CreateAnimationOptions( SvgChartAnimation component )
-    {
-        if ( component is null )
-            return new();
-
-        return new()
-        {
-            Enabled = component.Enabled,
-            Duration = component.Duration,
-            Delay = component.Delay,
-            Easing = component.Easing,
-            AnimateOnLoad = component.AnimateOnLoad,
-            AnimateOnUpdate = component.AnimateOnUpdate,
-            Geometry = CreateGeometryAnimationOptions( component.Geometry ),
-            Opacity = CreateOpacityAnimationOptions( component.Opacity ),
-            Stroke = CreateStrokeAnimationOptions( component.Stroke ),
-            Transform = CreateTransformAnimationOptions( component.Transform ),
-            Path = CreatePathAnimationOptions( component.Path )
         };
     }
 
@@ -934,15 +912,9 @@ public class SvgChart<TItem> : SvgChartBase
     private SvgChartLegendOptions ResolveLegend( SvgChartOptions options )
     {
         var legendComponent = legendComponents.LastOrDefault();
+        var legendOptions = options.Legend ?? new();
 
-        if ( legendComponent is null )
-            return options.Legend ?? new();
-
-        return new()
-        {
-            Visible = legendComponent.Visible,
-            Position = legendComponent.Position
-        };
+        return legendComponent?.ResolveOptions( legendOptions ) ?? legendOptions;
     }
 
     private SvgChartTooltipOptions ResolveTooltip( SvgChartOptions options )
@@ -950,20 +922,7 @@ public class SvgChart<TItem> : SvgChartBase
         var tooltipComponent = tooltipComponents.LastOrDefault();
         var tooltipOptions = options.Tooltip ?? new();
 
-        if ( tooltipComponent is null )
-            return tooltipOptions;
-
-        return new()
-        {
-            Enabled = tooltipComponent.Enabled,
-            InteractionMode = tooltipComponent.InteractionMode,
-            Formatter = tooltipComponent.Formatter ?? tooltipOptions.Formatter,
-            Template = tooltipComponent.Template ?? tooltipOptions.Template,
-            Width = tooltipComponent.Width,
-            Height = tooltipComponent.Height,
-            OffsetX = tooltipComponent.OffsetX,
-            OffsetY = tooltipComponent.OffsetY
-        };
+        return tooltipComponent?.ResolveOptions( tooltipOptions ) ?? tooltipOptions;
     }
 
     private SvgChartZoomOptions ResolveZoom( SvgChartOptions options )
@@ -974,16 +933,7 @@ public class SvgChart<TItem> : SvgChartBase
         if ( zoomComponent is null )
             return CreateZoomOptions( zoomOptions );
 
-        return new()
-        {
-            Enabled = zoomComponent.Enabled,
-            Mode = zoomComponent.Mode,
-            Wheel = zoomComponent.Wheel,
-            Pan = zoomComponent.Pan,
-            MinZoom = zoomComponent.MinZoom,
-            MaxZoom = zoomComponent.MaxZoom,
-            Viewport = zoomComponent.Viewport ?? zoomOptions.Viewport
-        };
+        return zoomComponent.ResolveOptions( zoomOptions );
     }
 
     private static SvgChartZoomOptions CreateZoomOptions( SvgChartZoomOptions options )

--- a/Source/Extensions/Blazorise.Charts.Svg/Components/SvgChartLegend.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Components/SvgChartLegend.cs
@@ -1,4 +1,6 @@
 #region Using directives
+using System.Threading.Tasks;
+using Blazorise.Extensions;
 using Microsoft.AspNetCore.Components;
 #endregion
 
@@ -9,7 +11,24 @@ namespace Blazorise.Charts.Svg;
 /// </summary>
 public class SvgChartLegend : SvgChartComponentBase
 {
+    #region Members
+
+    private ComponentParameterInfo<bool> paramVisible;
+
+    private ComponentParameterInfo<SvgChartLegendPosition> paramPosition;
+
+    #endregion
+
     #region Methods
+
+    /// <inheritdoc/>
+    public override Task SetParametersAsync( ParameterView parameters )
+    {
+        parameters.TryGetParameter( Visible, out paramVisible );
+        parameters.TryGetParameter( Position, out paramPosition );
+
+        return base.SetParametersAsync( parameters );
+    }
 
     protected override void Register()
     {
@@ -20,6 +39,17 @@ public class SvgChartLegend : SvgChartComponentBase
     protected override void Unregister()
     {
         RegisteredParent?.UnregisterLegend( this );
+    }
+
+    internal SvgChartLegendOptions ResolveOptions( SvgChartLegendOptions fallback )
+    {
+        fallback ??= new();
+
+        return new()
+        {
+            Visible = paramVisible.GetValueOrDefault( fallback.Visible ),
+            Position = paramPosition.GetValueOrDefault( fallback.Position )
+        };
     }
 
     #endregion

--- a/Source/Extensions/Blazorise.Charts.Svg/Components/SvgChartTitle.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Components/SvgChartTitle.cs
@@ -1,4 +1,6 @@
 #region Using directives
+using System.Threading.Tasks;
+using Blazorise.Extensions;
 using Microsoft.AspNetCore.Components;
 #endregion
 
@@ -9,7 +11,21 @@ namespace Blazorise.Charts.Svg;
 /// </summary>
 public class SvgChartTitle : SvgChartComponentBase
 {
+    #region Members
+
+    private ComponentParameterInfo<bool> paramVisible;
+
+    #endregion
+
     #region Methods
+
+    /// <inheritdoc/>
+    public override Task SetParametersAsync( ParameterView parameters )
+    {
+        parameters.TryGetParameter( Visible, out paramVisible );
+
+        return base.SetParametersAsync( parameters );
+    }
 
     protected override void Register()
     {
@@ -22,9 +38,19 @@ public class SvgChartTitle : SvgChartComponentBase
         RegisteredParent?.UnregisterTitle( this );
     }
 
+    internal bool ResolveVisible( bool fallback )
+    {
+        return paramVisible.GetValueOrDefault( fallback );
+    }
+
     #endregion
 
     #region Properties
+
+    /// <summary>
+    /// Defines whether the title and subtitle are visible.
+    /// </summary>
+    [Parameter] public bool Visible { get; set; } = true;
 
     /// <summary>
     /// Defines title options.

--- a/Source/Extensions/Blazorise.Charts.Svg/Components/SvgChartTooltip.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Components/SvgChartTooltip.cs
@@ -1,5 +1,7 @@
 #region Using directives
 using System;
+using System.Threading.Tasks;
+using Blazorise.Extensions;
 using Microsoft.AspNetCore.Components;
 #endregion
 
@@ -10,7 +12,42 @@ namespace Blazorise.Charts.Svg;
 /// </summary>
 public class SvgChartTooltip : SvgChartComponentBase
 {
+    #region Members
+
+    private ComponentParameterInfo<bool> paramEnabled;
+
+    private ComponentParameterInfo<SvgChartInteractionMode> paramInteractionMode;
+
+    private ComponentParameterInfo<Func<SvgChartTooltipContext, string>> paramFormatter;
+
+    private ComponentParameterInfo<RenderFragment<SvgChartTooltipContext>> paramTemplate;
+
+    private ComponentParameterInfo<double> paramWidth;
+
+    private ComponentParameterInfo<double> paramHeight;
+
+    private ComponentParameterInfo<double> paramOffsetX;
+
+    private ComponentParameterInfo<double> paramOffsetY;
+
+    #endregion
+
     #region Methods
+
+    /// <inheritdoc/>
+    public override Task SetParametersAsync( ParameterView parameters )
+    {
+        parameters.TryGetParameter( Enabled, out paramEnabled );
+        parameters.TryGetParameter( InteractionMode, out paramInteractionMode );
+        parameters.TryGetParameter( Formatter, out paramFormatter );
+        parameters.TryGetParameter( Template, out paramTemplate );
+        parameters.TryGetParameter( Width, out paramWidth );
+        parameters.TryGetParameter( Height, out paramHeight );
+        parameters.TryGetParameter( OffsetX, out paramOffsetX );
+        parameters.TryGetParameter( OffsetY, out paramOffsetY );
+
+        return base.SetParametersAsync( parameters );
+    }
 
     protected override void Register()
     {
@@ -21,6 +58,23 @@ public class SvgChartTooltip : SvgChartComponentBase
     protected override void Unregister()
     {
         RegisteredParent?.UnregisterTooltip( this );
+    }
+
+    internal SvgChartTooltipOptions ResolveOptions( SvgChartTooltipOptions fallback )
+    {
+        fallback ??= new();
+
+        return new()
+        {
+            Enabled = paramEnabled.GetValueOrDefault( fallback.Enabled ),
+            InteractionMode = paramInteractionMode.GetValueOrDefault( fallback.InteractionMode ),
+            Formatter = paramFormatter.GetValueOrDefault( fallback.Formatter ),
+            Template = paramTemplate.GetValueOrDefault( fallback.Template ),
+            Width = paramWidth.GetValueOrDefault( fallback.Width ),
+            Height = paramHeight.GetValueOrDefault( fallback.Height ),
+            OffsetX = paramOffsetX.GetValueOrDefault( fallback.OffsetX ),
+            OffsetY = paramOffsetY.GetValueOrDefault( fallback.OffsetY )
+        };
     }
 
     #endregion

--- a/Source/Extensions/Blazorise.Charts.Svg/Infrastructure/SvgChartModelBuilder.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Infrastructure/SvgChartModelBuilder.cs
@@ -354,9 +354,10 @@ internal sealed class SvgChartModelBuilder<TItem>
 
     private HashSet<string> ResolveStackedValueAxisIds( List<SvgChartRenderSeries> series )
     {
+        var valueAxisOptions = ResolveOptions().YAxis ?? new();
         var axes = valueAxisComponents.Count == 0
-            ? new List<SvgChartAxisOptions> { CreateValueAxisOptions( ResolveOptions().YAxis ?? new() ) }
-            : valueAxisComponents.Select( CreateValueAxisOptions ).ToList();
+            ? new List<SvgChartAxisOptions> { CreateValueAxisOptions( valueAxisOptions ) }
+            : valueAxisComponents.Select( axis => axis.ResolveOptions( valueAxisOptions ) ).ToList();
 
         var defaultAxis = axes.Last();
 
@@ -758,9 +759,10 @@ internal sealed class SvgChartModelBuilder<TItem>
 
     private List<SvgChartRenderValueAxis> ResolveValueAxes( SvgChartOptions options, List<SvgChartRenderSeries> series, SvgChartZoomOptions zoom, SvgChartViewport viewport )
     {
+        var valueAxisOptions = options.YAxis ?? new();
         var axes = valueAxisComponents.Count == 0
-            ? new List<SvgChartAxisOptions> { CreateValueAxisOptions( options.YAxis ?? new() ) }
-            : valueAxisComponents.Select( CreateValueAxisOptions ).ToList();
+            ? new List<SvgChartAxisOptions> { CreateValueAxisOptions( valueAxisOptions ) }
+            : valueAxisComponents.Select( axis => axis.ResolveOptions( valueAxisOptions ) ).ToList();
         var referencedAxisIds = series.Select( x => x.ValueAxisId )
             .Where( x => !string.IsNullOrWhiteSpace( x ) )
             .Distinct( StringComparer.Ordinal )
@@ -822,20 +824,7 @@ internal sealed class SvgChartModelBuilder<TItem>
         var tooltipComponent = tooltipComponents.LastOrDefault();
         var tooltipOptions = options.Tooltip ?? new();
 
-        if ( tooltipComponent is null )
-            return tooltipOptions;
-
-        return new()
-        {
-            Enabled = tooltipComponent.Enabled,
-            InteractionMode = tooltipComponent.InteractionMode,
-            Formatter = tooltipComponent.Formatter ?? tooltipOptions.Formatter,
-            Template = tooltipComponent.Template ?? tooltipOptions.Template,
-            Width = tooltipComponent.Width,
-            Height = tooltipComponent.Height,
-            OffsetX = tooltipComponent.OffsetX,
-            OffsetY = tooltipComponent.OffsetY
-        };
+        return tooltipComponent?.ResolveOptions( tooltipOptions ) ?? tooltipOptions;
     }
 
     private SvgChartZoomOptions ResolveZoom( SvgChartOptions options )
@@ -846,16 +835,7 @@ internal sealed class SvgChartModelBuilder<TItem>
         if ( zoomComponent is null )
             return CreateZoomOptions( zoomOptions );
 
-        return new()
-        {
-            Enabled = zoomComponent.Enabled,
-            Mode = zoomComponent.Mode,
-            Wheel = zoomComponent.Wheel,
-            Pan = zoomComponent.Pan,
-            MinZoom = zoomComponent.MinZoom,
-            MaxZoom = zoomComponent.MaxZoom,
-            Viewport = zoomComponent.Viewport ?? zoomOptions.Viewport
-        };
+        return zoomComponent.ResolveOptions( zoomOptions );
     }
 
     private static SvgChartZoomOptions CreateZoomOptions( SvgChartZoomOptions options )

--- a/Source/Extensions/Blazorise.Charts.Svg/Infrastructure/SvgChartOptionsMapper.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Infrastructure/SvgChartOptionsMapper.cs
@@ -29,43 +29,15 @@ internal static class SvgChartOptionsMapper
         if ( axis is null )
             return CreateValueAxisOptions( new SvgChartAxisOptions() );
 
-        return new()
-        {
-            Id = axis.Id,
-            Position = axis.Position,
-            BeginAtZero = axis.BeginAtZero,
-            Min = axis.Min,
-            Max = axis.Max,
-            TickCount = axis.TickCount,
-            Stacked = axis.Stacked,
-            TickFormatter = axis.TickFormatter,
-            GridLines = CreateGridLinesOptions( axis.GridLines ),
-            Labels = CreateLabelsOptions( new() { Offset = 24 }, axis.LabelsOptions ),
-            Title = axis.Title
-        };
+        return axis.ResolveOptions( new() );
     }
 
     public static SvgChartAxisOptions CreateCategoryAxisOptions<TItem>( SvgChartAxisOptions options, SvgChartCategoryAxis<TItem> axis )
     {
-        options ??= new();
-
         if ( axis is null )
             return CreateValueAxisOptions( options );
 
-        return new()
-        {
-            Id = axis.Id,
-            Position = axis.Position,
-            BeginAtZero = options.BeginAtZero,
-            Min = options.Min,
-            Max = options.Max,
-            TickCount = options.TickCount,
-            Stacked = options.Stacked,
-            TickFormatter = axis.TickFormatter ?? options.TickFormatter,
-            GridLines = CreateGridLinesOptions( options.GridLines, axis.GridLines ),
-            Labels = CreateLabelsOptions( options.Labels, axis.LabelsOptions ),
-            Title = axis.Title
-        };
+        return axis.ResolveOptions( options );
     }
 
     public static SvgChartAxisLabelsOptions CreateLabelsOptions( SvgChartAxisLabelsOptions labels )
@@ -75,7 +47,7 @@ internal static class SvgChartOptionsMapper
 
         return new()
         {
-            Visible = labels.Visible,
+            Visible = labels.Visible ?? true,
             Step = labels.Step,
             AutoSkip = labels.AutoSkip,
             MaxTicksLimit = labels.MaxTicksLimit,
@@ -94,7 +66,7 @@ internal static class SvgChartOptionsMapper
 
         return new()
         {
-            Visible = overrides.Visible,
+            Visible = overrides.Visible ?? options?.Visible ?? true,
             Step = overrides.Step,
             AutoSkip = overrides.AutoSkip,
             MaxTicksLimit = overrides.MaxTicksLimit,
@@ -106,6 +78,16 @@ internal static class SvgChartOptionsMapper
         };
     }
 
+    public static SvgChartAxisLabelsOptions CreateLabelsOptions( SvgChartAxisLabelsOptions options, ComponentParameterInfo<SvgChartAxisLabelsOptions> overrides )
+    {
+        if ( !overrides.Defined )
+            return CreateLabelsOptions( options );
+
+        return overrides.Value is null
+            ? null
+            : CreateLabelsOptions( options, overrides.Value );
+    }
+
     public static SvgChartGridLinesOptions CreateGridLinesOptions( SvgChartGridLinesOptions gridLines )
     {
         if ( gridLines is null )
@@ -113,7 +95,7 @@ internal static class SvgChartOptionsMapper
 
         return new()
         {
-            Visible = gridLines.Visible,
+            Visible = gridLines.Visible ?? true,
             Color = gridLines.Color,
             Width = gridLines.Width,
             Opacity = gridLines.Opacity,
@@ -128,7 +110,7 @@ internal static class SvgChartOptionsMapper
 
         return new()
         {
-            Visible = overrides.Visible,
+            Visible = overrides.Visible ?? options?.Visible ?? true,
             Color = overrides.Color ?? options?.Color,
             Width = overrides.Width,
             Opacity = overrides.Opacity,
@@ -136,17 +118,34 @@ internal static class SvgChartOptionsMapper
         };
     }
 
+    public static SvgChartGridLinesOptions CreateGridLinesOptions( SvgChartGridLinesOptions options, ComponentParameterInfo<SvgChartGridLinesOptions> overrides )
+    {
+        if ( !overrides.Defined )
+            return CreateGridLinesOptions( options );
+
+        return overrides.Value is null
+            ? null
+            : CreateGridLinesOptions( options, overrides.Value );
+    }
+
     public static SvgChartTextOptions CreateTextOptions( SvgChartTextOptions options )
     {
         if ( options is null )
-            return new() { Visible = false };
+        {
+            return new()
+            {
+                Visible = false,
+                Position = SvgChartTextPosition.Top,
+                Alignment = SvgChartTextAlignment.Center
+            };
+        }
 
         return new()
         {
-            Visible = options.Visible,
+            Visible = options.Visible ?? true,
             Text = options.Text,
-            Position = options.Position,
-            Alignment = options.Alignment,
+            Position = options.Position ?? SvgChartTextPosition.Top,
+            Alignment = options.Alignment ?? SvgChartTextAlignment.Center,
             Padding = CreateSpacing( options.Padding ),
             Font = CreateFontOptions( options.Font ),
             Opacity = options.Opacity
@@ -160,10 +159,10 @@ internal static class SvgChartOptionsMapper
 
         return new()
         {
-            Visible = overrides.Visible,
+            Visible = overrides.Visible ?? options?.Visible ?? true,
             Text = overrides.Text ?? options?.Text,
-            Position = overrides.Position,
-            Alignment = overrides.Alignment,
+            Position = overrides.Position ?? options?.Position ?? SvgChartTextPosition.Top,
+            Alignment = overrides.Alignment ?? options?.Alignment ?? SvgChartTextAlignment.Center,
             Padding = CreateSpacing( overrides.Padding ?? options?.Padding ),
             Font = CreateFontOptions( options?.Font, overrides.Font ),
             Opacity = overrides.Opacity ?? options?.Opacity

--- a/Source/Extensions/Blazorise.Charts.Svg/Infrastructure/SvgChartStreamingResolver.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Infrastructure/SvgChartStreamingResolver.cs
@@ -9,17 +9,7 @@ internal static class SvgChartStreamingResolver
         if ( streaming is null )
             return fallback ?? new() { Enabled = false };
 
-        return new()
-        {
-            Enabled = streaming.Enabled,
-            MaxDataPoints = streaming.MaxDataPoints,
-            VisibleDataPoints = streaming.VisibleDataPoints,
-            Duration = streaming.Duration,
-            IndexAxis = streaming.IndexAxis,
-            Reverse = streaming.Reverse,
-            Animation = streaming.Animation ?? fallback?.Animation ?? new(),
-            RefreshInterval = streaming.RefreshInterval
-        };
+        return streaming.ResolveOptions( fallback );
     }
 
     public static bool IsReversed( SvgChartStreamingOptions streaming )

--- a/Source/Extensions/Blazorise.Charts.Svg/Options/SvgChartAxisLabelsOptions.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Options/SvgChartAxisLabelsOptions.cs
@@ -8,9 +8,9 @@ public class SvgChartAxisLabelsOptions
     #region Properties
 
     /// <summary>
-    /// Defines whether labels are visible.
+    /// Defines whether labels are visible. When null, the value is inherited from the parent options.
     /// </summary>
-    public bool Visible { get; set; } = true;
+    public bool? Visible { get; set; }
 
     /// <summary>
     /// Defines the interval for visible labels.

--- a/Source/Extensions/Blazorise.Charts.Svg/Options/SvgChartGridLinesOptions.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Options/SvgChartGridLinesOptions.cs
@@ -8,9 +8,9 @@ public class SvgChartGridLinesOptions
     #region Properties
 
     /// <summary>
-    /// Defines whether grid lines are visible.
+    /// Defines whether grid lines are visible. When null, the value is inherited from the parent options.
     /// </summary>
-    public bool Visible { get; set; } = true;
+    public bool? Visible { get; set; }
 
     /// <summary>
     /// Defines the grid line color.

--- a/Source/Extensions/Blazorise.Charts.Svg/Options/SvgChartTextOptions.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Options/SvgChartTextOptions.cs
@@ -8,9 +8,9 @@ public class SvgChartTextOptions
     #region Properties
 
     /// <summary>
-    /// Defines whether the text is visible.
+    /// Defines whether the text is visible. When null, the value is inherited from the parent options.
     /// </summary>
-    public bool Visible { get; set; } = true;
+    public bool? Visible { get; set; }
 
     /// <summary>
     /// Defines the text content.
@@ -18,14 +18,14 @@ public class SvgChartTextOptions
     public string Text { get; set; }
 
     /// <summary>
-    /// Defines the text position.
+    /// Defines the text position. When null, the value is inherited from the parent options.
     /// </summary>
-    public SvgChartTextPosition Position { get; set; } = SvgChartTextPosition.Top;
+    public SvgChartTextPosition? Position { get; set; }
 
     /// <summary>
-    /// Defines the text alignment.
+    /// Defines the text alignment. When null, the value is inherited from the parent options.
     /// </summary>
-    public SvgChartTextAlignment Alignment { get; set; } = SvgChartTextAlignment.Center;
+    public SvgChartTextAlignment? Alignment { get; set; }
 
     /// <summary>
     /// Defines the text padding.

--- a/Source/Extensions/Blazorise.Charts.Svg/Plugins/SvgChartAnimation.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Plugins/SvgChartAnimation.cs
@@ -1,5 +1,7 @@
 #region Using directives
 using System;
+using System.Threading.Tasks;
+using Blazorise.Extensions;
 using Microsoft.AspNetCore.Components;
 #endregion
 
@@ -10,6 +12,74 @@ namespace Blazorise.Charts.Svg;
 /// </summary>
 public class SvgChartAnimation : SvgChartPluginBase
 {
+    #region Members
+
+    private ComponentParameterInfo<bool> paramEnabled;
+
+    private ComponentParameterInfo<TimeSpan> paramDuration;
+
+    private ComponentParameterInfo<TimeSpan> paramDelay;
+
+    private ComponentParameterInfo<SvgChartAnimationEasing> paramEasing;
+
+    private ComponentParameterInfo<bool> paramAnimateOnLoad;
+
+    private ComponentParameterInfo<bool> paramAnimateOnUpdate;
+
+    private ComponentParameterInfo<SvgChartGeometryAnimationOptions> paramGeometry;
+
+    private ComponentParameterInfo<SvgChartOpacityAnimationOptions> paramOpacity;
+
+    private ComponentParameterInfo<SvgChartStrokeAnimationOptions> paramStroke;
+
+    private ComponentParameterInfo<SvgChartTransformAnimationOptions> paramTransform;
+
+    private ComponentParameterInfo<SvgChartPathAnimationOptions> paramPath;
+
+    #endregion
+
+    #region Methods
+
+    /// <inheritdoc/>
+    public override Task SetParametersAsync( ParameterView parameters )
+    {
+        parameters.TryGetParameter( Enabled, out paramEnabled );
+        parameters.TryGetParameter( Duration, out paramDuration );
+        parameters.TryGetParameter( Delay, out paramDelay );
+        parameters.TryGetParameter( Easing, out paramEasing );
+        parameters.TryGetParameter( AnimateOnLoad, out paramAnimateOnLoad );
+        parameters.TryGetParameter( AnimateOnUpdate, out paramAnimateOnUpdate );
+        parameters.TryGetParameter( Geometry, out paramGeometry );
+        parameters.TryGetParameter( Opacity, out paramOpacity );
+        parameters.TryGetParameter( Stroke, out paramStroke );
+        parameters.TryGetParameter( Transform, out paramTransform );
+        parameters.TryGetParameter( Path, out paramPath );
+
+        return base.SetParametersAsync( parameters );
+    }
+
+    internal SvgChartAnimationOptions ResolveOptions( SvgChartAnimationOptions fallback )
+    {
+        fallback ??= new();
+
+        return new()
+        {
+            Enabled = paramEnabled.GetValueOrDefault( fallback.Enabled ),
+            Duration = paramDuration.GetValueOrDefault( fallback.Duration ),
+            Delay = paramDelay.GetValueOrDefault( fallback.Delay ),
+            Easing = paramEasing.GetValueOrDefault( fallback.Easing ),
+            AnimateOnLoad = paramAnimateOnLoad.GetValueOrDefault( fallback.AnimateOnLoad ),
+            AnimateOnUpdate = paramAnimateOnUpdate.GetValueOrDefault( fallback.AnimateOnUpdate ),
+            Geometry = paramGeometry.GetValueOrDefault( fallback.Geometry ),
+            Opacity = paramOpacity.GetValueOrDefault( fallback.Opacity ),
+            Stroke = paramStroke.GetValueOrDefault( fallback.Stroke ),
+            Transform = paramTransform.GetValueOrDefault( fallback.Transform ),
+            Path = paramPath.GetValueOrDefault( fallback.Path )
+        };
+    }
+
+    #endregion
+
     #region Properties
 
     /// <summary>

--- a/Source/Extensions/Blazorise.Charts.Svg/Plugins/SvgChartDataLabels.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Plugins/SvgChartDataLabels.cs
@@ -2,6 +2,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
+using Blazorise.Extensions;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.AspNetCore.Components.Web;
@@ -14,6 +16,51 @@ namespace Blazorise.Charts.Svg;
 /// </summary>
 public class SvgChartDataLabels : SvgChartPluginBase
 {
+    #region Members
+
+    private ComponentParameterInfo<bool> paramVisible;
+
+    private ComponentParameterInfo<bool> paramInteractive;
+
+    private ComponentParameterInfo<SvgChartDataLabelPosition> paramPosition;
+
+    private ComponentParameterInfo<double> paramOffset;
+
+    private ComponentParameterInfo<double> paramOpacity;
+
+    private ComponentParameterInfo<SvgChartFontOptions> paramFont;
+
+    private ComponentParameterInfo<SvgChartSpacing> paramPadding;
+
+    private ComponentParameterInfo<Color> paramBackgroundColor;
+
+    private ComponentParameterInfo<SvgChartBorderOptions> paramBorder;
+
+    private ComponentParameterInfo<Func<SvgChartDataLabelContext, string>> paramFormatter;
+
+    #endregion
+
+    #region Methods
+
+    /// <inheritdoc/>
+    public override Task SetParametersAsync( ParameterView parameters )
+    {
+        parameters.TryGetParameter( Visible, out paramVisible );
+        parameters.TryGetParameter( Interactive, out paramInteractive );
+        parameters.TryGetParameter( Position, out paramPosition );
+        parameters.TryGetParameter( Offset, out paramOffset );
+        parameters.TryGetParameter( Opacity, out paramOpacity );
+        parameters.TryGetParameter( Font, out paramFont );
+        parameters.TryGetParameter( Padding, out paramPadding );
+        parameters.TryGetParameter( BackgroundColor, out paramBackgroundColor );
+        parameters.TryGetParameter( Border, out paramBorder );
+        parameters.TryGetParameter( Formatter, out paramFormatter );
+
+        return base.SetParametersAsync( parameters );
+    }
+
+    #endregion
+
     #region Properties
 
     /// <summary>
@@ -76,6 +123,10 @@ public class SvgChartDataLabels : SvgChartPluginBase
     /// </summary>
     [Parameter] public EventCallback<SvgChartPointEventArgs> Hovered { get; set; }
 
+    #endregion
+
+    #region Methods
+
     /// <inheritdoc/>
     public override void Render( SvgChartPluginRenderContext context, RenderTreeBuilder builder, ref int sequence )
     {
@@ -115,6 +166,30 @@ public class SvgChartDataLabels : SvgChartPluginBase
             BackgroundColor = options.BackgroundColor,
             Border = SvgChartAnnotationRenderHelpers.CreateBorderOptions( options.Border ),
             Formatter = options.Formatter
+        };
+    }
+
+    internal static SvgChartDataLabels Create( SvgChartDataLabelsOptions options, SvgChartDataLabels component )
+    {
+        if ( component is null )
+            return Create( options );
+
+        options ??= new();
+
+        return new()
+        {
+            Visible = component.paramVisible.GetValueOrDefault( options.Visible ),
+            Interactive = component.paramInteractive.GetValueOrDefault( options.Interactive ),
+            Position = component.paramPosition.GetValueOrDefault( options.Position ),
+            Offset = component.paramOffset.GetValueOrDefault( options.Offset ),
+            Opacity = component.paramOpacity.GetValueOrDefault( options.Opacity ),
+            Font = SvgChartAnnotationRenderHelpers.CreateFontOptions( component.paramFont.GetValueOrDefault( options.Font ) ),
+            Padding = CreateSpacing( component.paramPadding.GetValueOrDefault( options.Padding ) ),
+            BackgroundColor = component.paramBackgroundColor.GetValueOrDefault( options.BackgroundColor ),
+            Border = SvgChartAnnotationRenderHelpers.CreateBorderOptions( component.paramBorder.GetValueOrDefault( options.Border ) ),
+            Formatter = component.paramFormatter.GetValueOrDefault( options.Formatter ),
+            Clicked = component.Clicked,
+            Hovered = component.Hovered
         };
     }
 

--- a/Source/Extensions/Blazorise.Charts.Svg/Plugins/SvgChartStreaming.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Plugins/SvgChartStreaming.cs
@@ -1,5 +1,7 @@
 #region Using directives
 using System;
+using System.Threading.Tasks;
+using Blazorise.Extensions;
 using Microsoft.AspNetCore.Components;
 #endregion
 
@@ -10,6 +12,62 @@ namespace Blazorise.Charts.Svg;
 /// </summary>
 public class SvgChartStreaming : SvgChartPluginBase
 {
+    #region Members
+
+    private ComponentParameterInfo<bool> paramEnabled;
+
+    private ComponentParameterInfo<int?> paramMaxDataPoints;
+
+    private ComponentParameterInfo<int?> paramVisibleDataPoints;
+
+    private ComponentParameterInfo<TimeSpan?> paramDuration;
+
+    private ComponentParameterInfo<SvgChartIndexAxis> paramIndexAxis;
+
+    private ComponentParameterInfo<bool> paramReverse;
+
+    private ComponentParameterInfo<SvgChartStreamingAnimationOptions> paramAnimation;
+
+    private ComponentParameterInfo<TimeSpan> paramRefreshInterval;
+
+    #endregion
+
+    #region Methods
+
+    /// <inheritdoc/>
+    public override Task SetParametersAsync( ParameterView parameters )
+    {
+        parameters.TryGetParameter( Enabled, out paramEnabled );
+        parameters.TryGetParameter( MaxDataPoints, out paramMaxDataPoints );
+        parameters.TryGetParameter( VisibleDataPoints, out paramVisibleDataPoints );
+        parameters.TryGetParameter( Duration, out paramDuration );
+        parameters.TryGetParameter( IndexAxis, out paramIndexAxis );
+        parameters.TryGetParameter( Reverse, out paramReverse );
+        parameters.TryGetParameter( Animation, out paramAnimation );
+        parameters.TryGetParameter( RefreshInterval, out paramRefreshInterval );
+
+        return base.SetParametersAsync( parameters );
+    }
+
+    internal SvgChartStreamingOptions ResolveOptions( SvgChartStreamingOptions fallback )
+    {
+        fallback ??= new();
+
+        return new()
+        {
+            Enabled = paramEnabled.GetValueOrDefault( fallback.Enabled ),
+            MaxDataPoints = paramMaxDataPoints.GetValueOrDefault( fallback.MaxDataPoints ),
+            VisibleDataPoints = paramVisibleDataPoints.GetValueOrDefault( fallback.VisibleDataPoints ),
+            Duration = paramDuration.GetValueOrDefault( fallback.Duration ),
+            IndexAxis = paramIndexAxis.GetValueOrDefault( fallback.IndexAxis ),
+            Reverse = paramReverse.GetValueOrDefault( fallback.Reverse ),
+            Animation = paramAnimation.GetValueOrDefault( fallback.Animation ),
+            RefreshInterval = paramRefreshInterval.GetValueOrDefault( fallback.RefreshInterval )
+        };
+    }
+
+    #endregion
+
     #region Properties
 
     /// <summary>

--- a/Source/Extensions/Blazorise.Charts.Svg/Plugins/SvgChartZoom.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Plugins/SvgChartZoom.cs
@@ -1,4 +1,6 @@
 #region Using directives
+using System.Threading.Tasks;
+using Blazorise.Extensions;
 using Microsoft.AspNetCore.Components;
 #endregion
 
@@ -9,6 +11,58 @@ namespace Blazorise.Charts.Svg;
 /// </summary>
 public class SvgChartZoom : SvgChartPluginBase
 {
+    #region Members
+
+    private ComponentParameterInfo<bool> paramEnabled;
+
+    private ComponentParameterInfo<SvgChartZoomMode> paramMode;
+
+    private ComponentParameterInfo<bool> paramWheel;
+
+    private ComponentParameterInfo<bool> paramPan;
+
+    private ComponentParameterInfo<double> paramMinZoom;
+
+    private ComponentParameterInfo<double> paramMaxZoom;
+
+    private ComponentParameterInfo<SvgChartViewport> paramViewport;
+
+    #endregion
+
+    #region Methods
+
+    /// <inheritdoc/>
+    public override Task SetParametersAsync( ParameterView parameters )
+    {
+        parameters.TryGetParameter( Enabled, out paramEnabled );
+        parameters.TryGetParameter( Mode, out paramMode );
+        parameters.TryGetParameter( Wheel, out paramWheel );
+        parameters.TryGetParameter( Pan, out paramPan );
+        parameters.TryGetParameter( MinZoom, out paramMinZoom );
+        parameters.TryGetParameter( MaxZoom, out paramMaxZoom );
+        parameters.TryGetParameter( Viewport, out paramViewport );
+
+        return base.SetParametersAsync( parameters );
+    }
+
+    internal SvgChartZoomOptions ResolveOptions( SvgChartZoomOptions fallback )
+    {
+        fallback ??= new();
+
+        return new()
+        {
+            Enabled = paramEnabled.GetValueOrDefault( fallback.Enabled ),
+            Mode = paramMode.GetValueOrDefault( fallback.Mode ),
+            Wheel = paramWheel.GetValueOrDefault( fallback.Wheel ),
+            Pan = paramPan.GetValueOrDefault( fallback.Pan ),
+            MinZoom = paramMinZoom.GetValueOrDefault( fallback.MinZoom ),
+            MaxZoom = paramMaxZoom.GetValueOrDefault( fallback.MaxZoom ),
+            Viewport = SvgChartGeometry.CloneViewport( paramViewport.GetValueOrDefault( fallback.Viewport ) )
+        };
+    }
+
+    #endregion
+
     #region Properties
 
     /// <summary>

--- a/Source/Extensions/Blazorise.Charts.Svg/Renderers/SvgChartAxesRenderer.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Renderers/SvgChartAxesRenderer.cs
@@ -41,7 +41,7 @@ internal static class SvgChartAxesRenderer
 
         var primaryLabels = primaryAxis.Labels ?? new();
 
-        if ( primaryLabels.Visible )
+        if ( primaryLabels.Visible != false )
         {
             for ( var i = 0; i < primaryAxis.Ticks.Count; i++ )
             {
@@ -88,7 +88,7 @@ internal static class SvgChartAxesRenderer
     {
         var labels = model.CategoryAxis.Labels ?? new();
 
-        if ( !labels.Visible )
+        if ( labels.Visible == false )
             return;
 
         var labelCount = Math.Max( model.Labels.Count, model.CategorySlotCount );
@@ -166,7 +166,7 @@ internal static class SvgChartAxesRenderer
                 builder.CloseElement();
             }
 
-            if ( valueLabels.Visible )
+            if ( valueLabels.Visible != false )
             {
                 builder.OpenElement( sequence++, "text" );
                 builder.AddAttribute( sequence++, "x", SvgChartRenderHelpers.Format( x ) );
@@ -189,7 +189,7 @@ internal static class SvgChartAxesRenderer
 
         var categoryLabels = model.CategoryAxis?.Labels ?? new();
 
-        if ( categoryLabels.Visible )
+        if ( categoryLabels.Visible != false )
         {
             var labelStep = ResolveVerticalAxisLabelStep( model, plot, categoryLabels, model.Labels.Count );
 
@@ -224,7 +224,7 @@ internal static class SvgChartAxesRenderer
 
         var labels = model.CategoryAxis.Labels ?? new();
         var labelCount = Math.Max( model.Labels.Count, model.CategorySlotCount );
-        var labelPlacement = labels.Visible
+        var labelPlacement = labels.Visible != false
             ? ResolveHorizontalAxisLabelPlacement( model, plot, labels, labelCount, index =>
             {
                 var labelIndex = index < model.CategoryLabelIndexes.Count ? model.CategoryLabelIndexes[index] : index;
@@ -302,7 +302,7 @@ internal static class SvgChartAxesRenderer
 
         builder.CloseElement();
 
-        if ( !labels.Visible )
+        if ( labels.Visible == false )
             return;
 
         builder.OpenElement( sequence++, "g" );
@@ -451,7 +451,7 @@ internal static class SvgChartAxesRenderer
             builder.AddAttribute( sequence++, "stroke-opacity", "0.22" );
             builder.CloseElement();
 
-            if ( labels.Visible )
+            if ( labels.Visible != false )
             {
                 for ( var i = 0; i < axis.Ticks.Count; i++ )
                 {

--- a/Source/Extensions/Blazorise.Charts.Svg/Renderers/SvgChartTextRenderer.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Renderers/SvgChartTextRenderer.cs
@@ -31,6 +31,9 @@ internal static class SvgChartTextRenderer
         if ( componentOptions is not null )
             resolved = SvgChartOptionsMapper.CreateTextOptions( resolved, componentOptions );
 
+        if ( titleComponent is not null )
+            resolved.Visible = titleComponent.ResolveVisible( resolved.Visible ?? true );
+
         return resolved;
     }
 
@@ -42,6 +45,9 @@ internal static class SvgChartTextRenderer
 
         if ( componentOptions is not null )
             resolved = SvgChartOptionsMapper.CreateTextOptions( resolved, componentOptions );
+
+        if ( titleComponent is not null )
+            resolved.Visible = titleComponent.ResolveVisible( resolved.Visible ?? true );
 
         return resolved;
     }
@@ -110,7 +116,7 @@ internal static class SvgChartTextRenderer
         builder.AddAttribute( sequence++, "class", text.Position == SvgChartTextPosition.Top ? "svg-chart-title" : "svg-chart-subtitle" );
         builder.AddAttribute( sequence++, "x", SvgChartRenderHelpers.Format( x ) );
         builder.AddAttribute( sequence++, "y", SvgChartRenderHelpers.Format( y ) );
-        builder.AddAttribute( sequence++, "text-anchor", ResolveTextAnchor( text.Alignment ) );
+        builder.AddAttribute( sequence++, "text-anchor", ResolveTextAnchor( text.Alignment ?? SvgChartTextAlignment.Center ) );
         builder.AddAttribute( sequence++, "font-size", SvgChartRenderHelpers.Format( fontSize ) );
         builder.AddAttribute( sequence++, "fill", ResolveTextColor( options, text ) );
         SvgChartRenderHelpers.AddFontFamilyAttribute( builder, ref sequence, font.Family ?? options.Font?.Family );
@@ -292,7 +298,7 @@ internal static class SvgChartTextRenderer
         {
             SvgChartTextPosition.Start => start + padding.Start + fontSize,
             SvgChartTextPosition.End => options.Width - end - padding.End - fontSize,
-            _ => padding.Start + ResolveTextAlignmentOffset( options.Width - padding.Start - padding.End, text.Alignment )
+            _ => padding.Start + ResolveTextAlignmentOffset( options.Width - padding.Start - padding.End, text.Alignment ?? SvgChartTextAlignment.Center )
         };
     }
 
@@ -303,8 +309,8 @@ internal static class SvgChartTextRenderer
         return text.Position switch
         {
             SvgChartTextPosition.Bottom => options.Height - bottom - padding.Bottom,
-            SvgChartTextPosition.Start => options.Height - padding.Bottom - ResolveTextAlignmentOffset( options.Height - padding.Top - padding.Bottom, text.Alignment ),
-            SvgChartTextPosition.End => padding.Top + ResolveTextAlignmentOffset( options.Height - padding.Top - padding.Bottom, text.Alignment ),
+            SvgChartTextPosition.Start => options.Height - padding.Bottom - ResolveTextAlignmentOffset( options.Height - padding.Top - padding.Bottom, text.Alignment ?? SvgChartTextAlignment.Center ),
+            SvgChartTextPosition.End => padding.Top + ResolveTextAlignmentOffset( options.Height - padding.Top - padding.Bottom, text.Alignment ?? SvgChartTextAlignment.Center ),
             _ => top + padding.Top + fontSize
         };
     }


### PR DESCRIPTION
Fixes SVG chart visibility and option precedence so explicitly defined component parameters override chart options, while omitted parameters inherit configured option values. Adds `Visible` to `SvgChartTitle` and applies consistent parameter tracking across SVG chart components.