### PR TITLE
SVG Charts: respect configured time zones on time axes

### DIFF
--- a/Documentation/Blazorise.Docs/Pages/Docs/Extensions/SvgChart/SvgChartPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Extensions/SvgChart/SvgChartPage.razor
@@ -165,6 +165,15 @@
     <DocsPageSectionHeader Title="Continuous time axis">
         Use continuous time scaling when sample spacing should match the actual timestamp distance.
     </DocsPageSectionHeader>
+    <DocsPageParagraph>
+        Continuous time axes use UTC milliseconds internally and display values in the <Code>TimeZone</Code> configured on <Code>SvgChartTimeAxis</Code>. The default is <Code>TimeZoneInfo.Local</Code>.
+    </DocsPageParagraph>
+    <DocsPageParagraph>
+        A <Code>DateTime</Code> with <Code>Kind</Code> set to <Code>Utc</Code> or <Code>Local</Code> represents an instant and is converted to the configured time zone. A <Code>DateTime</Code> with <Code>Kind</Code> set to <Code>Unspecified</Code> is interpreted as a wall-clock value in the configured time zone. Axis labels and default tooltips use the same conversion and format.
+    </DocsPageParagraph>
+    <DocsPageParagraph>
+        In Blazor Server, <Code>TimeZoneInfo.Local</Code> is the server time zone and may differ from the browser user's time zone. Pass the user's <Code>TimeZoneInfo</Code> to <Code>TimeZone</Code> when user-local display is required. Blazorise does not infer the browser time zone automatically.
+    </DocsPageParagraph>
     <DocsPageSectionContent Code="SvgTimeAxisChartExample" Outlined FullWidth>
         <SvgTimeAxisChartExample />
     </DocsPageSectionContent>

--- a/Source/Extensions/Blazorise.Charts.Svg/Axes/SvgChartTimeAxis.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Axes/SvgChartTimeAxis.cs
@@ -16,6 +16,11 @@ public class SvgChartTimeAxis<TItem> : SvgChartCategoryAxis<TItem>
     /// <summary>
     /// Defines a selector used to read time values from chart items.
     /// </summary>
+    /// <remarks>
+    /// Values with <see cref="DateTimeKind.Utc"/> or <see cref="DateTimeKind.Local"/> represent instants and are
+    /// converted to <see cref="TimeZone"/>. Values with <see cref="DateTimeKind.Unspecified"/> are interpreted in
+    /// <see cref="TimeZone"/> without changing their wall-clock fields.
+    /// </remarks>
     [Parameter] public Func<TItem, DateTime?> TimeValue { get; set; }
 
     /// <summary>
@@ -37,6 +42,15 @@ public class SvgChartTimeAxis<TItem> : SvgChartCategoryAxis<TItem>
     /// Defines the culture name used to format time labels.
     /// </summary>
     [Parameter] public string Culture { get; set; }
+
+    /// <summary>
+    /// Defines the time zone used to interpret unspecified time values and format time labels.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="TimeZoneInfo.Local"/>. In Blazor Server applications this is the server time zone;
+    /// set this parameter to the user's time zone when it differs from the server time zone.
+    /// </remarks>
+    [Parameter] public TimeZoneInfo TimeZone { get; set; } = TimeZoneInfo.Local;
 
     #endregion
 }

--- a/Source/Extensions/Blazorise.Charts.Svg/Components/SvgChart.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Components/SvgChart.cs
@@ -175,7 +175,7 @@ public class SvgChart<TItem> : SvgChartBase
         var currentAnimationPointBounds = new Dictionary<string, SvgChartPointBounds>();
         var currentAnimationPathValues = new Dictionary<string, string>();
         var pluginContext = CreatePluginRenderContext( model, plot );
-        var seriesRendererContext = new SvgChartSeriesRendererContext( pluginContext, chartAnimation, previousAnimationPointBounds, currentAnimationPointBounds, previousAnimationPathValues, currentAnimationPathValues );
+        var seriesRendererContext = new SvgChartSeriesRendererContext( pluginContext, chartAnimation, previousAnimationPointBounds, currentAnimationPointBounds, previousAnimationPathValues, currentAnimationPathValues, ( value, index ) => FormatCategory( model, value, index ) );
         var zoom = model.Zoom;
 
         runStreamingAnimationAfterRender = streamingAnimation.Enabled;
