### PR TITLE
Field: deprecate JustifyContent in favor of Flex

### DIFF
--- a/Demos/Shared/Blazorise.Demo.Components/Pages/DropdownListPage.razor
+++ b/Demos/Shared/Blazorise.Demo.Components/Pages/DropdownListPage.razor
@@ -7,7 +7,7 @@
                 <CardTitle>Dropdown List: Single Value</CardTitle>
             </CardHeader>
             <CardBody>
-                <Field Horizontal JustifyContent="JustifyContent.End">
+                <Field Horizontal Flex="Flex.JustifyContent.End">
                     <FieldLabel ColumnSize="ColumnSize.Is2">Select Value</FieldLabel>
                     <FieldBody ColumnSize="ColumnSize.Is10">
                         <DropdownList TItem="Country"
@@ -23,7 +23,7 @@
                         </DropdownList>
                     </FieldBody>
                 </Field>
-                <Field Horizontal JustifyContent="JustifyContent.End">
+                <Field Horizontal Flex="Flex.JustifyContent.End">
                     <FieldBody ColumnSize="ColumnSize.Is10.Is2.WithOffset">
                         Selected value: @selectedDropValue
                     </FieldBody>
@@ -51,7 +51,7 @@
                 Showing the use of IReadOnlyList&lt;T&gt; as the TValue type for DropdownList.
             </CardBody>
             <CardBody>
-                <Field Horizontal JustifyContent="JustifyContent.End">
+                <Field Horizontal Flex="Flex.JustifyContent.End">
                     <FieldLabel ColumnSize="ColumnSize.Is2">Select Value</FieldLabel>
                     <FieldBody ColumnSize="ColumnSize.Is10">
                         <DropdownList TItem="Country"
@@ -68,7 +68,7 @@
                         </DropdownList>
                     </FieldBody>
                 </Field>
-                <Field Horizontal JustifyContent="JustifyContent.End">
+                <Field Horizontal Flex="Flex.JustifyContent.End">
                     <FieldBody ColumnSize="ColumnSize.Is10.Is2.WithOffset">
                         Selected values: @(selectedDropValues is not null ? string.Join( ',', selectedDropValues ) : "")
                     </FieldBody>
@@ -94,7 +94,7 @@
                 Showing the use of Array as the TValue type for DropdownList.
             </CardBody>
             <CardBody>
-                <Field Horizontal JustifyContent="JustifyContent.End">
+                <Field Horizontal Flex="Flex.JustifyContent.End">
                     <FieldLabel ColumnSize="ColumnSize.Is2">Select Value</FieldLabel>
                     <FieldBody ColumnSize="ColumnSize.Is10">
                         <DropdownList TItem="Country"
@@ -111,7 +111,7 @@
                         </DropdownList>
                     </FieldBody>
                 </Field>
-                <Field Horizontal JustifyContent="JustifyContent.End">
+                <Field Horizontal Flex="Flex.JustifyContent.End">
                     <FieldBody ColumnSize="ColumnSize.Is10.Is2.WithOffset">
                         Selected values: @(selectedDropValues2 is not null ? string.Join( ',', selectedDropValues2 ) : "")
                     </FieldBody>

--- a/Demos/Shared/Blazorise.Demo.Components/Pages/RepeaterPage.razor
+++ b/Demos/Shared/Blazorise.Demo.Components/Pages/RepeaterPage.razor
@@ -8,7 +8,7 @@
                 <CardTitle>Repeater</CardTitle>
             </CardHeader>
             <CardBody>
-                <Field Horizontal JustifyContent="JustifyContent.End">
+                <Field Horizontal Flex="Flex.JustifyContent.End">
                     <FieldLabel ColumnSize="ColumnSize.Is6">
                         <Buttons>
                             <Button Color="Color.Primary" Clicked="@(() => items.Add( items.Count + 1 ))">Add</Button>
@@ -30,7 +30,7 @@
                         </Dropdown>
                     </FieldBody>
                 </Field>
