### PR TITLE
Jobs: add native job submission form

### DIFF
--- a/Documentation/Blazorise.Docs.Server/Infrastructure/GitHubJobSubmissionService.cs
+++ b/Documentation/Blazorise.Docs.Server/Infrastructure/GitHubJobSubmissionService.cs
@@ -1,0 +1,233 @@
+#region Using directives
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using Blazorise.Docs.Models;
+using Blazorise.Docs.Options;
+using Blazorise.Docs.Services;
+using Microsoft.Extensions.Options;
+#endregion
+
+namespace Blazorise.Docs.Server.Infrastructure;
+
+internal sealed class GitHubJobSubmissionService : IJobSubmissionService
+{
+    #region Members
+
+    private const string GitHubApiVersion = "2026-03-10";
+
+    private static readonly HashSet<string> EmploymentTypes = new( StringComparer.Ordinal )
+    {
+        "Full-time",
+        "Part-time",
+        "Contract",
+        "Internship",
+        "Temporary",
+        "Other"
+    };
+
+    private static readonly HashSet<string> SeniorityOptions = new( StringComparer.Ordinal )
+    {
+        "Intern",
+        "Junior",
+        "Mid",
+        "Senior",
+        "Lead",
+        "Principal",
+        "Other"
+    };
+
+    private readonly HttpClient httpClient;
+    private readonly JobsOptions options;
+
+    #endregion
+
+    #region Constructors
+
+    public GitHubJobSubmissionService( HttpClient httpClient, IOptions<JobsOptions> options )
+    {
+        this.httpClient = httpClient;
+        this.options = options.Value ?? new JobsOptions();
+
+        this.httpClient.DefaultRequestHeaders.UserAgent.ParseAdd( "BlazoriseDocsJobs/1.0" );
+    }
+
+    #endregion
+
+    #region Methods
+
+    public async Task<JobSubmissionResult> SubmitAsync( JobSubmission submission, CancellationToken cancellationToken = default )
+    {
+        ValidateConfiguration();
+        ValidateSubmission( submission );
+
+        string requestUrl = $"https://api.github.com/repos/{Uri.EscapeDataString( options.GitHubOwner )}/{Uri.EscapeDataString( options.GitHubRepository )}/issues";
+        GitHubIssueRequest payload = new GitHubIssueRequest
+        {
+            Title = $"[JOB] {submission.RoleTitle.Trim()}",
+            Body = BuildIssueBody( submission ),
+            Labels = new[] { "type:job", "status:pending" }
+        };
+
+        using HttpRequestMessage request = new HttpRequestMessage( HttpMethod.Post, requestUrl )
+        {
+            Content = JsonContent.Create( payload )
+        };
+        request.Headers.Accept.Add( new MediaTypeWithQualityHeaderValue( "application/vnd.github+json" ) );
+        request.Headers.Authorization = new AuthenticationHeaderValue( "Bearer", options.GitHubToken );
+        request.Headers.Add( "X-GitHub-Api-Version", GitHubApiVersion );
+
+        using HttpResponseMessage response = await httpClient.SendAsync( request, cancellationToken );
+        if ( !response.IsSuccessStatusCode )
+        {
+            string responseContent = await response.Content.ReadAsStringAsync( cancellationToken );
+            throw new InvalidOperationException( $"GitHub rejected the job submission with status {(int)response.StatusCode}: {responseContent}" );
+        }
+
+        GitHubIssueResponse result = await response.Content.ReadFromJsonAsync<GitHubIssueResponse>( cancellationToken: cancellationToken );
+        if ( result is null || result.Number <= 0 || string.IsNullOrWhiteSpace( result.HtmlUrl ) )
+            throw new InvalidOperationException( "GitHub returned an invalid response for the job submission." );
+
+        return new JobSubmissionResult
+        {
+            IssueNumber = result.Number,
+            IssueUrl = result.HtmlUrl
+        };
+    }
+
+    private void ValidateConfiguration()
+    {
+        if ( string.IsNullOrWhiteSpace( options.GitHubOwner ) )
+            throw new InvalidOperationException( "The GitHub jobs repository owner is not configured." );
+
+        if ( string.IsNullOrWhiteSpace( options.GitHubRepository ) )
+            throw new InvalidOperationException( "The GitHub jobs repository name is not configured." );
+
+        if ( string.IsNullOrWhiteSpace( options.GitHubToken ) )
+            throw new InvalidOperationException( "The GitHub token for job submissions is not configured." );
+    }
+
+    private static void ValidateSubmission( JobSubmission submission )
+    {
+        ArgumentNullException.ThrowIfNull( submission );
+
+        RequireText( submission.CompanyName, "Company name", 200 );
+        RequireText( submission.RoleTitle, "Role title", 200 );
+        RequireText( submission.Location, "Location", 200 );
+        RequireText( submission.Tags, "Tags/keywords", 500 );
+        RequireText( submission.Description, "Description", 30000 );
+        RequireOptionalText( submission.SalaryRange, "Salary range", 200 );
+        RequireOptionalText( submission.ContactEmail, "Contact email", 320 );
+
+        string[] tags = submission.Tags.Split( ',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries );
+        if ( tags.Length == 0 )
+            throw new ArgumentException( "Tags/keywords must include at least one value.", nameof( submission ) );
+
+        if ( submission.Remote is not ( "Yes" or "No" ) )
+            throw new ArgumentException( "Remote must be Yes or No.", nameof( submission ) );
+
+        if ( !EmploymentTypes.Contains( submission.EmploymentType ) )
+            throw new ArgumentException( "Employment type is invalid.", nameof( submission ) );
+
+        if ( !SeniorityOptions.Contains( submission.Seniority ) )
+            throw new ArgumentException( "Seniority is invalid.", nameof( submission ) );
+
+        RequireText( submission.ApplyUrl, "Apply URL", 2000 );
+        if ( !Uri.TryCreate( submission.ApplyUrl.Trim(), UriKind.Absolute, out Uri applyUri )
+             || ( !string.Equals( applyUri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase )
+                  && !string.Equals( applyUri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase ) ) )
+        {
+            throw new ArgumentException( "Apply URL must be a valid HTTP or HTTPS URL.", nameof( submission ) );
+        }
+
+        if ( !string.IsNullOrWhiteSpace( submission.ContactEmail ) && !System.Net.Mail.MailAddress.TryCreate( submission.ContactEmail.Trim(), out _ ) )
+            throw new ArgumentException( "Contact email is invalid.", nameof( submission ) );
+
+        if ( !submission.ExpiryDate.HasValue || submission.ExpiryDate.Value.Date < DateTime.UtcNow.Date )
+            throw new ArgumentException( "Expiry date must be today or later.", nameof( submission ) );
+
+        if ( !submission.Confirmation )
+            throw new ArgumentException( "Submission confirmation is required.", nameof( submission ) );
+    }
+
+    private static void RequireText( string value, string fieldName, int maximumLength )
+    {
+        if ( string.IsNullOrWhiteSpace( value ) )
+            throw new ArgumentException( $"{fieldName} is required." );
+
+        if ( value.Length > maximumLength )
+            throw new ArgumentException( $"{fieldName} cannot exceed {maximumLength.ToString( CultureInfo.InvariantCulture )} characters." );
+    }
+
+    private static void RequireOptionalText( string value, string fieldName, int maximumLength )
+    {
+        if ( value is not null && value.Length > maximumLength )
+            throw new ArgumentException( $"{fieldName} cannot exceed {maximumLength.ToString( CultureInfo.InvariantCulture )} characters." );
+    }
+
+    private static string BuildIssueBody( JobSubmission submission )
+    {
+        StringBuilder body = new StringBuilder();
+
+        AppendField( body, "Company name", submission.CompanyName );
+        AppendField( body, "Role title", submission.RoleTitle );
+        AppendField( body, "Location", submission.Location );
+        AppendField( body, "Remote", submission.Remote );
+        AppendField( body, "Employment type", submission.EmploymentType );
+        AppendField( body, "Seniority", submission.Seniority );
+        AppendField( body, "Tags/keywords", submission.Tags );
+        AppendField( body, "Apply URL", submission.ApplyUrl );
+        AppendField( body, "Description", submission.Description );
+        AppendField( body, "Salary range", submission.SalaryRange );
+        AppendField( body, "Contact email", submission.ContactEmail );
+        AppendField( body, "Expiry date", submission.ExpiryDate.Value.ToString( "yyyy-MM-dd", CultureInfo.InvariantCulture ) );
+        body.AppendLine( "## Confirmation" );
+        body.AppendLine();
+        body.Append( "- [x] I confirm I have rights to post this job and it's not spam." );
+
+        return body.ToString();
+    }
+
+    private static void AppendField( StringBuilder body, string heading, string value )
+    {
+        body.Append( "## " );
+        body.AppendLine( heading );
+        body.AppendLine();
+        body.AppendLine( string.IsNullOrWhiteSpace( value ) ? "_No response_" : value.Trim() );
+        body.AppendLine();
+    }
+
+    #endregion
+
+    #region Nested types
+
+    private sealed class GitHubIssueRequest
+    {
+        [JsonPropertyName( "title" )]
+        public string Title { get; set; }
+
+        [JsonPropertyName( "body" )]
+        public string Body { get; set; }
+
+        [JsonPropertyName( "labels" )]
+        public IReadOnlyList<string> Labels { get; set; }
+    }
+
+    private sealed class GitHubIssueResponse
+    {
+        [JsonPropertyName( "number" )]
+        public long Number { get; set; }
+
+        [JsonPropertyName( "html_url" )]
+        public string HtmlUrl { get; set; }
+    }
+
+    #endregion
+}

--- a/Documentation/Blazorise.Docs.Server/Infrastructure/ServerJobsService.cs
+++ b/Documentation/Blazorise.Docs.Server/Infrastructure/ServerJobsService.cs
@@ -45,8 +45,6 @@ internal sealed class ServerJobsService : IJobsService
         this.options = options.Value ?? new JobsOptions();
 
         this.httpClient.DefaultRequestHeaders.UserAgent.ParseAdd( "BlazoriseJobsFeed/1.0" );
-        if ( !string.IsNullOrWhiteSpace( this.options.GitHubToken ) )
-            this.httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue( "Bearer", this.options.GitHubToken );
     }
 
     #endregion

