### PR TITLE
SVG Chart: fix axis titles and stacked data labels

### DIFF
--- a/Source/Extensions/Blazorise.Charts.Svg/Infrastructure/SvgChartModelBuilder.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Infrastructure/SvgChartModelBuilder.cs
@@ -795,6 +795,7 @@ internal sealed class SvgChartModelBuilder<TItem>
                 Position = axis.Position,
                 GridLines = axis.GridLines,
                 Labels = axis.Labels,
+                Title = axis.Title,
                 TickFormatter = axis.TickFormatter,
                 Stacked = axis.Stacked,
                 Min = scale.Min,

--- a/Source/Extensions/Blazorise.Charts.Svg/Models/SvgChartRenderValueAxis.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Models/SvgChartRenderValueAxis.cs
@@ -17,6 +17,8 @@ internal sealed class SvgChartRenderValueAxis
 
     public SvgChartAxisLabelsOptions Labels { get; init; }
 
+    public string Title { get; init; }
+
     public Func<SvgChartAxisTickContext, string> TickFormatter { get; init; }
 
     public bool Stacked { get; init; }

--- a/Source/Extensions/Blazorise.Charts.Svg/Plugins/SvgChartDataLabels.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Plugins/SvgChartDataLabels.cs
@@ -242,16 +242,16 @@ public class SvgChartDataLabels : SvgChartPluginBase
     private static void AddColumnDataLabelPoints( List<(SvgChartPointEventArgs Point, string Color, SvgChartType ChartType)> points, SvgChartPluginRenderContext context, SvgChartPluginSeries series )
     {
         var visibleColumnSeries = context.Series.Where( x => x.Type == SvgChartType.Column && !x.Hidden ).ToList();
-        var seriesIndex = visibleColumnSeries.IndexOf( series );
+        var stackGroups = visibleColumnSeries.Select( ResolveStackGroup ).Distinct().ToList();
+        var stackIndex = stackGroups.IndexOf( ResolveStackGroup( series ) );
 
-        if ( seriesIndex < 0 )
+        if ( stackIndex < 0 )
             return;
 
         var categoryWidth = GetCategoryWidth( context );
         var groupWidth = categoryWidth * 0.72;
-        var barWidth = Math.Max( 1, groupWidth / visibleColumnSeries.Count );
+        var barWidth = Math.Max( 1, groupWidth / stackGroups.Count );
         var baselineValue = Math.Clamp( 0, context.GetValueMin( series.ValueAxisId ), context.GetValueMax( series.ValueAxisId ) );
-        var baseline = context.ProjectY( baselineValue, series.ValueAxisId );
 
         for ( var pointIndex = 0; pointIndex < context.Labels.Count && pointIndex < series.Values.Count; pointIndex++ )
         {
@@ -261,10 +261,13 @@ public class SvgChartDataLabels : SvgChartPluginBase
                 continue;
 
             var categoryStart = context.ProjectCategoryBoundary( pointIndex ) + ( categoryWidth - groupWidth ) / 2;
-            var x = categoryStart + barWidth * seriesIndex + barWidth * 0.1;
-            var y = context.ProjectY( value.Value, series.ValueAxisId );
-            var height = Math.Abs( baseline - y );
-            var rectY = Math.Min( y, baseline );
+            var x = categoryStart + barWidth * stackIndex + barWidth * 0.1;
+            var startValue = ResolveStackValue( series.StackBaseValues, pointIndex, baselineValue );
+            var endValue = ResolveStackValue( series.StackEndValues, pointIndex, value.Value );
+            var startY = context.ProjectY( startValue, series.ValueAxisId );
+            var endY = context.ProjectY( endValue, series.ValueAxisId );
+            var height = Math.Abs( startY - endY );
+            var rectY = Math.Min( startY, endY );
             var rectWidth = Math.Max( 1, barWidth * 0.8 );
             var bounds = new SvgChartPointBounds { X = x, Y = rectY, Width = rectWidth, Height = height };
 
@@ -275,16 +278,16 @@ public class SvgChartDataLabels : SvgChartPluginBase
     private static void AddBarDataLabelPoints( List<(SvgChartPointEventArgs Point, string Color, SvgChartType ChartType)> points, SvgChartPluginRenderContext context, SvgChartPluginSeries series )
     {
         var visibleBarSeries = context.Series.Where( x => x.Type == SvgChartType.Bar && !x.Hidden ).ToList();
-        var seriesIndex = visibleBarSeries.IndexOf( series );
+        var stackGroups = visibleBarSeries.Select( ResolveStackGroup ).Distinct().ToList();
+        var stackIndex = stackGroups.IndexOf( ResolveStackGroup( series ) );
 
-        if ( seriesIndex < 0 || context.Labels.Count == 0 )
+        if ( stackIndex < 0 || context.Labels.Count == 0 )
             return;
 
         var categoryHeight = context.PlotArea.Height / context.Labels.Count;
         var groupHeight = categoryHeight * 0.72;
-        var barHeight = Math.Max( 1, groupHeight / visibleBarSeries.Count );
+        var barHeight = Math.Max( 1, groupHeight / stackGroups.Count );
         var baselineValue = Math.Clamp( 0, context.GetValueMin( series.ValueAxisId ), context.GetValueMax( series.ValueAxisId ) );
-        var baseline = context.ProjectX( baselineValue, series.ValueAxisId );
 
         for ( var pointIndex = 0; pointIndex < context.Labels.Count && pointIndex < series.Values.Count; pointIndex++ )
         {
@@ -294,10 +297,13 @@ public class SvgChartDataLabels : SvgChartPluginBase
                 continue;
 
             var categoryStart = context.PlotArea.Top + categoryHeight * pointIndex + ( categoryHeight - groupHeight ) / 2;
-            var x = context.ProjectX( value.Value, series.ValueAxisId );
-            var width = Math.Abs( x - baseline );
-            var rectX = Math.Min( x, baseline );
-            var y = categoryStart + barHeight * seriesIndex + barHeight * 0.1;
+            var startValue = ResolveStackValue( series.StackBaseValues, pointIndex, baselineValue );
+            var endValue = ResolveStackValue( series.StackEndValues, pointIndex, value.Value );
+            var startX = context.ProjectValueX( startValue, series.ValueAxisId );
+            var endX = context.ProjectValueX( endValue, series.ValueAxisId );
+            var width = Math.Abs( endX - startX );
+            var rectX = Math.Min( endX, startX );
+            var y = categoryStart + barHeight * stackIndex + barHeight * 0.1;
             var rectHeight = Math.Max( 1, barHeight * 0.8 );
             var bounds = new SvgChartPointBounds { X = rectX, Y = y, Width = width, Height = rectHeight };
 
@@ -607,6 +613,16 @@ public class SvgChartDataLabels : SvgChartPluginBase
         var range = Math.Max( context.CategorySlotCount, 1 );
 
         return context.PlotArea.Width / range;
+    }
+
+    private static string ResolveStackGroup( SvgChartPluginSeries series )
+    {
+        return series.StackEndValues.Count > 0 ? series.Stack ?? string.Empty : series.Name;
+    }
+
+    private static double ResolveStackValue( IReadOnlyList<double?> values, int index, double fallback )
+    {
+        return index >= 0 && index < values.Count && values[index].HasValue ? values[index].Value : fallback;
     }
 
     private static (double X, double Y) PolarToCartesian( double centerX, double centerY, double radius, double angle )

--- a/Source/Extensions/Blazorise.Charts.Svg/Renderers/SvgChartAxesRenderer.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Renderers/SvgChartAxesRenderer.cs
@@ -80,6 +80,8 @@ internal static class SvgChartAxesRenderer
             RenderCategoryAxisLabels( builder, ref sequence, model, plot, streamingAnimation, categoryAxisLabelsClipPathId );
 
         RenderRightValueAxes( builder, ref sequence, model, plot, primaryAxis );
+        RenderVerticalAxisTitle( builder, ref sequence, model, plot, primaryAxis.Title, false, "svg-chart-value-axis-title" );
+        RenderHorizontalAxisTitle( builder, ref sequence, model, plot, model.CategoryAxis?.Title, "svg-chart-category-axis-title" );
 
         builder.CloseElement();
     }
@@ -211,6 +213,9 @@ internal static class SvgChartAxesRenderer
                 builder.CloseElement();
             }
         }
