### PR TITLE
Autocomplete: select unique checkbox matches on Enter

### DIFF
--- a/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
+++ b/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
@@ -1327,7 +1327,9 @@ public partial class Autocomplete<TItem, TValue>
     }
 
     private bool ShouldSelectOnConfirmKey
-        => SelectionMode != AutocompleteSelectionMode.Checkbox || activeItemNavigatedByKeyboard;
+        => SelectionMode != AutocompleteSelectionMode.Checkbox
+            || activeItemNavigatedByKeyboard
+            || ( FreeTyping && ActiveItemIndex >= 0 && FilteredData.Count == 1 );
 
     private bool IsSuggestedActiveItem( TItem item )
     {

--- a/Tests/Blazorise.Tests/Components/AutocompleteCheckboxComponentTest.cs
+++ b/Tests/Blazorise.Tests/Components/AutocompleteCheckboxComponentTest.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Blazorise.Components;
 using Bunit;
 using Xunit;
 
@@ -103,6 +104,32 @@ public class AutocompleteCheckboxComponentTest : AutocompleteMultipleBaseCompone
             Assert.Equal( new[] { "Portugal", "Croatia" }, comp.Instance.SelectedTexts );
         }, TestExtensions.WaitTime );
         Assert.Equal( 0, selectedValuesChanged );
+    }
+
+    [Fact]
+    public async Task Enter_WithFreeTyping_ShouldSelect_AutoPreselectedSuggestion()
+    {
+        var comp = Render<Autocomplete<string, string>>( parameters => parameters
+            .Add( x => x.Data, new List<string> { "New York", "London", "Tokyo", "Paris", "Berlin" } )
+            .Add( x => x.TextField, item => item )
+            .Add( x => x.ValueField, item => item )
+            .Add( x => x.SelectionMode, AutocompleteSelectionMode.Checkbox )
+            .Add( x => x.Filter, AutocompleteFilter.Contains )
+            .Add( x => x.FreeTyping, true )
+            .Add( x => x.MinSearchLength, 0 )
+            .Add( x => x.Debounce, false ) );
+
+        var autoComplete = comp.Find( ".b-is-autocomplete input" );
+
+        await autoComplete.FocusAsync( new() );
+        await autoComplete.InputAsync( "ris" );
+        await autoComplete.KeyDownAsync( Key.Enter );
+
+        comp.WaitForAssertion( () =>
+        {
+            Assert.Equal( new[] { "Paris" }, comp.Instance.SelectedValues );
+            Assert.Equal( new[] { "Paris" }, comp.Instance.SelectedTexts );
+        }, TestExtensions.WaitTime );
     }
 
     [Fact]


### PR DESCRIPTION
This fixes Autocomplete in Checkbox mode when FreeTyping is enabled. Pressing Enter now selects an existing auto-preselected item when the entered text produces a single matching suggestion.

Ambiguous searches continue to require explicit keyboard navigation before Enter selects an item, preserving the existing Checkbox behavior. Free-typed values with no matching suggestion continue to work as before.

Unit tests cover both the existing ambiguous-search behavior and the new unique-match scenario using a Contains filter.