@@ -633,7 +633,7 @@ public class SvgChart<TItem> : SvgChartBase
         {
             builder.OpenElement( sequence++, "div" );
             builder.AddAttribute( sequence++, "style", "font-weight:600;line-height:1.2;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;" );
-            builder.AddContent( sequence++, context.Items.Count > 1 ? context.Category : context.SeriesName );
+            builder.AddContent( sequence++, context.Items.Count > 1 ? FormatCategory( model, context.Category, context.PointIndex ) : context.SeriesName );
             builder.CloseElement();
 
             if ( tooltip.Formatter is not null || context.Items.Count <= 1 )
@@ -1062,7 +1062,7 @@ public class SvgChart<TItem> : SvgChartBase
             Items = items,
             Bounds = point.Bounds,
             Color = color,
-            Text = GetPointLabel( point ),
+            Text = GetPointLabel( point, model ),
             X = x,
             Y = y,
             Width = width,
@@ -1168,9 +1168,20 @@ public class SvgChart<TItem> : SvgChartBase
         };
     }
 
-    private static string GetPointLabel( SvgChartPointEventArgs point )
+    private static string GetPointLabel( SvgChartPointEventArgs point, SvgChartRenderModel model )
     {
-        return $"{point.Category}, {point.Value}. {point.SeriesName}.";
+        return $"{FormatCategory( model, point.Category, point.PointIndex )}, {point.Value}. {point.SeriesName}.";
+    }
+
+    private static string FormatCategory( SvgChartRenderModel model, object value, int index )
+    {
+        return model.CategoryValueFormatter?.Invoke( new()
+        {
+            Value = value,
+            Index = index,
+            CategoryAxis = true,
+            AxisId = model.CategoryAxis?.Id
+        } ) ?? SvgChartRenderHelpers.FormatDataLabelValue( value );
     }
 
     private static string ResolvePointColor( SvgChartRenderSeries series, int pointIndex )

--- a/Source/Extensions/Blazorise.Charts.Svg/Infrastructure/SvgChartModelBuilder.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Infrastructure/SvgChartModelBuilder.cs
@@ -118,6 +118,7 @@ internal sealed class SvgChartModelBuilder<TItem>
             CategoryScale = categoryScale,
             CategoryAxis = categoryAxisOptions,
             CategoryTickFormatter = ResolveCategoryTickFormatter( categoryAxis, categoryAxisOptions ),
+            CategoryValueFormatter = ResolveCategoryValueFormatter( categoryAxis ),
             Series = series,
             Min = primaryValueAxis.Min,
             Max = primaryValueAxis.Max,
@@ -432,33 +433,46 @@ internal sealed class SvgChartModelBuilder<TItem>
             return categoryAxis.TickFormatter;
 
         if ( categoryAxis is SvgChartTimeAxis<TItem> timeAxis )
-        {
-            var culture = ResolveTimeCulture( timeAxis.Culture );
-
-            return context =>
-            {
-                if ( timeAxis.Scale == SvgChartTimeScale.Continuous && context.Value is double doubleValue )
-                    return DateTimeOffset.FromUnixTimeMilliseconds( Convert.ToInt64( doubleValue ) ).ToString( ResolveTimeFormat( timeAxis ), culture );
-
-                if ( context.Value is DateTime dateTime )
-                    return dateTime.ToString( ResolveTimeFormat( timeAxis ), culture );
-
-                if ( context.Value is DateTimeOffset dateTimeOffset )
-                    return dateTimeOffset.ToString( ResolveTimeFormat( timeAxis ), culture );
-
-                return context.Value?.ToString();
-            };
-        }
+            return ResolveTimeValueFormatter( timeAxis );
 
         return categoryAxisOptions.TickFormatter;
     }
 