-                <Field Horizontal JustifyContent="JustifyContent.End">
+                <Field Horizontal Flex="Flex.JustifyContent.End">
                     <FieldBody ColumnSize="ColumnSize.Is12">
                         <UnorderedList>
                             <Repeater Items="@items">

--- a/Demos/Shared/Blazorise.Demo.Components/Pages/SelectListPage.razor
+++ b/Demos/Shared/Blazorise.Demo.Components/Pages/SelectListPage.razor
@@ -8,7 +8,7 @@
                 <CardTitle>Select List</CardTitle>
             </CardHeader>
             <CardBody>
-                <Field Horizontal JustifyContent="JustifyContent.End">
+                <Field Horizontal Flex="Flex.JustifyContent.End">
                     <FieldLabel ColumnSize="ColumnSize.Is2">Select Value</FieldLabel>
                     <FieldBody ColumnSize="ColumnSize.Is10">
                         <SelectList TItem="Country"
@@ -20,7 +20,7 @@
                                     DefaultItemText="Choose your country" />
                     </FieldBody>
                 </Field>
-                <Field Horizontal JustifyContent="JustifyContent.End">
+                <Field Horizontal Flex="Flex.JustifyContent.End">
                     <FieldBody ColumnSize="ColumnSize.Is10.Is2.WithOffset">
                         Selected value: @selectedListValue
                     </FieldBody>
@@ -34,7 +34,7 @@
                 <CardTitle>With Multiple Selections</CardTitle>
             </CardHeader>
             <CardBody>
-                <Field Horizontal JustifyContent="JustifyContent.End">
+                <Field Horizontal Flex="Flex.JustifyContent.End">
                     <FieldLabel ColumnSize="ColumnSize.Is2">Select Value</FieldLabel>
                     <FieldBody ColumnSize="ColumnSize.Is10">
                         <SelectList TItem="Country"
@@ -47,7 +47,7 @@
                                     DefaultItemText="Choose your country(s)" />
                     </FieldBody>
                 </Field>
-                <Field Horizontal JustifyContent="JustifyContent.End">
+                <Field Horizontal Flex="Flex.JustifyContent.End">
                     <FieldBody ColumnSize="ColumnSize.Is10.Is2.WithOffset">
                         Selected value(s):  @(selectedListValues != null ? string.Join( ',', selectedListValues ) : "")
                     </FieldBody>

--- a/Demos/Shared/Blazorise.Demo/Pages/FormsPage.razor
+++ b/Demos/Shared/Blazorise.Demo/Pages/FormsPage.razor
@@ -354,12 +354,12 @@
                         <TextInput Role="TextRole.Password" Placeholder="Retype password" />
                     </FieldBody>
                 </Field>
-                <Field Horizontal JustifyContent="JustifyContent.End">
+                <Field Horizontal Flex="Flex.JustifyContent.End">
                     <FieldBody ColumnSize="ColumnSize.Is9.Is3.WithOffset">
                         <Check TValue="bool">Check me out</Check>
                     </FieldBody>
                 </Field>
-                <Field Horizontal JustifyContent="JustifyContent.End">
+                <Field Horizontal Flex="Flex.JustifyContent.End">
                     <FieldBody ColumnSize="ColumnSize.Is9.Is3.WithOffset">
                         <Button Color="Color.Primary">Submit</Button>
                     </FieldBody>

--- a/Demos/Shared/Blazorise.Demo/Pages/ValidationsPage.razor
+++ b/Demos/Shared/Blazorise.Demo/Pages/ValidationsPage.razor
@@ -83,7 +83,7 @@
                         </Field>
                     </Validation>
                     <Validation Validator="@ValidateDateOfBirth">
-                        <Field Horizontal JustifyContent="JustifyContent.End">
+                        <Field Horizontal Flex="Flex.JustifyContent.End">
                             <FieldLabel RequiredIndicator ColumnSize="ColumnSize.IsFull.OnTablet.Is3.OnDesktop">Date</FieldLabel>
                             <FieldBody ColumnSize="ColumnSize.IsFull.OnTablet.Is9.OnDesktop">
                                 <DateInput TValue="DateOnly ?">