--- a/Documentation/Blazorise.Docs.Server/Startup.cs
+++ b/Documentation/Blazorise.Docs.Server/Startup.cs
@@ -87,6 +87,7 @@ public class Startup
         services.Configure<JobsOptions>( Configuration.GetSection( JobsOptions.SectionName ) );
         services.AddHttpClient();
         services.AddHttpClient<IJobsService, ServerJobsService>();
+        services.AddHttpClient<IJobSubmissionService, GitHubJobSubmissionService>();
         services.AddValidatorsFromAssembly( typeof( App ).Assembly );
 
         services.Configure<BrevoApiOptions>( Configuration.GetSection( BrevoApiOptions.SectionName ) );

--- a/Documentation/Blazorise.Docs.Server/appsettings.json
+++ b/Documentation/Blazorise.Docs.Server/appsettings.json
@@ -41,7 +41,8 @@
   },
   "Jobs": {
     "FeedUrl": "https://blazorise.github.io/Blazorise.Jobs/jobs.json",
-    "SubmitJobUrl": "https://github.com/Blazorise/Blazorise.Jobs/issues/new?template=job.yml",
+    "GitHubOwner": "Blazorise",
+    "GitHubRepository": "Blazorise.Jobs",
     "GitHubToken": null,
     "RefreshSecret": null
   },