+    private static Func<SvgChartAxisTickContext, string> ResolveCategoryValueFormatter( SvgChartCategoryAxis<TItem> categoryAxis )
+    {
+        return categoryAxis is SvgChartTimeAxis<TItem> timeAxis
+            ? ResolveTimeValueFormatter( timeAxis )
+            : null;
+    }
+
+    private static Func<SvgChartAxisTickContext, string> ResolveTimeValueFormatter( SvgChartTimeAxis<TItem> timeAxis )
+    {
+        var culture = ResolveTimeCulture( timeAxis.Culture );
+        var timeZone = ResolveTimeZone( timeAxis.TimeZone );
+
+        return context =>
+        {
+            if ( timeAxis.Scale == SvgChartTimeScale.Continuous && context.Value is double doubleValue )
+                return FormatTimeValue( DateTimeOffset.FromUnixTimeMilliseconds( Convert.ToInt64( doubleValue ) ), timeAxis, culture, timeZone );
+
+            if ( context.Value is DateTime dateTime )
+                return FormatTimeValue( ResolveDateTimeOffset( dateTime, timeZone ), timeAxis, culture, timeZone );
+
+            if ( context.Value is DateTimeOffset dateTimeOffset )
+                return FormatTimeValue( dateTimeOffset, timeAxis, culture, timeZone );
+
+            return context.Value?.ToString();
+        };
+    }
+
     private static List<double?> ResolveTimeAxisValues( SvgChartCategoryAxis<TItem> categoryAxis, List<object> labels )
     {
-        if ( categoryAxis is not SvgChartTimeAxis<TItem> { Scale: SvgChartTimeScale.Continuous } || labels.Count == 0 )
+        if ( categoryAxis is not SvgChartTimeAxis<TItem> { Scale: SvgChartTimeScale.Continuous } timeAxis || labels.Count == 0 )
             return null;
 
-        return labels.Select( ToUnixMilliseconds ).ToList();
+        var timeZone = ResolveTimeZone( timeAxis.TimeZone );
+
+        return labels.Select( value => ToUnixMilliseconds( value, timeZone ) ).ToList();
     }
 
     private static SvgChartScale ResolveContinuousCategoryScale( SvgChartCategoryAxis<TItem> categoryAxis, SvgChartAxisOptions categoryAxisOptions, List<object> labels, List<SvgChartRenderSeries> series, SvgChartZoomOptions zoom, SvgChartViewport viewport )
@@ -471,9 +485,10 @@ internal sealed class SvgChartModelBuilder<TItem>
         if ( visibleSeries.Count == 0 || visibleSeries.Any( x => x.Type is not ( SvgChartType.Line or SvgChartType.Area or SvgChartType.Scatter or SvgChartType.Bubble ) ) )
             return null;
 
+        var timeZone = ResolveTimeZone( timeAxis.TimeZone );
         var values = visibleSeries
             .SelectMany( x => x.XValues )
-            .Concat( labels.Select( ToUnixMilliseconds ) )
+            .Concat( labels.Select( value => ToUnixMilliseconds( value, timeZone ) ) )
             .Where( x => x.HasValue )
             .Select( x => x.Value )
             .ToList();
@@ -521,22 +536,33 @@ internal sealed class SvgChartModelBuilder<TItem>
         }
     }
 