@@ -95,7 +95,7 @@
                         </Field>
                     </Validation>
                     <Validation UsePattern>
-                        <Field Horizontal JustifyContent="JustifyContent.End">
+                        <Field Horizontal Flex="Flex.JustifyContent.End">
                             <FieldLabel RequiredIndicator ColumnSize="ColumnSize.IsFull.OnTablet.Is3.OnDesktop">Pattern</FieldLabel>
                             <FieldBody ColumnSize="ColumnSize.IsFull.OnTablet.Is9.OnDesktop">
                                 <TextInput Pattern="[A-Za-z]{3}">
@@ -107,7 +107,7 @@
                         </Field>
                     </Validation>
                     <Validation Validator="ValidationRule.IsChecked">
-                        <Field Horizontal JustifyContent="JustifyContent.End">
+                        <Field Horizontal Flex="Flex.JustifyContent.End">
                             <FieldBody ColumnSize="ColumnSize.Is9.Is3.WithOffset">
                                 <Check TValue="bool">
                                     <ChildContent>
@@ -121,7 +121,7 @@
                         </Field>
                     </Validation>
                 </Validations>
-                <Field Horizontal JustifyContent="JustifyContent.End">
+                <Field Horizontal Flex="Flex.JustifyContent.End">
                     <FieldBody ColumnSize="ColumnSize.Is9.Is3.WithOffset">
                         <Button Color="Color.Primary">Submit</Button>
                     </FieldBody>
@@ -208,7 +208,7 @@
                         </Field>
                     </Validation>
                     <Validation Validator="@ValidateDateOfBirth">
-                        <Field Horizontal JustifyContent="JustifyContent.End">
+                        <Field Horizontal Flex="Flex.JustifyContent.End">
                             <FieldLabel RequiredIndicator ColumnSize="ColumnSize.IsFull.OnTablet.Is3.OnDesktop">Date</FieldLabel>
                             <FieldBody ColumnSize="ColumnSize.IsFull.OnTablet.Is9.OnDesktop">
                                 <DateInput TValue="DateOnly ?">
@@ -220,7 +220,7 @@
                         </Field>
                     </Validation>
                     <Validation UsePattern>
-                        <Field Horizontal JustifyContent="JustifyContent.End">
+                        <Field Horizontal Flex="Flex.JustifyContent.End">
                             <FieldLabel RequiredIndicator ColumnSize="ColumnSize.IsFull.OnTablet.Is3.OnDesktop">Pattern</FieldLabel>
                             <FieldBody ColumnSize="ColumnSize.IsFull.OnTablet.Is9.OnDesktop">
                                 <TextInput Pattern="[A-Za-z]{3}">
@@ -232,7 +232,7 @@
                         </Field>
                     </Validation>
                     <Validation Validator="ValidationRule.IsChecked">
-                        <Field Horizontal JustifyContent="JustifyContent.End">
+                        <Field Horizontal Flex="Flex.JustifyContent.End">
                             <FieldBody ColumnSize="ColumnSize.Is9.Is3.WithOffset">
                                 <Check TValue="bool">
                                     <ChildContent>
@@ -245,7 +245,7 @@
                             </FieldBody>
                         </Field>
                     </Validation>
-                    <Field Horizontal JustifyContent="JustifyContent.End">
+                    <Field Horizontal Flex="Flex.JustifyContent.End">
                         <FieldBody ColumnSize="ColumnSize.Is9.Is3.WithOffset">
                             <Button Color="Color.Primary" Clicked="@Submit">Submit</Button>
                         </FieldBody>
@@ -363,7 +363,7 @@
                         </Field>
                     </Validation>
                     <Validation>
-                        <Field Horizontal JustifyContent="JustifyContent.End">
+                        <Field Horizontal Flex="Flex.JustifyContent.End">
                             <FieldBody ColumnSize="ColumnSize.Is9.Is3.WithOffset">
                                 <Check @bind-Value="@user.TermsAndConditions">
                                     <ChildContent>
@@ -376,7 +376,7 @@
                             </FieldBody>
                         </Field>
                     </Validation>
