### PR TITLE
ContextMenu: prevent initial position flash

### DIFF
--- a/Source/Blazorise/Components/ContextMenu/ContextMenu.razor.cs
+++ b/Source/Blazorise/Components/ContextMenu/ContextMenu.razor.cs
@@ -437,6 +437,8 @@ public partial class ContextMenu : BaseComponent, IAsyncDisposable
 
     internal int EffectiveSubmenuHoverCloseDelay => SubmenuHoverCloseDelay;
 
+    internal bool IsFloatingPositionInitialized => floatingPositionInitialized;
+
     private string RootSelector => $"[data-context-menu-id='{ElementId}']";
 
     private string ResolvedTargetSelector

--- a/Source/Blazorise/Components/ContextMenu/ContextMenuBody.razor.cs
+++ b/Source/Blazorise/Components/ContextMenu/ContextMenuBody.razor.cs
@@ -46,6 +46,14 @@ public partial class ContextMenuBody : BaseComponent
         base.BuildClasses( builder );
     }
 
+    /// <inheritdoc/>
+    protected override void BuildStyles( StyleBuilder builder )
+    {
+        base.BuildStyles( builder );
+
+        builder.Append( "visibility:hidden", ParentContextMenu?.IsFloatingPositionInitialized != true );
+    }
+
     #endregion
 
     #region Properties
@@ -68,6 +76,9 @@ public partial class ContextMenuBody : BaseComponent
                 return;
 
             parentContextMenuState = value;
+
+            if ( value?.Visible != true )
+                DirtyStyles();
         }
     }
 


### PR DESCRIPTION
Hides the context menu until Floating UI completes its initial positioning, preventing it from briefly appearing at zero coordinates on first open across all providers.