+    private static TimeZoneInfo ResolveTimeZone( TimeZoneInfo timeZone )
+    {
+        return timeZone ?? TimeZoneInfo.Local;
+    }
+
+    private static string FormatTimeValue( DateTimeOffset value, SvgChartTimeAxis<TItem> axis, System.Globalization.CultureInfo culture, TimeZoneInfo timeZone )
+    {
+        return TimeZoneInfo.ConvertTime( value, timeZone ).ToString( ResolveTimeFormat( axis ), culture );
+    }
+
     private static SvgChartScale BuildTimeScale( double min, double max, int tickCount, SvgChartTimeAxis<TItem> timeAxis )
     {
-        var minDate = DateTimeOffset.FromUnixTimeMilliseconds( Convert.ToInt64( min ) );
-        var maxDate = DateTimeOffset.FromUnixTimeMilliseconds( Convert.ToInt64( max ) );
+        var timeZone = ResolveTimeZone( timeAxis.TimeZone );
+        var minDate = TimeZoneInfo.ConvertTime( DateTimeOffset.FromUnixTimeMilliseconds( Convert.ToInt64( min ) ), timeZone );
+        var maxDate = TimeZoneInfo.ConvertTime( DateTimeOffset.FromUnixTimeMilliseconds( Convert.ToInt64( max ) ), timeZone );
         var unit = ResolveTimeUnit( timeAxis, maxDate - minDate );
         var step = ResolveTimeStep( unit, maxDate - minDate, tickCount );
         var current = FloorTime( minDate, unit, step );
         var ticks = new List<double>();
 
         while ( current < minDate )
-            current = AddTimeUnit( current, unit, step );
+            current = AddTimeUnit( current, unit, step, timeZone );
 
         for ( var i = 0; current <= maxDate && i < tickCount * 4; i++ )
         {
             ticks.Add( current.ToUnixTimeMilliseconds() );
-            current = AddTimeUnit( current, unit, step );
+            current = AddTimeUnit( current, unit, step, timeZone );
         }
 
         if ( ticks.Count == 0 || ticks[0] > min )
@@ -622,7 +648,7 @@ internal sealed class SvgChartModelBuilder<TItem>
         };
     }
 
-    private static DateTimeOffset AddTimeUnit( DateTimeOffset value, SvgChartTimeUnit unit, int step )
+    private static DateTimeOffset AddTimeUnit( DateTimeOffset value, SvgChartTimeUnit unit, int step, TimeZoneInfo timeZone )
     {
         return unit switch
         {
@@ -630,20 +656,30 @@ internal sealed class SvgChartModelBuilder<TItem>
             SvgChartTimeUnit.Second => value.AddSeconds( step ),
             SvgChartTimeUnit.Minute => value.AddMinutes( step ),
             SvgChartTimeUnit.Hour => value.AddHours( step ),
-            SvgChartTimeUnit.Day => value.AddDays( step ),
-            SvgChartTimeUnit.Month => value.AddMonths( step ),
-            SvgChartTimeUnit.Year => value.AddYears( step ),
+            SvgChartTimeUnit.Day => ResolveDateTimeOffset( value.DateTime.AddDays( step ), timeZone ),
+            SvgChartTimeUnit.Month => ResolveDateTimeOffset( value.DateTime.AddMonths( step ), timeZone ),
+            SvgChartTimeUnit.Year => ResolveDateTimeOffset( value.DateTime.AddYears( step ), timeZone ),
             _ => value.AddMinutes( step )
         };
     }
 
-    private static double? ToUnixMilliseconds( object value )
+    private static double? ToUnixMilliseconds( object value, TimeZoneInfo timeZone )
     {
         return value switch
         {
-            DateTime dateTime => new DateTimeOffset( dateTime ).ToUnixTimeMilliseconds(),
+            DateTime dateTime => ResolveDateTimeOffset( dateTime, timeZone ).ToUnixTimeMilliseconds(),
             DateTimeOffset dateTimeOffset => dateTimeOffset.ToUnixTimeMilliseconds(),
             _ => null
+        };
+    }
+
+    private static DateTimeOffset ResolveDateTimeOffset( DateTime value, TimeZoneInfo timeZone )
+    {
+        return value.Kind switch
+        {
+            DateTimeKind.Utc => new DateTimeOffset( value ),
+            DateTimeKind.Local => new DateTimeOffset( value ),
+            _ => new DateTimeOffset( value, timeZone.GetUtcOffset( value ) )
         };
     }
 

--- a/Source/Extensions/Blazorise.Charts.Svg/Models/SvgChartRenderModel.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Models/SvgChartRenderModel.cs
@@ -35,6 +35,8 @@ internal sealed class SvgChartRenderModel
 
     public Func<SvgChartAxisTickContext, string> CategoryTickFormatter { get; init; }
 
+    public Func<SvgChartAxisTickContext, string> CategoryValueFormatter { get; init; }
+
     public List<SvgChartRenderSeries> Series { get; init; } = [];
 
     public double Min { get; init; }

