### PR TITLE
Validation: clear validation state for disabled fields

### DIFF
--- a/Source/Blazorise/Components/Validation/Validation.razor.cs
+++ b/Source/Blazorise/Components/Validation/Validation.razor.cs
@@ -123,8 +123,7 @@ public partial class Validation : ComponentBase, IValidation, IDisposable
             ParentValidations.NotifyValidationRemoved( this );
         }
 
-        cancellationTokenSource?.Dispose();
-        cancellationTokenSource = null;
+        CancelPendingValidation();
     }
 
     /// <summary>
@@ -240,6 +239,13 @@ public partial class Validation : ComponentBase, IValidation, IDisposable
     /// </remarks>
     public Task NotifyInputChanged<T>( T newExpressionValue, bool overrideNewValue = false )
     {
+        if ( inputComponent.Disabled )
+        {
+            Clear();
+
+            return Task.CompletedTask;
+        }
+
         var newValidationValue = overrideNewValue
             ? newExpressionValue
             : inputComponent.ValidationValue;
@@ -282,12 +288,16 @@ public partial class Validation : ComponentBase, IValidation, IDisposable
     /// <returns>Returns the validation result.</returns>
     public ValidationStatus Validate( object newValidationValue )
     {
-        if ( !inputComponent.Disabled )
+        if ( inputComponent.Disabled )
         {
-            var validationHandler = GetValidationHandler();
+            Clear();
 
-            validationHandler?.Validate( this, newValidationValue );
+            return Status;
         }
+
+        var validationHandler = GetValidationHandler();
+
+        validationHandler?.Validate( this, newValidationValue );
 
         return Status;
     }
@@ -328,32 +338,45 @@ public partial class Validation : ComponentBase, IValidation, IDisposable
     /// <returns>Returns the validation result.</returns>
     private async Task<ValidationStatus> TriggerValidation( object newValidationValue )
     {
-        if ( !inputComponent.Disabled )
+        CancelPendingValidation();
+
+        if ( inputComponent.Disabled )
         {
-            cancellationTokenSource?.Cancel();
-            cancellationTokenSource?.Dispose();
+            Clear();
 
-            // Create a CTS for this request.
-            cancellationTokenSource = new();
-
-            var cancellationToken = cancellationTokenSource.Token;
-
-            try
-            {
-                var validationHandler = GetValidationHandler();
-
-                if ( validationHandler is not null )
-                {
-                    cancellationToken.ThrowIfCancellationRequested();
-                    await validationHandler.ValidateAsync( this, newValidationValue, cancellationToken );
-                }
-            }
-            catch ( OperationCanceledException )
-            {
-            }
+            return Status;
         }
 
-        return await Task.FromResult( Status );
+        // Create a CTS for this request.
+        cancellationTokenSource = new();
+
+        var cancellationToken = cancellationTokenSource.Token;
+
+        try
+        {
+            var validationHandler = GetValidationHandler();
+
+            if ( validationHandler is not null )
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await validationHandler.ValidateAsync( this, newValidationValue, cancellationToken );
+            }
+        }
+        catch ( OperationCanceledException )
+        {
+        }
+
+        return Status;
+    }
+
+    /// <summary>
+    /// Cancels and releases any validation that is currently running.
+    /// </summary>
+    private void CancelPendingValidation()
+    {
+        cancellationTokenSource?.Cancel();
+        cancellationTokenSource?.Dispose();
+        cancellationTokenSource = null;
     }
 
     /// <summary>
@@ -407,6 +430,8 @@ public partial class Validation : ComponentBase, IValidation, IDisposable
     /// </summary>
     public void Clear()
     {
+        CancelPendingValidation();
+
         NotifyValidationStatusChanged( ValidationStatus.None );
     }
 

--- a/Tests/Blazorise.Tests/Components/TextInputComponentTest.cs
+++ b/Tests/Blazorise.Tests/Components/TextInputComponentTest.cs
@@ -163,6 +163,82 @@ public class TextInputComponentTest : BunitContext
         Assert.Equal( string.Empty, validationError.TextContent.Trim() );
     }
 
+    [Theory]
+    [InlineData( ValidationMode.Auto )]
+    [InlineData( ValidationMode.Manual )]
+    public async Task ValidationState_IsCleared_WhenInputBecomesDisabled( ValidationMode mode )
+    {
+        var disabled = false;
+        var validationCount = 0;
+
+        Action<ValidatorEventArgs> validator = eventArgs =>
+        {
+            validationCount++;
+            ValidationRule.IsNotEmpty( eventArgs );
+        };
+
+        RenderFragment childContent = builder =>
+        {
+            builder.OpenComponent<Validation>( 0 );
+            builder.AddAttribute( 1, nameof( Validation.Validator ), validator );
+            builder.AddAttribute( 2, nameof( Validation.ChildContent ), (RenderFragment)( childBuilder =>
+            {
+                childBuilder.OpenComponent<TextInput>( 0 );
+                childBuilder.AddAttribute( 1, nameof( TextInput.Value ), string.Empty );
+                childBuilder.AddAttribute( 2, nameof( TextInput.Disabled ), disabled );
+                childBuilder.CloseComponent();
+            } ) );
+            builder.CloseComponent();
+        };
+
+        var comp = Render<Validations>( parameters => parameters
+            .Add( p => p.Mode, mode )
+            .Add( p => p.ChildContent, childContent ) );
+
+        Validation validation = comp.FindComponent<Validation>().Instance;
+
+        if ( mode == ValidationMode.Manual )
+            Assert.False( await comp.Instance.ValidateAll() );
+
+        Assert.Equal( ValidationStatus.Error, validation.Status );
+        Assert.Equal( 1, validationCount );
+
+        disabled = true;
+        comp.Render( parameters => parameters
+            .Add( p => p.Mode, mode )
+            .Add( p => p.ChildContent, childContent ) );
+
+        comp.WaitForAssertion( () =>
+        {
+            Assert.Equal( ValidationStatus.None, validation.Status );
+            Assert.DoesNotContain( "is-invalid", comp.Find( "input" ).ClassList );
+            Assert.Equal( 1, validationCount );
+        } );
+
+        Assert.True( await comp.Instance.ValidateAll() );
+        Assert.Equal( ValidationStatus.None, validation.Status );
+        Assert.Equal( 1, validationCount );
+
+        disabled = false;
+        comp.Render( parameters => parameters
+            .Add( p => p.Mode, mode )
+            .Add( p => p.ChildContent, childContent ) );
+
+        if ( mode == ValidationMode.Manual )
+        {
+            Assert.Equal( ValidationStatus.None, validation.Status );
+            Assert.Equal( 1, validationCount );
+            Assert.False( await comp.Instance.ValidateAll() );
+        }
+
+        comp.WaitForAssertion( () =>
+        {
+            Assert.Equal( ValidationStatus.Error, validation.Status );
+            Assert.Contains( "is-invalid", comp.Find( "input" ).ClassList );
+            Assert.Equal( 2, validationCount );
+        } );
+    }
+
     private IRenderedComponent<Validations> RenderRequiredTextInput( RequiredTextModel model )
     {
         return Render<Validations>( parameters => parameters


### PR DESCRIPTION
Closes #6701

Disabled fields now clear their existing validation status and messages instead of retaining stale error or success states. Pending asynchronous validation is canceled when the state is cleared, preventing outdated results from being reapplied.