### PR TITLE
ModalProvider: expose the topmost visible modal

### DIFF
--- a/Documentation/Blazorise.Docs/Pages/Docs/Services/ModalProvider/ModalProviderApiPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Services/ModalProvider/ModalProviderApiPage.razor
@@ -16,6 +16,16 @@
 
 <ComponentApiDocs ComponentTypes="[typeof(ModalProvider)]" />
 
+<DocsPageSubsectionTitle ElementId="api-modalprovider-properties">
+    ModalProvider properties
+</DocsPageSubsectionTitle>
+
+<DocsAttributes Name="Property" Title="Properties" ShowDefaults="false">
+    <DocsAttributesItem Name="TopMost" Type="ModalInstance">
+        Gets the most recently activated visible modal instance, or <Code>null</Code> when no modal is visible.
+    </DocsAttributesItem>
+</DocsAttributes>
+
 <DocsPageSubsectionTitle ElementId="api-imodalservice">
     IModalService
 </DocsPageSubsectionTitle>

--- a/Source/Blazorise/Components/ModalProvider/ModalProvider.razor.cs
+++ b/Source/Blazorise/Components/ModalProvider/ModalProvider.razor.cs
@@ -57,6 +57,8 @@ public partial class ModalProvider : BaseComponent
         if ( existingModalInstance is not null )
         {
             existingModalInstance.Visible = true;
+            modalInstances.Remove( existingModalInstance );
+            modalInstances.Add( existingModalInstance );
         }
         else if ( modalInstances.Contains( modalInstance ) )
         {
@@ -77,7 +79,7 @@ public partial class ModalProvider : BaseComponent
     /// </summary>
     /// <returns></returns>
     internal Task Hide()
-        => modalInstances?.LastOrDefault()?.ModalRef?.Hide() ?? Task.CompletedTask;
+        => TopMost?.ModalRef?.Hide() ?? Task.CompletedTask;
 
     /// <summary>
     /// Closes the modal.
@@ -140,6 +142,12 @@ public partial class ModalProvider : BaseComponent
     #endregion
 
     #region Properties
+
+    /// <summary>
+    /// Gets the most recently activated visible modal instance, or null when no modal is visible.
+    /// </summary>
+    public ModalInstance TopMost
+        => modalInstances?.LastOrDefault( x => x.Visible );
 
     /// <summary>
     /// The ModalService

--- a/Tests/Blazorise.Tests/Components/ModalProviderComponentTest.cs
+++ b/Tests/Blazorise.Tests/Components/ModalProviderComponentTest.cs
@@ -1,0 +1,85 @@
+using System.Threading.Tasks;
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Blazorise.Tests.Components;
+
+public class ModalProviderComponentTest : BunitContext
+{
+    public ModalProviderComponentTest()
+    {
+        Services.AddBlazoriseTests().AddBootstrapProviders().AddEmptyIconProvider();
+        Services.AddScoped<IModalService, ModalService>();
+        JSInterop
+            .AddBlazoriseButton()
+            .AddBlazoriseModal()
+            .AddBlazoriseClosable();
+    }
+
+    [Fact]
+    public void TopMost_ShouldBeNull_WhenNoModalIsVisible()
+    {
+        var component = Render<ModalProvider>();
+
+        Assert.Null( component.Instance.TopMost );
+    }
+
+    [Fact]
+    public async Task TopMost_ShouldReturnMostRecentlyActivatedVisibleModal()
+    {
+        var component = Render<ModalProvider>();
+        var modalService = Services.GetRequiredService<IModalService>();
+
+        var firstModal = await ShowModal( component, modalService, "First" );
+        var secondModal = await ShowModal( component, modalService, "Second" );
+
+        Assert.Same( secondModal, component.Instance.TopMost );
+
+        await component.InvokeAsync( () => modalService.Hide( secondModal ) );
+
+        Assert.Same( firstModal, component.Instance.TopMost );
+    }
+
+    [Fact]
+    public async Task TopMost_ShouldSkipClosedStatefulModal()
+    {
+        var component = Render<ModalProvider>();
+        var modalService = Services.GetRequiredService<IModalService>();
+
+        var firstModal = await ShowModal( component, modalService, "First" );
+        var secondModal = await ShowModal( component, modalService, "Second", new() { Stateful = true } );
+
+        await component.InvokeAsync( () => modalService.Hide( secondModal ) );
+
+        Assert.False( secondModal.Visible );
+        Assert.Same( firstModal, component.Instance.TopMost );
+
+        await component.InvokeAsync( () => modalService.Hide() );
+
+        Assert.Null( component.Instance.TopMost );
+    }
+
+    [Fact]
+    public async Task Show_ShouldPromoteReopenedStatefulModal()
+    {
+        var component = Render<ModalProvider>();
+        var modalService = Services.GetRequiredService<IModalService>();
+
+        var firstModal = await ShowModal( component, modalService, "First", new() { Stateful = true } );
+        var secondModal = await ShowModal( component, modalService, "Second" );
+
+        await component.InvokeAsync( () => modalService.Hide( firstModal ) );
+        await component.InvokeAsync( () => modalService.Show( firstModal ) );
+
+        Assert.True( firstModal.Visible );
+        Assert.Same( firstModal, component.Instance.TopMost );
+        Assert.NotSame( secondModal, component.Instance.TopMost );
+    }
+
+    private static Task<ModalInstance> ShowModal( IRenderedComponent<ModalProvider> component, IModalService modalService, string title, ModalInstanceOptions options = null )
+    {
+        return component.InvokeAsync( () => modalService.Show( title, (RenderFragment)( builder => builder.AddContent( 0, title ) ), options ) );
+    }
+}


### PR DESCRIPTION
Closes #4704

This adds a public `TopMost` property to `ModalProvider`, allowing consumers to determine whether a modal is currently displayed and retrieve the modal that should receive user interaction.

TopMost returns the most recently activated visible `ModalInstance`, or null when no modal is visible. Closed stateful modal instances are ignored even though they remain retained by the provider. Reopening a stateful modal promotes it to the top of the modal stack.

The parameterless `Hide()` method now uses the same TopMost resolution, preventing a closed stateful instance from blocking an earlier visible modal from being closed.