--- a/Source/Extensions/Blazorise.Charts.Svg/Renderers/SvgChartSeriesRendererContext.cs
+++ b/Source/Extensions/Blazorise.Charts.Svg/Renderers/SvgChartSeriesRendererContext.cs
@@ -18,7 +18,8 @@ internal sealed class SvgChartSeriesRendererContext
         IReadOnlyDictionary<string, SvgChartPointBounds> previousPointBounds,
         Dictionary<string, SvgChartPointBounds> currentPointBounds,
         IReadOnlyDictionary<string, string> previousPathValues,
-        Dictionary<string, string> currentPathValues )
+        Dictionary<string, string> currentPathValues,
+        Func<object, int, string> categoryFormatter )
     {
         Chart = chart;
         Animation = animation ?? new();
@@ -26,6 +27,7 @@ internal sealed class SvgChartSeriesRendererContext
         this.currentPointBounds = currentPointBounds ?? [];
         this.previousPathValues = previousPathValues ?? new Dictionary<string, string>();
         this.currentPathValues = currentPathValues ?? [];
+        this.categoryFormatter = categoryFormatter;
     }
 
     #endregion
@@ -39,6 +41,8 @@ internal sealed class SvgChartSeriesRendererContext
     private readonly IReadOnlyDictionary<string, string> previousPathValues;
 
     private readonly Dictionary<string, string> currentPathValues;
+
+    private readonly Func<object, int, string> categoryFormatter;
 
     #endregion
 
@@ -175,7 +179,9 @@ internal sealed class SvgChartSeriesRendererContext
 
     public string GetPointLabel( SvgChartPointEventArgs point )
     {
-        return $"{point.Category}, {point.Value}. {point.SeriesName}.";
+        var category = categoryFormatter?.Invoke( point.Category, point.PointIndex ) ?? point.Category?.ToString();
+
+        return $"{category}, {point.Value}. {point.SeriesName}.";
     }
 
     public string ResolveColor( int index )

--- a/Tests/Blazorise.Tests/Blazorise.Tests.csproj
+++ b/Tests/Blazorise.Tests/Blazorise.Tests.csproj
@@ -30,6 +30,7 @@
     <ProjectReference Include="..\..\Source\Extensions\Blazorise.Gantt\Blazorise.Gantt.csproj" />
     <ProjectReference Include="..\..\Source\Extensions\Blazorise.PivotGrid\Blazorise.PivotGrid.csproj" />
     <ProjectReference Include="..\..\Source\Extensions\Blazorise.Scheduler\Blazorise.Scheduler.csproj" />
+    <ProjectReference Include="..\..\Source\Extensions\Blazorise.Charts.Svg\Blazorise.Charts.Svg.csproj" />
     <ProjectReference Include="..\..\Source\Helpers\Blazorise.Tests.bUnit\Blazorise.Tests.bUnit.csproj" />
     <ProjectReference Include="..\BasicTestApp.Server\BasicTestApp.Server.csproj" />
   </ItemGroup>

