### PR TITLE
Demos: reduce WebAssembly startup download size

### DIFF
--- a/Build/Blazorise.Client.props
+++ b/Build/Blazorise.Client.props
@@ -18,6 +18,7 @@
 	<ItemGroup>
 		<BlazorWebAssemblyLazyLoad Include="Blazorise.Demo.Charts.wasm" />
 		<BlazorWebAssemblyLazyLoad Include="Blazorise.Charts.wasm" />
+		<BlazorWebAssemblyLazyLoad Include="Blazorise.Charts.Svg.wasm" />
 		<BlazorWebAssemblyLazyLoad Include="Blazorise.Charts.Annotation.wasm" />
 		<BlazorWebAssemblyLazyLoad Include="Blazorise.Charts.DataLabels.wasm" />
 		<BlazorWebAssemblyLazyLoad Include="Blazorise.Charts.Streaming.wasm" />
@@ -25,6 +26,7 @@
 		<BlazorWebAssemblyLazyLoad Include="Lambda2Js.wasm" />
 		<BlazorWebAssemblyLazyLoad Include="Blazorise.Demo.DataGrid.wasm" />
 		<BlazorWebAssemblyLazyLoad Include="Blazorise.DataGrid.wasm" />
+		<BlazorWebAssemblyLazyLoad Include="Microsoft.CSharp.wasm" />
 		<BlazorWebAssemblyLazyLoad Include="Blazorise.Demo.Reporting.wasm" />
 		<BlazorWebAssemblyLazyLoad Include="Blazorise.Demo.Components.wasm" />
 		<BlazorWebAssemblyLazyLoad Include="Blazorise.Demo.Extensions.wasm" />
@@ -44,6 +46,7 @@
 		<BlazorWebAssemblyLazyLoad Include="Blazorise.Splitter.wasm" />
 		<BlazorWebAssemblyLazyLoad Include="Blazorise.TreeView.wasm" />
 		<BlazorWebAssemblyLazyLoad Include="Blazorise.Video.wasm" />
+		<BlazorWebAssemblyLazyLoad Include="TodoApp.wasm" />
 	</ItemGroup>
 
 </Project>

--- a/Build/Blazorise.Demo.props
+++ b/Build/Blazorise.Demo.props
@@ -13,15 +13,4 @@
 		<PackageReference Include="Microsoft.AspNetCore.Components.Web" />
 	</ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Markdig" />
-		<PackageReference Include="Microsoft.Extensions.Caching.Memory" />
-		<PackageReference Include="Microsoft.Extensions.Http" />
-		<PackageReference Include="FluentValidation" />
-		<PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
-		<PackageReference Include="Flurl.Http" />
-		<PackageReference Include="Blazored.LocalStorage" />
-		<PackageReference Include="Bogus" />
-	</ItemGroup>
-	
 </Project>

--- a/Demos/Blazorise.Demo.AntDesign/wwwroot/index.html
+++ b/Demos/Blazorise.Demo.AntDesign/wwwroot/index.html
@@ -23,7 +23,6 @@
     <link href="_content/Blazorise.SpinKit/blazorise.spinkit.css?v=2.3.0.0" rel="stylesheet" />
     <link href="_content/Blazorise.LoadingIndicator/blazorise.loadingindicator.css?v=2.3.0.0" rel="stylesheet" />
     <link href="_content/Blazorise.Demo/demo.css?v=2.3.0.0" rel="stylesheet" />
-    <script src="https://www.google.com/recaptcha/api.js" async defer></script>
 </head>
 <body>
     <div id="app">

--- a/Demos/Blazorise.Demo.Bootstrap/wwwroot/index.html
+++ b/Demos/Blazorise.Demo.Bootstrap/wwwroot/index.html
@@ -24,7 +24,6 @@
     <link href="_content/Blazorise.LoadingIndicator/blazorise.loadingindicator.css?v=2.3.0.0" rel="stylesheet" />
     <link href="_content/Blazorise.Demo/demo.css?v=2.3.0.0" rel="stylesheet" />
 
-    <script src="https://www.google.com/recaptcha/api.js" async defer></script>
 </head>
 <body>
     <div id="app">

--- a/Demos/Blazorise.Demo.Bootstrap5/Program.cs
+++ b/Demos/Blazorise.Demo.Bootstrap5/Program.cs
@@ -1,6 +1,4 @@
 #region Using directives