+
+        RenderHorizontalAxisTitle( builder, ref sequence, model, plot, model.PrimaryValueAxis.Title, "svg-chart-value-axis-title" );
+        RenderVerticalAxisTitle( builder, ref sequence, model, plot, model.CategoryAxis?.Title, false, "svg-chart-category-axis-title" );
 
         builder.CloseElement();
     }
@@ -468,8 +473,57 @@ internal static class SvgChartAxesRenderer
                 }
             }
 
+            RenderVerticalAxisTitle( builder, ref sequence, model, plot, axis.Title, true, "svg-chart-value-axis-title" );
+
             builder.CloseElement();
         }
+    }
+
+    private static void RenderHorizontalAxisTitle( RenderTreeBuilder builder, ref int sequence, SvgChartRenderModel model, SvgChartPlotArea plot, string title, string className )
+    {
+        if ( string.IsNullOrWhiteSpace( title ) )
+            return;
+
+        var options = model.Options ?? new();
+        var fontSize = options.Font?.Size ?? 11;
+        var bottomPadding = SvgChartTextRenderer.ResolveBottomPadding( options, model, options.PlotAreaPadding?.Bottom );
+        var x = plot.Left + plot.Width / 2;
+        var y = plot.Bottom + bottomPadding + fontSize;
+
+        builder.OpenElement( sequence++, "text" );
+        builder.AddAttribute( sequence++, "class", $"svg-chart-axis-title {className}" );
+        builder.AddAttribute( sequence++, "x", SvgChartRenderHelpers.Format( x ) );
+        builder.AddAttribute( sequence++, "y", SvgChartRenderHelpers.Format( y ) );
+        builder.AddAttribute( sequence++, "text-anchor", "middle" );
+        SvgChartTextRenderer.AddFontAttributes( builder, ref sequence, options, opacity: 0.84 );
+        builder.AddAttribute( sequence++, "font-weight", "600" );
+        builder.AddContent( sequence++, title );
+        builder.CloseElement();
+    }
+
+    private static void RenderVerticalAxisTitle( RenderTreeBuilder builder, ref int sequence, SvgChartRenderModel model, SvgChartPlotArea plot, string title, bool right, string className )
+    {
+        if ( string.IsNullOrWhiteSpace( title ) )
+            return;
+
+        var options = model.Options ?? new();
+        var axisTitleSize = SvgChartTextRenderer.ResolveAxisTitleReservedSize( options );
+        var x = right
+            ? plot.Right + SvgChartTextRenderer.ResolveEndPadding( options.PlotAreaPadding?.End ) + axisTitleSize / 2
+            : plot.Left - SvgChartTextRenderer.ResolveStartPadding( options, model, options.PlotAreaPadding?.Start ) - axisTitleSize / 2;
+        var y = plot.Top + plot.Height / 2;
+        var rotation = right ? 90 : -90;
+
+        builder.OpenElement( sequence++, "text" );
+        builder.AddAttribute( sequence++, "class", $"svg-chart-axis-title {className}" );
+        builder.AddAttribute( sequence++, "x", SvgChartRenderHelpers.Format( x ) );
+        builder.AddAttribute( sequence++, "y", SvgChartRenderHelpers.Format( y ) );
+        builder.AddAttribute( sequence++, "text-anchor", "middle" );
+        builder.AddAttribute( sequence++, "transform", $"rotate({rotation} {SvgChartRenderHelpers.Format( x )} {SvgChartRenderHelpers.Format( y )})" );
+        SvgChartTextRenderer.AddFontAttributes( builder, ref sequence, options, opacity: 0.84 );
+        builder.AddAttribute( sequence++, "font-weight", "600" );
+        builder.AddContent( sequence++, title );
+        builder.CloseElement();
     }
 
     private static void AddGridLineAttributes( RenderTreeBuilder builder, ref int sequence, SvgChartGridLinesOptions gridLines )