--- a/Tests/Blazorise.Tests/Components/SvgChartTimeAxisComponentTest.cs
+++ b/Tests/Blazorise.Tests/Components/SvgChartTimeAxisComponentTest.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using Blazorise.Charts.Svg;
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using Xunit;
+
+namespace Blazorise.Tests.Components;
+
+public class SvgChartTimeAxisComponentTest : BunitContext
+{
+    public SvgChartTimeAxisComponentTest()
+    {
+        Services.AddBlazoriseTests().AddBootstrapProviders().AddEmptyIconProvider();
+        JSInterop.AddBlazoriseUtilities();
+    }
+
+    [Fact]
+    public void ContinuousTimeAxis_InterpretsUnspecifiedValuesInConfiguredTimeZone()
+    {
+        TimeZoneInfo timeZone = CreateTestTimeZone();
+        List<TimeSample> samples =
+        [
+            new() { Time = new DateTime( 2026, 7, 15, 7, 0, 0, DateTimeKind.Unspecified ), Value = 1 },
+            new() { Time = new DateTime( 2026, 7, 15, 8, 0, 0, DateTimeKind.Unspecified ), Value = 2 }
+        ];
+
+        IRenderedComponent<SvgScatterChart<TimeSample>> component = RenderTimeChart( samples, timeZone );
+
+        component.WaitForAssertion( () => Assert.Contains( "07:00", component.Markup ) );
+
+        component.Find( ".svg-chart-point.svg-chart-scatter" ).MouseEnter();
+
+        component.WaitForAssertion( () => Assert.Contains( "07:00, 1. Samples.", component.Markup ) );
+    }
+
+    [Fact]
+    public void ContinuousTimeAxis_ConvertsUtcValuesToConfiguredTimeZone()
+    {
+        TimeZoneInfo timeZone = CreateTestTimeZone();
+        List<TimeSample> samples =
+        [
+            new() { Time = new DateTime( 2026, 7, 15, 5, 0, 0, DateTimeKind.Utc ), Value = 1 },
+            new() { Time = new DateTime( 2026, 7, 15, 6, 0, 0, DateTimeKind.Utc ), Value = 2 }
+        ];
+
+        IRenderedComponent<SvgScatterChart<TimeSample>> component = RenderTimeChart( samples, timeZone );
+
+        component.WaitForAssertion( () => Assert.Contains( "07:00", component.Markup ) );
+
+        component.Find( ".svg-chart-point.svg-chart-scatter" ).MouseEnter();
+
+        component.WaitForAssertion( () => Assert.Contains( "07:00, 1. Samples.", component.Markup ) );
+    }
+
+    private IRenderedComponent<SvgScatterChart<TimeSample>> RenderTimeChart( List<TimeSample> samples, TimeZoneInfo timeZone )
+    {
+        return Render<SvgScatterChart<TimeSample>>( parameters => parameters
+            .Add( chart => chart.Items, samples )
+            .AddChildContent( builder =>
+            {
+                builder.OpenComponent<SvgScatterSeries<TimeSample>>( 0 );
+                builder.AddAttribute( 1, nameof( SvgScatterSeries<TimeSample>.Name ), "Samples" );
+                builder.AddAttribute( 2, nameof( SvgScatterSeries<TimeSample>.YValue ), (Func<TimeSample, double?>)( item => item.Value ) );
+                builder.CloseComponent();
+
+                builder.OpenComponent<SvgChartTimeAxis<TimeSample>>( 3 );
+                builder.AddAttribute( 4, nameof( SvgChartTimeAxis<TimeSample>.TimeValue ), (Func<TimeSample, DateTime?>)( item => item.Time ) );
+                builder.AddAttribute( 5, nameof( SvgChartTimeAxis<TimeSample>.Scale ), SvgChartTimeScale.Continuous );
+                builder.AddAttribute( 6, nameof( SvgChartTimeAxis<TimeSample>.Unit ), SvgChartTimeUnit.Minute );
+                builder.AddAttribute( 7, nameof( SvgChartTimeAxis<TimeSample>.Format ), "HH:mm" );
+                builder.AddAttribute( 8, nameof( SvgChartTimeAxis<TimeSample>.TimeZone ), timeZone );
+                builder.CloseComponent();
+            } ) );
+    }
+
+    private static TimeZoneInfo CreateTestTimeZone()
+    {
+        return TimeZoneInfo.CreateCustomTimeZone( "SvgChartTimeAxisTest", TimeSpan.FromHours( 2 ), "UTC+02:00", "UTC+02:00" );
+    }
+
+    private sealed class TimeSample
+    {
+        public DateTime Time { get; set; }
+
+        public double Value { get; set; }
+    }
+}


### PR DESCRIPTION
Closes #6681

Fixes `SvgChartTimeAxis` positioning time values using UTC while displaying their original local value in tooltips, which caused axis labels and data points to differ by the local UTC offset.

A new `TimeZone` parameter has been added to `SvgChartTimeAxis`, defaulting to `TimeZoneInfo.Local`. UTC and local DateTime values are treated as instants and converted to the configured timezone. Unspecified values are interpreted as wall-clock values in that timezone. Axis labels, default tooltips, and point accessibility labels now use the same conversion.

The documentation explains the expected behavior for each `DateTimeKind` and notes that `TimeZoneInfo.Local` represents the  server timezone in Blazor Server applications. Applications requiring browser-user-local display must supply the user’s timezone explicitly.