-                    <Field Horizontal JustifyContent="JustifyContent.End">
+                    <Field Horizontal Flex="Flex.JustifyContent.End">
                         <FieldBody ColumnSize="ColumnSize.Is9.Is3.WithOffset">
                             <Button Color="Color.Primary">Submit</Button>
                         </FieldBody>
@@ -461,7 +461,7 @@
                         </Field>
                     </Validation>
                     <Validation>
-                        <Field Horizontal JustifyContent="JustifyContent.End">
+                        <Field Horizontal Flex="Flex.JustifyContent.End">
                             <FieldBody ColumnSize="ColumnSize.Is9.Is3.WithOffset">
                                 <Check @bind-Value="@manualUser.TermsAndConditions">
                                     <ChildContent>
@@ -474,7 +474,7 @@
                             </FieldBody>
                         </Field>
                     </Validation>
-                    <Field Horizontal JustifyContent="JustifyContent.End">
+                    <Field Horizontal Flex="Flex.JustifyContent.End">
                         <FieldBody ColumnSize="ColumnSize.Is9.Is3.WithOffset">
                             <Button Color="Color.Primary" Clicked="@AnnotationsSubmit">Submit</Button>
                         </FieldBody>

--- a/Documentation/Blazorise.Docs/Resources/docs-api-index.json
+++ b/Documentation/Blazorise.Docs/Resources/docs-api-index.json
@@ -1,5 +1,5 @@
 ﻿{
-  "generatedUtc": "2026-08-22T17:54:34.3151658Z",
+  "generatedUtc": "2026-08-23T06:26:12.0741384Z",
   "components": [
     {
       "type": "global::Blazorise.Abbreviation",
@@ -49027,6 +49027,7 @@
           "typeName": "JustifyContent",
           "defaultValue": "Default",
           "summary": "Specifies how the container's items are aligned along the main axis when there is extra space available.",
+          "remarks": "This parameter is retained for source compatibility. Use <strong>Flex</strong> instead.",
           "isBlazoriseEnum": true
         },
         {

--- a/Source/Blazorise/Components/Field/Field.razor.cs
+++ b/Source/Blazorise/Components/Field/Field.razor.cs
@@ -335,6 +335,10 @@ public partial class Field : BaseColumnComponent, IDisposable
     /// <summary>
     /// Specifies how the container's items are aligned along the main axis when there is extra space available.
     /// </summary>
+    /// <remarks>
+    /// This parameter is retained for source compatibility. Use <see cref="BaseComponent.Flex"/> instead.
+    /// </remarks>
+    [Obsolete( "Use the Flex parameter with Flex.JustifyContent instead." )]
     [Parameter]
     public JustifyContent JustifyContent
     {

--- a/Source/Extensions/Blazorise.DataGrid/Constants.cs
+++ b/Source/Extensions/Blazorise.DataGrid/Constants.cs
@@ -27,6 +27,7 @@ static class Constants
 
     // Flex
     internal static readonly IFluentFlex FlexRow = Flex.Row;
+    internal static readonly IFluentFlex FlexJustifyContentBetween = Flex.JustifyContent.Between;
     internal static readonly IFluentFlex FlexJustifyContentEndAlignItemsCenter = Flex.JustifyContent.End.AlignItems.Center;
     internal static readonly IFluentFlex FlexRowAlignItemsCenterJustifyContentEnd = Flex.Row.AlignItems.Center.JustifyContent.End;
     internal static readonly IFluentFlex FlexInlineFlexOnTabletJustifyContentCenterOnTablet = Flex.InlineFlex.OnTablet.JustifyContent.Center.OnTablet;

--- a/Source/Extensions/Blazorise.DataGrid/Internal/_DataGridPagination.razor
+++ b/Source/Extensions/Blazorise.DataGrid/Internal/_DataGridPagination.razor
@@ -1,6 +1,6 @@
 ﻿@typeparam TItem
 @inherits BaseComponent
-<Row class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
+<Row class="@ClassNames" style="@StyleNames" Flex="FlexJustifyContentBetween" @attributes="@Attributes">
     <Column ColumnSize="ColumnSizeIsAuto" Flex="FlexRow">
         @if ( GetButtonRowPosition() == PagerElementPosition.Start || GetButtonRowPosition() == PagerElementPosition.Default )
         {

--- a/Source/Extensions/Blazorise.DataGrid/Internal/_DataGridPagination.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/Internal/_DataGridPagination.razor.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Threading.Tasks;
 using Blazorise.Localization;
-using Blazorise.Utilities;
 using Microsoft.AspNetCore.Components;
 #endregion
 
@@ -72,13 +71,6 @@ partial class _DataGridPagination<TItem> : BaseComponent, IDisposable
     private async void OnLocalizationChanged( object sender, EventArgs e )
     {
         await InvokeAsync( StateHasChanged );
-    }
-
-    /// <inheritdoc />
-    protected override void BuildClasses( ClassBuilder builder )
-    {
-        builder.Append( ClassProvider.FieldJustifyContent( JustifyContent.Between ) );
-        base.BuildClasses( builder );
     }
 
     /// <summary>

--- a/Source/Helpers/Blazorise.Analyzers/AnalyzerReleases.Unshipped.txt
+++ b/Source/Helpers/Blazorise.Analyzers/AnalyzerReleases.Unshipped.txt
@@ -7,6 +7,7 @@ BLZJS002: Blazorise Animate obsolete script reference
 BLZP002: Blazorise parameter type changed
 BLZP003: Blazorise parameter removed
 BLZP004: Blazorise Color.Link is button/alert-only
+BLZP005: Blazorise parameter obsolete
 BLZR001: Blazorise Razor tag renamed
 BLZS001: Blazorise member renamed
 BLZS002: Blazorise member removed

--- a/Source/Helpers/Blazorise.Analyzers/BlazoriseMigrationMappings.cs
+++ b/Source/Helpers/Blazorise.Analyzers/BlazoriseMigrationMappings.cs
@@ -19,6 +19,8 @@ public sealed record ComponentMapping
 
     public IReadOnlyDictionary<string, string> ParameterRemovals { get; init; }
 
+    public IReadOnlyDictionary<string, string> ParameterObsoleteMessages { get; init; } = new Dictionary<string, string>();
+
     public TValueShape TValueShape { get; init; }
 
     public string Notes { get; init; }
@@ -466,6 +468,19 @@ public static partial class BlazoriseMigrationMappings
             },
             TValueShape.Any,
             "Fields now uses a single IFluentGutter on Gutter; HorizontalGutter, VerticalGutter and NoGutters have been replaced by the fluent gutter API." ) );
+
+        list.Add( new ComponentMapping(
+            "Blazorise.Field",
+            "Blazorise.Field",
+            new Dictionary<string, string>(),
+            TValueShape.Any,
+            "Field uses the fluent Flex utility for flexbox alignment." )
+        {
+            ParameterObsoleteMessages = new Dictionary<string, string>
+            {
+                ["JustifyContent"] = "Use the Flex parameter with Flex.JustifyContent instead.",
+            }
+        } );
 
         list.Add( new ComponentMapping(
             "Blazorise.ModalContent",

--- a/Source/Helpers/Blazorise.Analyzers/Migration/Rules/RenderTreeMigrationAnalyzer.cs
+++ b/Source/Helpers/Blazorise.Analyzers/Migration/Rules/RenderTreeMigrationAnalyzer.cs
@@ -50,6 +50,14 @@ public sealed class RenderTreeMigrationAnalyzer : DiagnosticAnalyzer
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true );
 
+    private static readonly DiagnosticDescriptor ParameterObsoleteRule = new(
+        id: "BLZP005",
+        title: "Blazorise parameter obsolete",
+        messageFormat: "Parameter '{0}' is obsolete on component '{1}': {2}",
+        category: "Usage",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true );
+
     private static readonly DiagnosticDescriptor ColorLinkRule = new(
         id: "BLZP004",
         title: "Blazorise Color.Link is button/alert-only",
@@ -72,6 +80,7 @@ public sealed class RenderTreeMigrationAnalyzer : DiagnosticAnalyzer
         ParameterRenameRule,
         ParameterTypeChangeRule,
         ParameterRemovedRule,
+        ParameterObsoleteRule,
         ColorLinkRule,
         TValueShapeRule );
 
@@ -208,6 +217,20 @@ public sealed class RenderTreeMigrationAnalyzer : DiagnosticAnalyzer
                     attributeName,
                     component.ComponentType.ToDisplayString( SymbolDisplayFormat.MinimallyQualifiedFormat ),
                     removalNote ) );
+            }
+
+            if ( mapping.ParameterObsoleteMessages.TryGetValue( attributeName, out string obsoleteMessage ) )
+            {
+                ImmutableDictionary<string, string?> properties = ImmutableDictionary<string, string?>.Empty
+                    .Add( MigrationDiagnosticProperties.OldName, attributeName );
+
+                context.ReportDiagnostic( Diagnostic.Create(
+                    ParameterObsoleteRule,
+                    location,
+                    properties,
+                    attributeName,
+                    component.ComponentType.ToDisplayString( SymbolDisplayFormat.MinimallyQualifiedFormat ),
+                    obsoleteMessage ) );
             }
 
             ReportParameterTypeChanges( context, component, attributeName, valueOperation, location );