--- a/Source/Extensions/Blazorise.Charts.Svg/Renderers/SvgChartTextRenderer.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Renderers/SvgChartTextRenderer.cs
@@ -58,17 +58,23 @@ internal static class SvgChartTextRenderer
 
         var padding = options.PlotAreaPadding;
         var topPadding = padding?.Top ?? 24d;
-        var endPadding = padding?.End ?? 18d;
+        var endPadding = ResolveEndPadding( padding?.End );
         var bottomPadding = ResolveBottomPadding( options, model, padding?.Bottom );
         var startPadding = ResolveStartPadding( options, model, padding?.Start );
+        var axisTitleSize = ResolveAxisTitleReservedSize( options );
+        var hasCartesianAxes = model is not null && !SvgChartGeometry.IsRadialChart( model );
+        var isBarChart = hasCartesianAxes && SvgChartGeometry.IsBarChart( model );
+        var hasStartAxisTitle = hasCartesianAxes && !string.IsNullOrWhiteSpace( isBarChart ? model.CategoryAxis?.Title : model.PrimaryValueAxis?.Title );
+        var hasBottomAxisTitle = hasCartesianAxes && !string.IsNullOrWhiteSpace( isBarChart ? model.PrimaryValueAxis?.Title : model.CategoryAxis?.Title );
+        var hasEndAxisTitle = hasCartesianAxes && !isBarChart && model.ValueAxes.Any( x => x != model.PrimaryValueAxis && x.Position == SvgChartAxisPosition.Right && !string.IsNullOrWhiteSpace( x.Title ) );
         var top = topPadding + GetTopTextHeight( title ) + GetTopTextHeight( subtitle );
 
         if ( hasTopLegend )
             top += SvgChartLegendRenderer.ResolveReservedHeight( model, options, SvgChartLegendPosition.Top );
 