-using System;
-using System.Net.Http;
 using System.Threading.Tasks;
 using Blazorise.Bootstrap5;
 using Blazorise.Icons.Bootstrap;
@@ -15,15 +13,8 @@ public class Program
     {
         var builder = WebAssemblyHostBuilder.CreateDefault( args );
 
-        using HttpClient httpClient = new()
-        {
-            BaseAddress = new Uri( builder.HostEnvironment.BaseAddress )
-        };
-
-        byte[] demoReportFontData = await httpClient.GetByteArrayAsync( "_content/Blazorise.Demo/fonts/OpenSans-Regular.ttf" );
-
         builder.Services
-            .SetupDemoServices( builder.Configuration["Licensing:ProductToken"], builder.Configuration["ReCaptchaSiteKey"], demoReportFontData )
+            .SetupDemoServices( builder.Configuration["Licensing:ProductToken"], builder.Configuration["ReCaptchaSiteKey"] )
             .AddBootstrap5Providers()
             .AddBootstrapIcons();
 

--- a/Demos/Blazorise.Demo.Bootstrap5/wwwroot/index.html
+++ b/Demos/Blazorise.Demo.Bootstrap5/wwwroot/index.html
@@ -25,7 +25,6 @@
     <link href="_content/Blazorise.LoadingIndicator/blazorise.loadingindicator.css?v=2.3.0.0" rel="stylesheet" />
     <link href="_content/Blazorise.Demo/demo.css?v=2.3.0.0" rel="stylesheet" />
 
-    <script src="https://www.google.com/recaptcha/api.js" async defer></script>
 </head>
 <body>
     <div id="app">

--- a/Demos/Blazorise.Demo.Bulma/wwwroot/index.html
+++ b/Demos/Blazorise.Demo.Bulma/wwwroot/index.html
@@ -24,7 +24,6 @@
     <link href="_content/Blazorise.LoadingIndicator/blazorise.loadingindicator.css?v=2.3.0.0" rel="stylesheet" />
     <link href="_content/Blazorise.Demo/demo.css?v=2.3.0.0" rel="stylesheet" />
 
-    <script src="https://www.google.com/recaptcha/api.js" async defer></script>
 </head>
 <body>
     <app id="app">

--- a/Demos/Blazorise.Demo.FluentUI2/wwwroot/index.html
+++ b/Demos/Blazorise.Demo.FluentUI2/wwwroot/index.html
@@ -24,7 +24,6 @@
     <link href="_content/Blazorise.LoadingIndicator/blazorise.loadingindicator.css?v=2.3.0.0" rel="stylesheet" />
     <link href="_content/Blazorise.Demo/demo.css?v=2.3.0.0" rel="stylesheet" />
 
-    <script src="https://www.google.com/recaptcha/api.js" async defer></script>
 </head>
 <body>
     <app id="app">

--- a/Demos/Blazorise.Demo.Material/wwwroot/index.html
+++ b/Demos/Blazorise.Demo.Material/wwwroot/index.html
@@ -26,7 +26,6 @@
     <link href="_content/Blazorise.LoadingIndicator/blazorise.loadingindicator.css?v=2.3.0.0" rel="stylesheet" />
     <link href="_content/Blazorise.Demo/demo.css?v=2.3.0.0" rel="stylesheet" />
 
-    <script src="https://www.google.com/recaptcha/api.js" async defer></script>
 </head>
 <body>
     <div id="app">

--- a/Demos/Blazorise.Demo.Tailwind/wwwroot/index.html
+++ b/Demos/Blazorise.Demo.Tailwind/wwwroot/index.html
@@ -26,7 +26,6 @@
     <link href="_content/Blazorise.Demo/demo.css?v=2.3.0.0" rel="stylesheet" />
 
     <link href="css/site.css" rel="stylesheet" />
-    <script src="https://www.google.com/recaptcha/api.js" async defer></script>
 </head>
 <body>
     <div id="app">

--- a/Demos/Shared/Blazorise.Demo.DataGrid/Pages/StateManagementPage.razor
+++ b/Demos/Shared/Blazorise.Demo.DataGrid/Pages/StateManagementPage.razor
@@ -67,10 +67,11 @@
 </Row>
 
 @code {
-    [Inject] Blazored.LocalStorage.ILocalStorageService LocalStorage { get; set; }
+    [Inject] IJSRuntime JSRuntime { get; set; }
     [Inject] EmployeeData EmployeeData { get; set; }
 
     private const string STORAGE_KEY = "__DATAGRID_STATE__";
+    private static readonly System.Text.Json.JsonSerializerOptions serializerOptions = new( System.Text.Json.JsonSerializerDefaults.Web );
     private DataGrid<Employee> dataGridRef;
     private IEnumerable<Employee> inMemoryData;
 
@@ -91,7 +92,7 @@
 
     private async Task ResetState()
     {
-        await LocalStorage.RemoveItemAsync( STORAGE_KEY );
+        await JSRuntime.InvokeVoidAsync( "localStorage.removeItem", STORAGE_KEY );
         var state = new DataGridState<Employee>()
             {
                 Page = 1,
@@ -102,7 +103,10 @@
 
     private async Task LoadState()
     {
-        var stateFromLocalStorage = await LocalStorage.GetItemAsync<DataGridState<Employee>>( STORAGE_KEY );
+        string stateJson = await JSRuntime.InvokeAsync<string>( "localStorage.getItem", STORAGE_KEY );
+        DataGridState<Employee> stateFromLocalStorage = string.IsNullOrWhiteSpace( stateJson )
+            ? null
+            : System.Text.Json.JsonSerializer.Deserialize<DataGridState<Employee>>( stateJson, serializerOptions );
 
         if ( stateFromLocalStorage is not null )
         {
@@ -123,6 +127,7 @@
     private async Task SaveState()
     {
         var state = await dataGridRef.GetState();
-        await LocalStorage.SetItemAsync( STORAGE_KEY, state );
+        string stateJson = System.Text.Json.JsonSerializer.Serialize( state, serializerOptions );
+        await JSRuntime.InvokeVoidAsync( "localStorage.setItem", STORAGE_KEY, stateJson );
     }
 }

--- a/Demos/Shared/Blazorise.Demo.DataGrid/_Imports.razor
+++ b/Demos/Shared/Blazorise.Demo.DataGrid/_Imports.razor
@@ -10,4 +10,3 @@
 @using Blazorise.DataGrid.Utils
 @using Blazorise.Shared.Data
 @using Blazorise.Shared.Models
-@using Blazored.LocalStorage

--- a/Demos/Shared/Blazorise.Demo.Extensions/Blazorise.Demo.Extensions.csproj
+++ b/Demos/Shared/Blazorise.Demo.Extensions/Blazorise.Demo.Extensions.csproj
@@ -9,8 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
-
     <ProjectReference Include="..\..\..\Shared\Blazorise.Shared\Blazorise.Shared.csproj" />
     <ProjectReference Include="..\..\..\Source\Blazorise\Blazorise.csproj" />
     <ProjectReference Include="..\..\..\Source\Extensions\Blazorise.Animate\Blazorise.Animate.csproj" />

--- a/Demos/Shared/Blazorise.Demo.Extensions/Pages/CodeEditorPage.razor
+++ b/Demos/Shared/Blazorise.Demo.Extensions/Pages/CodeEditorPage.razor
@@ -1,7 +1,5 @@
 @page "/tests/codeeditor"
 @using System.Threading
-@using Microsoft.CodeAnalysis
-@using Microsoft.CodeAnalysis.CSharp
 
 <Row>
     <Column>
@@ -176,8 +174,15 @@ public class Greeting
 
     private static Task<string> FormatCSharpDocumentAsync( string value )
     {
-        SyntaxNode root = CSharpSyntaxTree.ParseText( value ?? string.Empty ).GetRoot();
-        string formattedValue = root.NormalizeWhitespace( "    ", "\r\n" ).ToFullString();
+        string normalizedValue = ( value ?? string.Empty )
+            .Replace( "\r\n", "\n" )
+            .Replace( '\r', '\n' );
+        string formattedValue = string.Join(
+            "\r\n",
+            normalizedValue
+                .Split( '\n' )
+                .Select( line => line.Replace( "\t", "    " ).TrimEnd() ) )
+            .Trim();
 
         return Task.FromResult( formattedValue );
     }

--- a/Demos/Shared/Blazorise.Demo.Extensions/Pages/MarkdownPage.razor
+++ b/Demos/Shared/Blazorise.Demo.Extensions/Pages/MarkdownPage.razor
@@ -25,9 +25,6 @@
                                   ImageUploadProgressed="@OnImageUploadProgressed"
                                   ImageUploadEnded="@OnImageUploadEnded" />
                     </Column>
-                    <Column>
-                        @((MarkupString)markdownHtml)
-                    </Column>
                 </Row>
             </CardBody>
         </Card>
@@ -62,20 +59,9 @@
     string markdownValue = "# EasyMDE \n Go ahead, play around with the editor! Be sure to check out **bold**, *italic*, [links](https://google.com) and all the other features. You can type the Markdown syntax, use the toolbar, or use shortcuts like `ctrl-b` or `cmd-b`.";
     string markdownValidationValue;
 
-    string markdownHtml;
-
-    protected override void OnInitialized()
-    {
-        markdownHtml = Markdig.Markdown.ToHtml( markdownValue ?? string.Empty );
-
-        base.OnInitialized();
-    }
-
     Task OnMarkdownValueChanged( string value )
     {
         markdownValue = value;
-
-        markdownHtml = Markdig.Markdown.ToHtml( markdownValue ?? string.Empty );
 
         return Task.CompletedTask;
     }

--- a/Demos/Shared/Blazorise.Demo.Extensions/Pages/SchedulerPage.razor
+++ b/Demos/Shared/Blazorise.Demo.Extensions/Pages/SchedulerPage.razor
@@ -1,5 +1,4 @@
 ﻿@page "/tests/scheduler"
-@using Bogus
 <Row>
     <Column>
         <Card Margin="Margin.Is4.OnY">
@@ -50,22 +49,24 @@
 
     private static DateTime start = DateTime.Today.AddHours( 10 );
 
-    private Faker<SchedulerAppointment> appointmentFaker = new Faker<SchedulerAppointment>()
-        .RuleFor( a => a.Title, f => f.Lorem.Sentence( 3 ) )
-        .RuleFor( a => a.Description, f => f.Lorem.Paragraph() );
+    private int generatedAppointmentCount = 1;
 
     private Task OnSlotClicked( SchedulerSlotClickedEventArgs eventArgs )
     {
         var start = eventArgs.Start;
         var end = eventArgs.End;
 
-        var fakeAppointment = appointmentFaker.Generate();
-        fakeAppointment.Start = start;
-        fakeAppointment.End = end;
-        fakeAppointment.Color = "#0d6efd";
-        fakeAppointment.Location = "Main office";
+        SchedulerAppointment appointment = new(
+            $"Appointment {generatedAppointmentCount++}",
+            "Created from a selected scheduler slot.",
+            start,
+            end )
+        {
+            Color = "#0d6efd",
+            Location = "Main office",
+        };
 
-        Appointments.Add( fakeAppointment );
+        Appointments.Add( appointment );
 
         return Task.CompletedTask;
     }

--- a/Demos/Shared/Blazorise.Demo.Extensions/_Imports.razor
+++ b/Demos/Shared/Blazorise.Demo.Extensions/_Imports.razor
@@ -30,4 +30,3 @@
 @using Blazorise.TreeView
 @using Blazorise.Utilities
 @using Blazorise.Video
-@using Bogus

--- a/Demos/Shared/Blazorise.Demo.Reporting/Blazorise.Demo.Reporting.csproj
+++ b/Demos/Shared/Blazorise.Demo.Reporting/Blazorise.Demo.Reporting.csproj
@@ -15,7 +15,6 @@
     <ProjectReference Include="..\..\..\Source\Extensions\Blazorise.Pdf\Blazorise.Pdf.csproj" />
     <ProjectReference Include="..\..\..\Source\Extensions\Blazorise.PdfViewer\Blazorise.PdfViewer.csproj" />
     <ProjectReference Include="..\..\..\Source\Extensions\Blazorise.Reporting\Blazorise.Reporting.csproj" />
-    <ProjectReference Include="..\..\..\Source\Extensions\Blazorise.Reporting.DataSources.Csv\Blazorise.Reporting.DataSources.Csv.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Demos/Shared/Blazorise.Demo.Reporting/Pages/ReportingPage.razor
+++ b/Demos/Shared/Blazorise.Demo.Reporting/Pages/ReportingPage.razor
@@ -137,7 +137,7 @@
 </Row>
 
 @code {
-    [Inject] private Blazored.LocalStorage.ILocalStorageService LocalStorage { get; set; }
+    [Inject] private IJSRuntime JSRuntime { get; set; }
 
     [Inject] private IMessageService MessageService { get; set; }
 
@@ -201,20 +201,28 @@
     {
         string json = ReportJsonSerializer.Serialize( reportDefinition );
 
-        await LocalStorage.SetItemAsync( ReportStorageKey, json );
+        await JSRuntime.InvokeVoidAsync( "localStorage.setItem", ReportStorageKey, json );
         cleanDefinitionJson = json;
         await NotificationService.Success( "The report definition was saved.", "Report saved" );
     }
 
     private async Task<ReportDefinition> LoadReport()
     {
-        string json = await LocalStorage.GetItemAsync<string>( ReportStorageKey );
+        string json = await JSRuntime.InvokeAsync<string>( "localStorage.getItem", ReportStorageKey );
 
         if ( string.IsNullOrWhiteSpace( json ) )
         {
             await NotificationService.Warning( "Save the report before attempting to load it.", "No saved report" );
 
             return null;
+        }
+
+        if ( json.StartsWith( '"' ) )
+        {
+            string legacyJson = System.Text.Json.JsonSerializer.Deserialize<string>( json );
+
+            if ( !string.IsNullOrWhiteSpace( legacyJson ) )
+                json = legacyJson;
         }
 
         if ( HasUnsavedChanges()

--- a/Demos/Shared/Blazorise.Demo.Reporting/Pages/ReportingPage.razor
+++ b/Demos/Shared/Blazorise.Demo.Reporting/Pages/ReportingPage.razor
@@ -62,7 +62,6 @@
                     </ReportToolbar>
                     <ReportDataSources>
                         <ReportObjectDataSource Name="Invoice" Data="@invoice" />
-                        <ReportCsvDataSource Name="CsvInvoiceLines" Source="@invoiceLinesCsv" Encoding="utf-8" />
                     </ReportDataSources>
                     <ReportFormulaFields>
                         <ReportFormulaField Name="BillToSummary" Formula="'Bill to: ' + {BillTo.Name}" />
@@ -160,11 +159,6 @@
     private string cleanDefinitionJson;
 
     private bool loadingReport;
-
-    private const string invoiceLinesCsv = "Sku,Description,Quantity,UnitPrice,Total\r\n"
-        + "HB-104,CSV coastal inventory tags,18,30.00,540.00\r\n"
-        + "HB-118,CSV insulated cargo sleeves,22,50.00,1100.00\r\n"
-        + "HB-142,CSV route planning credits,31,25.00,775.00";
 
     private readonly InvoiceReportModel invoice = new()
     {

--- a/Demos/Shared/Blazorise.Demo.Reporting/_Imports.razor
+++ b/Demos/Shared/Blazorise.Demo.Reporting/_Imports.razor
@@ -8,6 +8,5 @@
 @using Blazorise.Pdf
 @using Blazorise.PdfViewer
 @using Blazorise.Reporting
-@using Blazorise.Reporting.DataSources.Csv
 @using Blazorise.Shared.Data
 @using Blazorise.Shared.Models

--- a/Demos/Shared/Blazorise.Demo/Blazorise.Demo.csproj
+++ b/Demos/Shared/Blazorise.Demo/Blazorise.Demo.csproj
@@ -16,7 +16,6 @@
     <ProjectReference Include="..\..\..\Source\Extensions\Blazorise.LoadingIndicator\Blazorise.LoadingIndicator.csproj" />
     <ProjectReference Include="..\..\..\Source\Extensions\Blazorise.Pdf\Blazorise.Pdf.csproj" />
     <ProjectReference Include="..\..\..\Source\Extensions\Blazorise.Reporting\Blazorise.Reporting.csproj" />
-    <ProjectReference Include="..\..\..\Source\Extensions\Blazorise.Reporting.DataSources.Csv\Blazorise.Reporting.DataSources.Csv.csproj" />
     <ProjectReference Include="..\..\..\Source\Extensions\Blazorise.RichTextEdit\Blazorise.RichTextEdit.csproj" />
     <ProjectReference Include="..\..\..\Source\Extensions\Blazorise.Snackbar\Blazorise.Snackbar.csproj" />
     <ProjectReference Include="..\..\..\Source\Extensions\Blazorise.FluentValidation\Blazorise.FluentValidation.csproj" />

--- a/Demos/Shared/Blazorise.Demo/Config.cs
+++ b/Demos/Shared/Blazorise.Demo/Config.cs
@@ -7,7 +7,6 @@ using Blazorise.FluentValidation;
 using Blazorise.LoadingIndicator;
 using Blazorise.Pdf;
 using Blazorise.Reporting;
-using Blazorise.Reporting.DataSources.Csv;
 using Blazorise.RichTextEdit;
 using Blazorise.Shared.Models;
 using FluentValidation;
@@ -58,7 +57,6 @@ public static class Config
             .AddBlazoriseFluentValidation()
             .AddBlazoriseReporting()
             .AddBlazorisePdfHttpResources()
-            .AddBlazoriseReportingCsvDataSource()
             .AddBlazoriseGoogleReCaptcha( options =>
             {
                 options.SiteKey = reCaptchaSiteKey;

--- a/Demos/Shared/Blazorise.Demo/Config.cs
+++ b/Demos/Shared/Blazorise.Demo/Config.cs
@@ -1,14 +1,15 @@
 #region Using directives
-using Blazored.LocalStorage;
 using Blazorise.Captcha.ReCaptcha;
 using Blazorise.CodeEditor;
 using Blazorise.Components;
+using Blazorise.Demo.Setup;
 using Blazorise.FluentValidation;
 using Blazorise.LoadingIndicator;
 using Blazorise.Pdf;
 using Blazorise.Reporting;
 using Blazorise.Reporting.DataSources.Csv;
 using Blazorise.RichTextEdit;
+using Blazorise.Shared.Models;
 using FluentValidation;
 using Microsoft.Extensions.DependencyInjection;
 #endregion
@@ -64,11 +65,8 @@ public static class Config
             } )
             .AddBlazoriseRouterTabs();
 
-        services.AddBlazoredLocalStorage();
-
-        services.AddValidatorsFromAssembly( typeof( App ).Assembly );
-
-        services.AddMemoryCache();
+        services.AddScoped<PersonValidator>();
+        services.AddScoped<IValidator<Person>>( serviceProvider => serviceProvider.GetRequiredService<PersonValidator>() );
 
         // register demo services to fetch test data
         services.AddScoped<Shared.Data.EmployeeData>();

--- a/Demos/Shared/Blazorise.Demo/WasmApp.razor
+++ b/Demos/Shared/Blazorise.Demo/WasmApp.razor
@@ -6,8 +6,11 @@
 @using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.AspNetCore.Components.WebAssembly.Services
 @using Microsoft.Extensions.Logging
+@using Microsoft.JSInterop
+@implements IAsyncDisposable
 @inject LazyAssemblyLoader AssemblyLoader
 @inject ILogger<WasmApp> Logger
+@inject IJSRuntime JSRuntime
 
 <Blazorise.ThemeProvider Theme="@theme">
     <Router AppAssembly="typeof( App ).Assembly"
@@ -35,6 +38,7 @@
     [
         "Blazorise.Demo.Charts.wasm",
         "Blazorise.Charts.wasm",
+        "Blazorise.Charts.Svg.wasm",
         "Blazorise.Charts.Annotation.wasm",
         "Blazorise.Charts.DataLabels.wasm",
         "Blazorise.Charts.Streaming.wasm",
@@ -46,6 +50,7 @@
     [
         "Blazorise.Demo.DataGrid.wasm",
         "Blazorise.DataGrid.wasm",
+        "Microsoft.CSharp.wasm",
     ];
 
     private static readonly string[] reportingAssemblies =
@@ -83,6 +88,11 @@
         "Blazorise.Splitter.wasm",
         "Blazorise.TreeView.wasm",
         "Blazorise.Video.wasm",
+    ];
+
+    private static readonly string[] todoAssemblies =
+    [
+        "TodoApp.wasm",
     ];
 
     private static readonly string[] componentRoutes =
@@ -131,18 +141,35 @@
 
     private readonly HashSet<string> loadedAssemblyFiles = new( StringComparer.OrdinalIgnoreCase );
 
+    private IJSObjectReference reCaptchaLoader;
+
     private async Task OnNavigateAsync( NavigationContext context )
     {
+        bool isReCaptchaRoute = string.Equals( context.Path?.TrimStart( '/' ), "tests/captcha", StringComparison.OrdinalIgnoreCase );
+
         var assembliesToLoad = GetAssemblyFilesForRoute( context.Path )
             .Where( assemblyFile => !loadedAssemblyFiles.Contains( assemblyFile ) )
             .ToArray();
 
-        if ( assembliesToLoad.Length == 0 )
+        if ( assembliesToLoad.Length == 0 && !isReCaptchaRoute )
             return;
 
         try
         {
             context.CancellationToken.ThrowIfCancellationRequested();
+
+            if ( isReCaptchaRoute )
+            {
+                reCaptchaLoader ??= await JSRuntime.InvokeAsync<IJSObjectReference>(
+                    "import",
+                    context.CancellationToken,
+                    "./_content/Blazorise.Demo/recaptcha-loader.js" );
+
+                await reCaptchaLoader.InvokeVoidAsync( "load", context.CancellationToken );
+            }
+
+            if ( assembliesToLoad.Length == 0 )
+                return;
 
             var loadedAssemblies = await AssemblyLoader.LoadAssembliesAsync( assembliesToLoad );
 
@@ -167,7 +194,7 @@
         }
         catch ( Exception exception )
         {
-            Logger.LogError( exception, "Unable to lazy load demo assemblies for route '{Route}'.", context.Path );
+            Logger.LogError( exception, "Unable to load demo resources for route '{Route}'.", context.Path );
         }
     }
 
@@ -194,12 +221,23 @@
         if ( IsInRouteGroup( path, extensionRoutes ) )
             return extensionAssemblies;
 
+        if ( string.Equals( path, "apps/todo", StringComparison.OrdinalIgnoreCase ) )
+            return todoAssemblies;
+
         return [];
     }
 
     private static bool IsInRouteGroup( string path, IEnumerable<string> routes )
     {
         return routes.Any( route => string.Equals( path, route, StringComparison.OrdinalIgnoreCase ) );
+    }
+
+    async ValueTask IAsyncDisposable.DisposeAsync()
+    {
+        if ( reCaptchaLoader is not null )
+        {
+            await reCaptchaLoader.DisposeAsync();
+        }
     }
 
     private Theme theme = new()

--- a/Demos/Shared/Blazorise.Demo/wwwroot/recaptcha-loader.js
+++ b/Demos/Shared/Blazorise.Demo/wwwroot/recaptcha-loader.js
@@ -1,0 +1,25 @@
+let loadPromise;
+
+export function load() {
+    if (globalThis.grecaptcha)
+        return Promise.resolve();
+
+    if (loadPromise)
+        return loadPromise;
+
+    loadPromise = new Promise((resolve, reject) => {
+        const script = document.createElement("script");
+        script.src = "https://www.google.com/recaptcha/api.js";
+        script.async = true;
+        script.defer = true;
+        script.onload = resolve;
+        script.onerror = () => {
+            loadPromise = undefined;
+            reject(new Error("Unable to load Google reCAPTCHA."));
+        };
+
+        document.head.appendChild(script);
+    });
+
+    return loadPromise;
+}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,6 @@
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="Blazored.LocalStorage" Version="4.5.0" />
     <PackageVersion Include="Blazorise.Licensing" Version="1.3.0" />
-    <PackageVersion Include="Bogus" Version="35.6.5" />
     <PackageVersion Include="bunit" Version="2.8.6" />
     <PackageVersion Include="ColorCode.HTML" Version="2.0.15" />
     <PackageVersion Include="coverlet.collector" Version="10.0.0" />
@@ -14,7 +13,6 @@
     <PackageVersion Include="FluentAssertions" Version="8.9.0" />
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
-    <PackageVersion Include="Flurl.Http" Version="4.0.2" />
     <PackageVersion Include="Fody" Version="6.9.3" />
     <PackageVersion Include="FodyHelpers" Version="6.9.3" />
     <PackageVersion Include="FodyPackaging" Version="6.9.3" />
@@ -30,9 +28,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageVersion Include="Microsoft.Playwright.NUnit" Version="1.59.0" />

--- a/Shared/Blazorise.Shared/Blazorise.Shared.csproj
+++ b/Shared/Blazorise.Shared/Blazorise.Shared.csproj
@@ -17,9 +17,4 @@
 		</EmbeddedResource>
 	</ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Caching.Abstractions" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
-	</ItemGroup>
-
 </Project>

--- a/Shared/Blazorise.Shared/Data/CountryData.cs
+++ b/Shared/Blazorise.Shared/Data/CountryData.cs
@@ -1,36 +1,26 @@
 ﻿#region Using directives
+using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Blazorise.Shared.Models;
-using Microsoft.Extensions.Caching.Memory;
 #endregion
 
 namespace Blazorise.Shared.Data;
 
 public class CountryData
 {
-    private readonly IMemoryCache cache;
-    private readonly string cacheKey = "cache_countries";
-
-    /// <summary>
-    /// Simplified code to get & cache data in memory...
-    /// </summary>
-    public CountryData( IMemoryCache memoryCache )
-    {
-        cache = memoryCache;
-    }
+    private static readonly Lazy<List<Country>> countries = new( LoadData );
 
     public Task<IEnumerable<Country>> GetDataAsync()
-        => cache.GetOrCreateAsync( cacheKey, LoadData );
+        => Task.FromResult<IEnumerable<Country>>( countries.Value );
 
-    private Task<IEnumerable<Country>> LoadData( ICacheEntry cacheEntry )
+    private static List<Country> LoadData()
     {
         Assembly assembly = typeof( EmployeeData ).Assembly;
         using var stream = assembly.GetManifestResourceStream( "Blazorise.Shared.Resources.CountryData.json" );
-        return Task.FromResult( JsonSerializer.Deserialize<List<Country>>( new StreamReader( stream ).ReadToEnd() ).AsEnumerable() );
+        return JsonSerializer.Deserialize<List<Country>>( new StreamReader( stream ).ReadToEnd() );
     }
 }

--- a/Shared/Blazorise.Shared/Data/EmployeeData.cs
+++ b/Shared/Blazorise.Shared/Data/EmployeeData.cs
@@ -1,4 +1,5 @@
 ﻿#region Using directives
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -6,7 +7,6 @@ using System.Reflection;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Blazorise.Shared.Models;
-using Microsoft.Extensions.Caching.Memory;
 #endregion
 
 namespace Blazorise.Shared.Data;
@@ -19,16 +19,7 @@ public class Gender
 
 public class EmployeeData
 {
-    private readonly IMemoryCache cache;
-    private readonly string employeesCacheKey = "cache_employees";
-
-    /// <summary>
-    /// Simplified code to get & cache data in memory...
-    /// </summary>
-    public EmployeeData( IMemoryCache memoryCache )
-    {
-        cache = memoryCache;
-    }
+    private static readonly Lazy<List<Employee>> employees = new( LoadData );
 
     public static IEnumerable<Gender> Genders = new List<Gender>()
     {
@@ -54,15 +45,15 @@ public class EmployeeData
         }
     };
 
-    public async Task<List<Employee>> GetDataAsync()
-        => ( await cache.GetOrCreateAsync( employeesCacheKey, LoadData ) )
-        .Select( x => new Employee( x ) ) //new() is used so we make sure that we are not returning the same item references avoiding an application wide "data corruption".
-        .ToList();
+    public Task<List<Employee>> GetDataAsync()
+        => Task.FromResult( employees.Value
+            .Select( x => new Employee( x ) ) //new() is used so we make sure that we are not returning the same item references avoiding an application wide "data corruption".
+            .ToList() );
 
-    private Task<List<Employee>> LoadData( ICacheEntry cacheEntry )
+    private static List<Employee> LoadData()
     {
         Assembly assembly = typeof( EmployeeData ).Assembly;
         using var stream = assembly.GetManifestResourceStream( "Blazorise.Shared.Resources.EmployeeData.json" );
-        return Task.FromResult( JsonSerializer.Deserialize<List<Employee>>( new StreamReader( stream ).ReadToEnd() ) );
+        return JsonSerializer.Deserialize<List<Employee>>( new StreamReader( stream ).ReadToEnd() );
     }
 }


### PR DESCRIPTION
Removes unused heavy dependencies and CSV reporting support, defers feature-specific assemblies and reCAPTCHA, and avoids blocking font downloads while preserving existing demos.