--- a/Tests/Blazorise.Analyzers.Tests/ComponentMigrationAnalyzerTests.cs
+++ b/Tests/Blazorise.Analyzers.Tests/ComponentMigrationAnalyzerTests.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 using Xunit;
 
 namespace Blazorise.Analyzers.Tests;
@@ -234,6 +235,36 @@ public class MyComponent : Microsoft.AspNetCore.Components.ComponentBase
         Assert.Contains( removalDiagnostics, d => d.GetMessage() == "Parameter 'Centered' was removed from component 'ModalContent': Use the Modal.Centered parameter instead." );
         Assert.Contains( removalDiagnostics, d => d.GetMessage() == "Parameter 'Scrollable' was removed from component 'ModalContent': Use the Modal.Scrollable parameter instead." );
         Assert.Contains( removalDiagnostics, d => d.GetMessage() == "Parameter 'Size' was removed from component 'ModalContent': Use the Modal.Size parameter instead." );
+    }
+
+    [Fact]
+    public async Task Reports_field_justifycontent_parameter_as_obsolete()
+    {
+        var source = @"
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace Blazorise
+{
+    public enum JustifyContent { Default, Start, End, Center, Between, Around }
+    public class Field : Microsoft.AspNetCore.Components.ComponentBase { }
+}
+
+public class MyComponent : Microsoft.AspNetCore.Components.ComponentBase
+{
+    public void Build( RenderTreeBuilder builder )
+    {
+        builder.OpenComponent<Blazorise.Field>( 0 );
+        builder.AddAttribute( 1, ""JustifyContent"", Blazorise.JustifyContent.End );
+        builder.CloseComponent();
+    }
+}";
+
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync( source );
+
+        var diagnostic = Assert.Single( diagnostics );
+        Assert.Equal( "BLZP005", diagnostic.Id );
+        Assert.Equal( DiagnosticSeverity.Warning, diagnostic.Severity );
+        Assert.Equal( "Parameter 'JustifyContent' is obsolete on component 'Field': Use the Flex parameter with Flex.JustifyContent instead.", diagnostic.GetMessage() );
     }
 
     [Fact]


### PR DESCRIPTION
Closes #4200

This marks the `Field.JustifyContent` parameter as obsolete and directs users to the shared Flex utility, for example `Flex="Flex.JustifyContent.End"`. The existing parameter behavior remains unchanged for source compatibility.

All repository-owned `Field` usages were migrated to the Flex API. The DataGrid pagination layout was also updated to stop calling the legacy FieldJustifyContent provider hook directly.

The analyzer now reports the new `BLZP005` warning when `Field.JustifyContent` is used and explains the recommended replacement. The migration mapping, analyzer release manifest, and focused analyzer coverage were updated accordingly.