-        var bottom = options.Height - bottomPadding - ( hasBottomLegend ? SvgChartLegendRenderer.ResolveReservedHeight( model, options, SvgChartLegendPosition.Bottom ) : 0 ) - GetBottomTextHeight( title ) - GetBottomTextHeight( subtitle );
-        var left = startPadding + GetStartTextWidth( title ) + GetStartTextWidth( subtitle );
-        var right = options.Width - endPadding - GetEndTextWidth( title ) - GetEndTextWidth( subtitle );
+        var bottom = options.Height - bottomPadding - ( hasBottomAxisTitle ? axisTitleSize : 0 ) - ( hasBottomLegend ? SvgChartLegendRenderer.ResolveReservedHeight( model, options, SvgChartLegendPosition.Bottom ) : 0 ) - GetBottomTextHeight( title ) - GetBottomTextHeight( subtitle );
+        var left = startPadding + ( hasStartAxisTitle ? axisTitleSize : 0 ) + GetStartTextWidth( title ) + GetStartTextWidth( subtitle );
+        var right = options.Width - endPadding - ( hasEndAxisTitle ? axisTitleSize : 0 ) - GetEndTextWidth( title ) - GetEndTextWidth( subtitle );
 
         return new()
         {
@@ -211,7 +217,7 @@ internal static class SvgChartTextRenderer
             : 0;
     }
 
-    private static double ResolveStartPadding( SvgChartOptions options, SvgChartRenderModel model, double? padding )
+    internal static double ResolveStartPadding( SvgChartOptions options, SvgChartRenderModel model, double? padding )
     {
         if ( padding.HasValue )
             return padding.Value;
@@ -230,7 +236,7 @@ internal static class SvgChartTextRenderer
         return Math.Max( fallback, Math.Min( maxLabelWidth + 14, options.Width * 0.45 ) );
     }
 
-    private static double ResolveBottomPadding( SvgChartOptions options, SvgChartRenderModel model, double? padding )
+    internal static double ResolveBottomPadding( SvgChartOptions options, SvgChartRenderModel model, double? padding )
     {
         if ( padding.HasValue )
             return padding.Value;
@@ -261,6 +267,16 @@ internal static class SvgChartTextRenderer
         var rotatedHeight = maxLabelWidth * Math.Sin( rotation ) + fontSize * Math.Cos( rotation );
 
         return Math.Max( fallback, Math.Min( labels.Offset + rotatedHeight + 8, options.Height * 0.35 ) );
+    }
+
+    internal static double ResolveEndPadding( double? padding )
+    {
+        return padding ?? 18d;
+    }
+
+    internal static double ResolveAxisTitleReservedSize( SvgChartOptions options )
+    {
+        return ( options?.Font?.Size ?? 11 ) + 8;
     }
 
     private static string FormatCategoryLabel( SvgChartRenderModel model, object value, int index )


### PR DESCRIPTION
Closes #6683

This PR renders category and value axis titles and reserves the required plot space to prevent them from overlapping chart content.

It also corrects data label bounds for stacked column and bar charts. Labels now use the same resolved stack base, stack end, and stack grouping as the corresponding series renderer.

With `Position="Center"`, labels appear inside their respective stacked segments. With `Position="Top"`, labels remain above the segment according to the existing positioning behavior, while `Offset` controls the space between the label and segment.