--- a/Documentation/Blazorise.Docs/Models/JobSubmission.cs
+++ b/Documentation/Blazorise.Docs/Models/JobSubmission.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace Blazorise.Docs.Models;
+
+/// <summary>
+/// Represents a job submitted for moderation.
+/// </summary>
+public sealed class JobSubmission
+{
+    public string CompanyName { get; set; } = string.Empty;
+    public string RoleTitle { get; set; } = string.Empty;
+    public string Location { get; set; } = string.Empty;
+    public string Remote { get; set; } = string.Empty;
+    public string EmploymentType { get; set; } = string.Empty;
+    public string Seniority { get; set; } = string.Empty;
+    public string Tags { get; set; } = string.Empty;
+    public string ApplyUrl { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public string SalaryRange { get; set; } = string.Empty;
+    public string ContactEmail { get; set; } = string.Empty;
+    public DateTime? ExpiryDate { get; set; }
+    public bool Confirmation { get; set; }
+}

--- a/Documentation/Blazorise.Docs/Options/JobsOptions.cs
+++ b/Documentation/Blazorise.Docs/Options/JobsOptions.cs
@@ -16,12 +16,17 @@ public class JobsOptions
     public string FeedUrl { get; set; } = "https://example.com/jobs/jobs.json";
 
     /// <summary>
-    /// Gets or sets the URL for submitting a job post.
+    /// Gets or sets the GitHub organization or user that owns the jobs repository.
     /// </summary>
-    public string SubmitJobUrl { get; set; } = "https://github.com/your-org/jobs/issues/new?template=job.yml";
+    public string GitHubOwner { get; set; } = "Blazorise";
 
     /// <summary>
-    /// Gets or sets the GitHub personal access token used for authentication.
+    /// Gets or sets the GitHub jobs repository name.
+    /// </summary>
+    public string GitHubRepository { get; set; } = "Blazorise.Jobs";
+
+    /// <summary>
+    /// Gets or sets the GitHub token used to create pending job issues.
     /// </summary>
     public string GitHubToken { get; set; }
 

--- a/Documentation/Blazorise.Docs/Pages/Home/JobsPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Home/JobsPage.razor
@@ -11,7 +11,7 @@
         Community-posted roles for Blazor and .NET teams.
     </Description>
     <Actions>
-        <Button Color="Color.Primary" Size="Size.Large" Type="ButtonType.Link" To="@SubmitJobUrl" Target="Target.Blank">
+        <Button Color="Color.Primary" Size="Size.Large" Type="ButtonType.Link" To="/jobs/submit">
             Submit a job
         </Button>
     </Actions>

--- a/Documentation/Blazorise.Docs/Pages/Home/JobsPage.razor.cs
+++ b/Documentation/Blazorise.Docs/Pages/Home/JobsPage.razor.cs
@@ -4,11 +4,9 @@ using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using Blazorise.Docs.Models;
-using Blazorise.Docs.Options;
 using Blazorise.Docs.Services;
 using Markdig;
 using Microsoft.AspNetCore.Components;
-using Microsoft.Extensions.Options;
 
 namespace Blazorise.Docs.Pages.Home;
 
@@ -33,23 +31,19 @@ public partial class JobsPage
     private string selectedSeniority = AllFilterOption;
     private JobsSortOption selectedSort = JobsSortOption.MostRecent;
 
-    private JobsOptions jobsOptions = new JobsOptions();
     private JobPost selectedJob;
     private bool detailsVisible;
     private MarkupString descriptionMarkup;
 
     [Inject] public IJobsService JobsService { get; set; }
-    [Inject] public IOptions<JobsOptions> JobsOptions { get; set; }
 
     private IReadOnlyList<string> EmploymentTypeOptions => employmentTypeOptions;
     private IReadOnlyList<string> SeniorityOptions => seniorityOptions;
-    private string SubmitJobUrl => jobsOptions.SubmitJobUrl;
     private string DetailsTitle => selectedJob?.Title ?? "Job details";
     private MarkupString DescriptionMarkup => descriptionMarkup;
 
     protected override async Task OnInitializedAsync()
     {
-        jobsOptions = JobsOptions?.Value ?? new JobsOptions();
         await LoadJobsAsync();
     }
 

--- a/Documentation/Blazorise.Docs/Pages/Home/JobsSubmitPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Home/JobsSubmitPage.razor
@@ -1,0 +1,291 @@
+@page "/jobs/submit"
+@using Blazorise.Docs.Models
+
+<Seo Canonical="/jobs/submit" Title="Submit a Blazorise Job" Description="Submit a Blazor or .NET role to the moderated Blazorise jobs board." />
+
+<PageHeader>
+    <Title>
+        Submit a job
+    </Title>
+    <Description>
+        Reach developers building with Blazor and .NET. Every submission is reviewed before it appears on the jobs board.
+    </Description>
+    <Actions>
+        <Button Color="Color.Secondary" Outline Size="Size.Large" Type="ButtonType.Link" To="/jobs">
+            Browse jobs
+        </Button>
+    </Actions>
+</PageHeader>
+
+<Container Padding="Padding.Is4.OnX.Is5.OnY">
+    <Row>
+        <Column ColumnSize="ColumnSize.Is12.Is8.OnWidescreen" Margin="Margin.IsAuto.OnX">
+            @if ( submissionResult is not null )
+            {
+                <Card Shadow="Shadow.Large" Border="Border.Is0.Rounded">
+                    <CardBody Padding="Padding.Is5">
+                        <Div TextAlignment="TextAlignment.Center">
+                            <Icon Name="IconName.CheckCircle" TextColor="TextColor.Success" TextSize="TextSize.Heading2" />
+                            <Heading Size="HeadingSize.Is3" Margin="Margin.Is3.FromTop.Is2.FromBottom">
+                                Job submitted for review
+                            </Heading>
+                            <Paragraph TextColor="TextColor.Muted">
+                                Your job is now in the Blazorise.Jobs moderation queue. Approved posts will appear on the jobs board.
+                            </Paragraph>
+                            <Paragraph>
+                                <Anchor To="@submissionResult.IssueUrl" Target="Target.Blank">
+                                    View GitHub issue #@submissionResult.IssueNumber
+                                </Anchor>
+                            </Paragraph>
+                            <Div Flex="Flex.Column.Row.OnMobile.JustifyContent.Center" Gap="Gap.Is2" Margin="Margin.Is4.FromTop">
+                                <Button Color="Color.Primary" Type="ButtonType.Link" To="/jobs">
+                                    Browse jobs
+                                </Button>
+                                <Button Color="Color.Secondary" Outline Clicked="@SubmitAnother">
+                                    Submit another job
+                                </Button>
+                            </Div>
+                        </Div>
+                    </CardBody>
+                </Card>
+            }
+            else
+            {
+                <Alert Color="Color.Info" Margin="Margin.Is3.FromBottom">
+                    Submissions are stored as public issues in the Blazorise.Jobs repository and are published only after moderator approval.
+                </Alert>
+
+                <Card Shadow="Shadow.Large" Border="Border.Is0.Rounded">
+                    <CardHeader Padding="Padding.Is4">
+                        <Heading Size="HeadingSize.Is4" Margin="Margin.Is0.FromBottom">Job details</Heading>
+                        <Paragraph TextColor="TextColor.Muted" Margin="Margin.Is1.FromTop.Is0.FromBottom">
+                            Fields marked with an asterisk are required.
+                        </Paragraph>
+                    </CardHeader>
+                    <CardBody Padding="Padding.Is4">
+                        <Form>
+                            <Validations @ref="@validationsRef" Mode="ValidationMode.Manual" ValidateOnLoad="false">
+                                <Fields>
+                                    <Validation Validator="ValidationRule.IsNotEmpty">
+                                        <Field ColumnSize="ColumnSize.Is12.Is6.OnDesktop">
+                                            <FieldLabel RequiredIndicator>Company name</FieldLabel>
+                                            <FieldBody>
+                                                <TextInput @bind-Value="@submission.CompanyName" Placeholder="Contoso">
+                                                    <Feedback>
+                                                        <ValidationError>Company name is required.</ValidationError>
+                                                    </Feedback>
+                                                </TextInput>
+                                                <FieldHelp>Legal or common company name.</FieldHelp>
+                                            </FieldBody>
+                                        </Field>
+                                    </Validation>
+                                    <Validation Validator="ValidationRule.IsNotEmpty">
+                                        <Field ColumnSize="ColumnSize.Is12.Is6.OnDesktop">
+                                            <FieldLabel RequiredIndicator>Role title</FieldLabel>
+                                            <FieldBody>
+                                                <TextInput @bind-Value="@submission.RoleTitle" Placeholder="Senior .NET Developer">
+                                                    <Feedback>
+                                                        <ValidationError>Role title is required.</ValidationError>
+                                                    </Feedback>
+                                                </TextInput>
+                                            </FieldBody>
+                                        </Field>
+                                    </Validation>
+                                </Fields>
+
+                                <Fields>
+                                    <Validation Validator="ValidationRule.IsNotEmpty">
+                                        <Field ColumnSize="ColumnSize.Is12.Is8.OnDesktop">
+                                            <FieldLabel RequiredIndicator>Location</FieldLabel>
+                                            <FieldBody>
+                                                <TextInput @bind-Value="@submission.Location" Placeholder="Berlin, DE">
+                                                    <Feedback>
+                                                        <ValidationError>Location is required.</ValidationError>
+                                                    </Feedback>
+                                                </TextInput>
+                                                <FieldHelp>City, region, or Worldwide.</FieldHelp>
+                                            </FieldBody>
+                                        </Field>
+                                    </Validation>
+                                    <Validation Validator="ValidationRule.IsSelected">
+                                        <Field ColumnSize="ColumnSize.Is12.Is4.OnDesktop">
+                                            <FieldLabel RequiredIndicator>Remote</FieldLabel>
+                                            <FieldBody>
+                                                <Select TValue="string" @bind-Value="@submission.Remote">
+                                                    <ChildContent>
+                                                        <SelectItem TValue="string" Value="@string.Empty">Choose...</SelectItem>
+                                                        <SelectItem TValue="string" Value="@("Yes")">Yes</SelectItem>
+                                                        <SelectItem TValue="string" Value="@("No")">No</SelectItem>
+                                                    </ChildContent>
+                                                    <Feedback>
+                                                        <ValidationError>Select whether the role is remote.</ValidationError>
+                                                    </Feedback>
+                                                </Select>
+                                            </FieldBody>
+                                        </Field>
+                                    </Validation>
+                                </Fields>
+
+                                <Fields>
+                                    <Validation Validator="ValidationRule.IsSelected">
+                                        <Field ColumnSize="ColumnSize.Is12.Is6.OnDesktop">
+                                            <FieldLabel RequiredIndicator>Employment type</FieldLabel>
+                                            <FieldBody>
+                                                <Select TValue="string" @bind-Value="@submission.EmploymentType">
+                                                    <ChildContent>
+                                                        <SelectItem TValue="string" Value="@string.Empty">Choose...</SelectItem>
+                                                        @foreach ( string employmentType in EmploymentTypes )
+                                                        {
+                                                            <SelectItem TValue="string" Value="@employmentType">@employmentType</SelectItem>
+                                                        }
+                                                    </ChildContent>
+                                                    <Feedback>
+                                                        <ValidationError>Employment type is required.</ValidationError>
+                                                    </Feedback>
+                                                </Select>
+                                            </FieldBody>
+                                        </Field>
+                                    </Validation>
+                                    <Validation Validator="ValidationRule.IsSelected">
+                                        <Field ColumnSize="ColumnSize.Is12.Is6.OnDesktop">
+                                            <FieldLabel RequiredIndicator>Seniority</FieldLabel>
+                                            <FieldBody>
+                                                <Select TValue="string" @bind-Value="@submission.Seniority">
+                                                    <ChildContent>
+                                                        <SelectItem TValue="string" Value="@string.Empty">Choose...</SelectItem>
+                                                        @foreach ( string seniority in SeniorityOptions )
+                                                        {
+                                                            <SelectItem TValue="string" Value="@seniority">@seniority</SelectItem>
+                                                        }
+                                                    </ChildContent>
+                                                    <Feedback>
+                                                        <ValidationError>Seniority is required.</ValidationError>
+                                                    </Feedback>
+                                                </Select>
+                                            </FieldBody>
+                                        </Field>
+                                    </Validation>
+                                </Fields>
+
+                                <Validation Validator="ValidationRule.IsNotEmpty">
+                                    <Field>
+                                        <FieldLabel RequiredIndicator>Tags/keywords</FieldLabel>
+                                        <FieldBody>
+                                            <TextInput @bind-Value="@submission.Tags" Placeholder="C#, Blazor, Azure">
+                                                <Feedback>
+                                                    <ValidationError>Add at least one tag or keyword.</ValidationError>
+                                                </Feedback>
+                                            </TextInput>
+                                            <FieldHelp>Separate tags with commas.</FieldHelp>
+                                        </FieldBody>
+                                    </Field>
+                                </Validation>
+
+                                <Validation Validator="@ValidateApplyUrl">
+                                    <Field>
+                                        <FieldLabel RequiredIndicator>Apply URL</FieldLabel>
+                                        <FieldBody>
+                                            <TextInput Role="TextRole.Url" @bind-Value="@submission.ApplyUrl" Placeholder="https://example.com/jobs/123">
+                                                <Feedback>
+                                                    <ValidationError />
+                                                </Feedback>
+                                            </TextInput>
+                                            <FieldHelp>Link directly to the application page.</FieldHelp>
+                                        </FieldBody>
+                                    </Field>
+                                </Validation>
+
+                                <Validation Validator="ValidationRule.IsNotEmpty">
+                                    <Field>
+                                        <FieldLabel RequiredIndicator>Description</FieldLabel>
+                                        <FieldBody>
+                                            <Markdown @bind-Value="@submission.Description" MinHeight="280px" UploadImage="false">
+                                                <Feedback>
+                                                    <ValidationError>Describe the role, responsibilities, and requirements.</ValidationError>
+                                                </Feedback>
+                                            </Markdown>
+                                            <FieldHelp>Markdown is supported.</FieldHelp>
+                                        </FieldBody>
+                                    </Field>
+                                </Validation>
+
+                                <Fields>
+                                    <Field ColumnSize="ColumnSize.Is12.Is6.OnDesktop">
+                                        <FieldLabel>Salary range</FieldLabel>
+                                        <FieldBody>
+                                            <TextInput @bind-Value="@submission.SalaryRange" Placeholder="EUR 60k - 80k" />
+                                            <FieldHelp>Optional.</FieldHelp>
+                                        </FieldBody>
+                                    </Field>
+                                    <Validation Validator="@ValidateOptionalEmail">
+                                        <Field ColumnSize="ColumnSize.Is12.Is6.OnDesktop">
+                                            <FieldLabel>Contact email</FieldLabel>
+                                            <FieldBody>
+                                                <TextInput Role="TextRole.Email" @bind-Value="@submission.ContactEmail" Placeholder="jobs@company.com">
+                                                    <Feedback>
+                                                        <ValidationError />
+                                                    </Feedback>
+                                                </TextInput>
+                                                <FieldHelp>Optional and excluded from the published jobs feed. The pending GitHub issue remains public.</FieldHelp>
+                                            </FieldBody>
+                                        </Field>
+                                    </Validation>
+                                </Fields>
+
+                                <Validation Validator="@ValidateExpiryDate">
+                                    <Field>
+                                        <FieldLabel RequiredIndicator>Expiry date</FieldLabel>
+                                        <FieldBody>
+                                            <DatePicker TValue="DateTime?" @bind-Value="@submission.ExpiryDate" InputFormat="yyyy-MM-dd" DisplayFormat="yyyy-MM-dd" Placeholder="YYYY-MM-DD">
+                                                <Feedback>
+                                                    <ValidationError />
+                                                </Feedback>
+                                            </DatePicker>
+                                            <FieldHelp>The posting will be removed after this date (UTC).</FieldHelp>
+                                        </FieldBody>
+                                    </Field>
+                                </Validation>
+
+                                <Validation Validator="ValidationRule.IsChecked">
+                                    <Field Margin="Margin.Is3.OnY">
+                                        <Check TValue="bool" @bind-Value="@submission.Confirmation">
+                                            <ChildContent>
+                                                I confirm I have rights to post this job and it is not spam.
+                                            </ChildContent>
+                                            <Feedback>
+                                                <ValidationError>You must confirm before submitting.</ValidationError>
+                                            </Feedback>
+                                        </Check>
+                                    </Field>
+                                </Validation>
+
+                                <Validation Validator="@CaptchaInput.ValidateRobot">
+                                    <Field>
+                                        <CaptchaInput @bind-Value="@notARobot">
+                                            <Feedback>
+                                                <ValidationError />
+                                            </Feedback>
+                                        </CaptchaInput>
+                                    </Field>
+                                </Validation>
+
+                                @if ( submissionError is not null )
+                                {
+                                    <Alert Color="Color.Danger" Margin="Margin.Is3.FromTop">
+                                        @submissionError
+                                    </Alert>
+                                }
+
+                                <Div Border="Border.Is1.OnTop" Padding="Padding.Is4.FromTop" Margin="Margin.Is4.FromTop" TextAlignment="TextAlignment.End">
+                                    <Button Color="Color.Primary" Size="Size.Large" Clicked="@SubmitAsync" Loading="@isSubmitting" Disabled="@isSubmitting">
+                                        Submit for review
+                                    </Button>
+                                </Div>
+                            </Validations>
+                        </Form>
+                    </CardBody>
+                </Card>
+            }
+        </Column>
+    </Row>
+</Container>

--- a/Documentation/Blazorise.Docs/Pages/Home/JobsSubmitPage.razor.cs
+++ b/Documentation/Blazorise.Docs/Pages/Home/JobsSubmitPage.razor.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Mail;
+using System.Threading.Tasks;
+using Blazorise.Docs.Models;
+using Blazorise.Docs.Services;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Logging;
+
+namespace Blazorise.Docs.Pages.Home;
+
+public partial class JobsSubmitPage
+{
+    private static readonly IReadOnlyList<string> EmploymentTypes = new[]
+    {
+        "Full-time",
+        "Part-time",
+        "Contract",
+        "Internship",
+        "Temporary",
+        "Other"
+    };
+
+    private static readonly IReadOnlyList<string> SeniorityOptions = new[]
+    {
+        "Intern",
+        "Junior",
+        "Mid",
+        "Senior",
+        "Lead",
+        "Principal",
+        "Other"
+    };
+
+    private Validations validationsRef;
+    private JobSubmission submission = CreateSubmission();
+    private JobSubmissionResult submissionResult;
+    private string submissionError;
+    private bool notARobot;
+    private bool isSubmitting;
+
+    [Inject] public IJobSubmissionService JobSubmissionService { get; set; }
+    [Inject] public ILogger<JobsSubmitPage> Logger { get; set; }
+
+    private async Task SubmitAsync()
+    {
+        if ( isSubmitting || !await validationsRef.ValidateAll() )
+            return;
+
+        isSubmitting = true;
+        submissionError = null;
+
+        try
+        {
+            submissionResult = await JobSubmissionService.SubmitAsync( submission );
+        }
+        catch ( Exception exc )
+        {
+            Logger.LogError( exc, "Error submitting a job to GitHub." );
+            submissionError = "We could not submit this job right now. Please try again later.";
+        }
+        finally
+        {
+            isSubmitting = false;
+        }
+    }
+
+    private void SubmitAnother()
+    {
+        submission = CreateSubmission();
+        submissionResult = null;
+        submissionError = null;
+        notARobot = false;
+    }
+
+    private static JobSubmission CreateSubmission()
+    {
+        return new JobSubmission
+        {
+            ExpiryDate = DateTime.UtcNow.Date.AddDays( 30 )
+        };
+    }
+
+    private static void ValidateApplyUrl( ValidatorEventArgs eventArgs )
+    {
+        string value = eventArgs.Value?.ToString();
+        bool valid = Uri.TryCreate( value, UriKind.Absolute, out Uri uri )
+                     && ( string.Equals( uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase )
+                          || string.Equals( uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase ) );
+
+        eventArgs.Status = valid ? ValidationStatus.Success : ValidationStatus.Error;
+        eventArgs.ErrorText = valid ? null : "Enter a valid HTTP or HTTPS application URL.";
+    }
+
+    private static void ValidateOptionalEmail( ValidatorEventArgs eventArgs )
+    {
+        string value = eventArgs.Value?.ToString();
+        bool valid = string.IsNullOrWhiteSpace( value ) || MailAddress.TryCreate( value, out _ );
+
+        eventArgs.Status = valid ? ValidationStatus.Success : ValidationStatus.Error;
+        eventArgs.ErrorText = valid ? null : "Enter a valid email address.";
+    }
+
+    private static void ValidateExpiryDate( ValidatorEventArgs eventArgs )
+    {
+        bool valid = eventArgs.Value is DateTime expiryDate && expiryDate.Date >= DateTime.UtcNow.Date;
+
+        eventArgs.Status = valid ? ValidationStatus.Success : ValidationStatus.Error;
+        eventArgs.ErrorText = valid ? null : "Choose an expiry date that is today or later.";
+    }
+}

--- a/Documentation/Blazorise.Docs/Services/JobSubmissionService.cs
+++ b/Documentation/Blazorise.Docs/Services/JobSubmissionService.cs
@@ -1,0 +1,28 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Blazorise.Docs.Models;
+
+namespace Blazorise.Docs.Services;
+
+/// <summary>
+/// Writes job submissions to the moderation queue.
+/// </summary>
+public interface IJobSubmissionService
+{
+    /// <summary>
+    /// Submits a job for moderation.
+    /// </summary>
+    /// <param name="submission">The job to submit.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>Information about the created moderation item.</returns>
+    Task<JobSubmissionResult> SubmitAsync( JobSubmission submission, CancellationToken cancellationToken = default );
+}
+
+/// <summary>
+/// Identifies a job that was submitted for moderation.
+/// </summary>
+public sealed class JobSubmissionResult
+{
+    public long IssueNumber { get; set; }
+    public string IssueUrl { get; set; } = string.Empty;
+}

--- a/Documentation/Blazorise.Docs/Services/JobsService.cs
+++ b/Documentation/Blazorise.Docs/Services/JobsService.cs
@@ -144,8 +144,6 @@ public sealed class JobsService : IJobsService
         {
             HttpRequestMessage request = new HttpRequestMessage( HttpMethod.Get, options.FeedUrl );
             request.Headers.Accept.Add( new MediaTypeWithQualityHeaderValue( "application/json" ) );
-            if ( !string.IsNullOrWhiteSpace( options.GitHubToken ) )
-                request.Headers.Authorization = new AuthenticationHeaderValue( "Bearer", options.GitHubToken );
             if ( !string.IsNullOrWhiteSpace( cachedEtag ) )
                 request.Headers.IfNoneMatch.Add( EntityTagHeaderValue.Parse( cachedEtag ) );
             return request;


### PR DESCRIPTION
Adds a dedicated `/jobs/submit` page containing all fields from the existing GitHub issue template. The form includes validation, Markdown support, CAPTCHA protection, submission progress, error handling, and a confirmation state.

Submissions are sent server-side to the Blazorise.Jobs repository as issues labeled `type:job` and `status:pending`, preserving the existing moderation and publishing workflow. The GitHub token remains server-side and is no longer included in public jobs-feed requests.

Configuration now uses `GitHubOwner`, `GitHubRepository`, and `GitHubToken` under the `Jobs` section. The token requires Issues write permission for the Blazorise.Jobs repository.