### PR TITLE
DropdownToggle: rename ToggleIconVisible to ShowToggleIcon

### DIFF
--- a/Demos/Shared/Blazorise.Demo/Pages/DropdownsPage.razor
+++ b/Demos/Shared/Blazorise.Demo/Pages/DropdownsPage.razor
@@ -92,7 +92,7 @@
                     </DropdownMenu>
                 </Dropdown>
                 <Dropdown>
-                    <DropdownToggle Color="Color.Danger" ToggleIconVisible="false">
+                    <DropdownToggle Color="Color.Danger" ShowToggleIcon="false">
                         Hidden toggle button
                     </DropdownToggle>
                     <DropdownMenu>

--- a/Documentation/Blazorise.Docs/Models/Snippets.generated.cs
+++ b/Documentation/Blazorise.Docs/Models/Snippets.generated.cs
@@ -2117,6 +2117,17 @@ namespace Blazorise.Docs.Models
     </DropdownMenu>
 </Dropdown>";
 
+        public const string DropdownToggleIconExample = @"<Dropdown>
+    <DropdownToggle Color=""Color.Primary"" ShowToggleIcon=""false"">
+        Dropdown without toggle icon
+    </DropdownToggle>
+    <DropdownMenu>
+        <DropdownItem>Action</DropdownItem>
+        <DropdownDivider />
+        <DropdownItem>Another Action</DropdownItem>
+    </DropdownMenu>
+</Dropdown>";
+
         public const string NestedDropdownDirectionExample = @"<Dropdown>
     <DropdownToggle Color=""Color.Primary"">Level 1</DropdownToggle>
     <DropdownMenu>

--- a/Documentation/Blazorise.Docs/Pages/Docs/Components/Dropdowns/Code/DropdownToggleIconExampleCode.html
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Components/Dropdowns/Code/DropdownToggleIconExampleCode.html
@@ -1,0 +1,14 @@
+<div class="blazorise-codeblock">
+<div class="html"><pre>
+<span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">Dropdown</span><span class="htmlTagDelimiter">&gt;</span>
+    <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">DropdownToggle</span> <span class="htmlAttributeName">Color</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="enum">Color</span><span class="enumValue">.Primary</span><span class="quot">&quot;</span> <span class="htmlAttributeName">ShowToggleIcon</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="keyword">false</span><span class="quot">&quot;</span><span class="htmlTagDelimiter">&gt;</span>
+        Dropdown without toggle icon
+    <span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">DropdownToggle</span><span class="htmlTagDelimiter">&gt;</span>
+    <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">DropdownMenu</span><span class="htmlTagDelimiter">&gt;</span>
+        <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">DropdownItem</span><span class="htmlTagDelimiter">&gt;</span>Action<span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">DropdownItem</span><span class="htmlTagDelimiter">&gt;</span>
+        <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">DropdownDivider</span> <span class="htmlTagDelimiter">/&gt;</span>
+        <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">DropdownItem</span><span class="htmlTagDelimiter">&gt;</span>Another Action<span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">DropdownItem</span><span class="htmlTagDelimiter">&gt;</span>
+    <span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">DropdownMenu</span><span class="htmlTagDelimiter">&gt;</span>
+<span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">Dropdown</span><span class="htmlTagDelimiter">&gt;</span>
+</pre></div>
+</div>

--- a/Documentation/Blazorise.Docs/Pages/Docs/Components/Dropdowns/DropdownPage.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Components/Dropdowns/DropdownPage.razor
@@ -1,4 +1,4 @@
-﻿@page "/docs/components/dropdown"
+@page "/docs/components/dropdown"
 
 <Seo Canonical="/docs/components/dropdown" Title="Blazorise Dropdown component" Description="Learn to use and work with the Blazorise Dropdown components which are toggleable, contextual overlays for displaying lists of links and actions in a dropdown menu format." />
 
@@ -64,6 +64,15 @@
     </DocsPageSectionHeader>
     <DocsPageSectionContent Code="DropdownExample" Outlined>
         <DropdownExample />
+    </DocsPageSectionContent>
+</DocsPageSection>
+
+<DocsPageSection>
+    <DocsPageSectionHeader Title="Toggle icon visibility">
+        Use the <Code>ShowToggleIcon</Code> parameter to control whether the dropdown toggle displays its indicator icon.
+    </DocsPageSectionHeader>
+    <DocsPageSectionContent Code="DropdownToggleIconExample" Outlined>
+        <DropdownToggleIconExample />
     </DocsPageSectionContent>
 </DocsPageSection>
 

--- a/Documentation/Blazorise.Docs/Pages/Docs/Components/Dropdowns/Examples/DropdownToggleIconExample.razor
+++ b/Documentation/Blazorise.Docs/Pages/Docs/Components/Dropdowns/Examples/DropdownToggleIconExample.razor
@@ -1,0 +1,12 @@
+@namespace Blazorise.Docs.Docs.Examples
+
+<Dropdown>
+    <DropdownToggle Color="Color.Primary" ShowToggleIcon="false">
+        Dropdown without toggle icon
+    </DropdownToggle>
+    <DropdownMenu>
+        <DropdownItem>Action</DropdownItem>
+        <DropdownDivider />
+        <DropdownItem>Another Action</DropdownItem>
+    </DropdownMenu>
+</Dropdown>

--- a/Documentation/Blazorise.Docs/Resources/docs-api-index.json
+++ b/Documentation/Blazorise.Docs/Resources/docs-api-index.json
@@ -1,5 +1,5 @@
 ﻿{
-  "generatedUtc": "2026-08-23T06:26:12.0741384Z",
+  "generatedUtc": "2026-08-24T09:00:26.8864828Z",
   "components": [
     {
       "type": "global::Blazorise.Abbreviation",
@@ -8832,6 +8832,15 @@
           "isBlazoriseEnum": true
         },
         {
+          "name": "ShowToggleIcon",
+          "type": "bool?",
+          "typeName": "bool?",
+          "defaultValue": "null",
+          "summary": "Specifies a value indicating whether the dropdown toggle icon is visible.",
+          "remarks": "Default: True",
+          "isBlazoriseEnum": false
+        },
+        {
           "name": "Stretched",
           "type": "bool",
           "typeName": "bool",
@@ -8941,7 +8950,7 @@
           "typeName": "bool?",
           "defaultValue": "null",
           "summary": "Specifies a value indicating whether the dropdown toggle icon is visible.",
-          "remarks": "Default: True",
+          "remarks": "This parameter is retained for source compatibility. Use <strong>ShowToggleIcon</strong> instead.",
           "isBlazoriseEnum": false
         },
         {
@@ -43944,7 +43953,7 @@
           "type": "Func<,>",
           "typeName": "Func<DockPaneClosingEventArgs, Task>",
           "defaultValue": "null",
-          "summary": "Callback invoked before the pane closes. Set <strong>DockPaneClosingEventArgs.Cancel</strong> to prevent closing.",
+          "summary": "Callback invoked before the pane closes.",
           "isBlazoriseEnum": false
         }
       ],
@@ -48585,6 +48594,15 @@
           "isBlazoriseEnum": true
         },
         {
+          "name": "ShowToggleIcon",
+          "type": "bool?",
+          "typeName": "bool?",
+          "defaultValue": "null",
+          "summary": "Specifies a value indicating whether the dropdown toggle icon is visible.",
+          "remarks": "Default: True",
+          "isBlazoriseEnum": false
+        },
+        {
           "name": "Size",
           "type": "global::Blazorise.Size?",
           "typeName": "Size?",
@@ -48678,7 +48696,7 @@
           "typeName": "bool?",
           "defaultValue": "null",
           "summary": "Specifies a value indicating whether the dropdown toggle icon is visible.",
-          "remarks": "Default: True",
+          "remarks": "This parameter is retained for source compatibility. Use <strong>ShowToggleIcon</strong> instead.",
           "isBlazoriseEnum": false
         },
         {

--- a/Documentation/Blazorise.Docs/Resources/docs-index.json
+++ b/Documentation/Blazorise.Docs/Resources/docs-index.json
@@ -1,5 +1,5 @@
 ﻿{
-  "generatedUtc": "2026-08-24T08:33:50.3364519Z",
+  "generatedUtc": "2026-08-24T09:03:32.3850362Z",
   "pages": [
     {
       "route": "/docs",
@@ -1583,6 +1583,14 @@
           "sourcePath": "Pages/Docs/Components/Dropdowns/Examples/DropdownExample.razor",
           "content": "<Dropdown>\r\n    <DropdownToggle Color=\"Color.Primary\">\r\n        Dropdown\r\n    </DropdownToggle>\r\n    <DropdownMenu>\r\n        <DropdownItem>Action</DropdownItem>\r\n        <DropdownDivider />\r\n        <DropdownItem>Another Action</DropdownItem>\r\n    </DropdownMenu>\r\n</Dropdown>",
           "title": "Dropdown"
+        },
+        {
+          "code": "DropdownToggleIconExample",
+          "kind": "razor",
+          "sourcePath": "Pages/Docs/Components/Dropdowns/Examples/DropdownToggleIconExample.razor",
+          "content": "<Dropdown>\r\n    <DropdownToggle Color=\"Color.Primary\" ShowToggleIcon=\"false\">\r\n        Dropdown without toggle icon\r\n    </DropdownToggle>\r\n    <DropdownMenu>\r\n        <DropdownItem>Action</DropdownItem>\r\n        <DropdownDivider />\r\n        <DropdownItem>Another Action</DropdownItem>\r\n    </DropdownMenu>\r\n</Dropdown>",
+          "title": "Toggle icon visibility",
+          "description": "Use the ShowToggleIcon parameter to control whether the dropdown toggle displays its indicator icon."
         },
         {
           "code": "DropdownCheckboxExample",

--- a/Source/Blazorise/Components/Bar/BarDropdownToggle.razor.cs
+++ b/Source/Blazorise/Components/Bar/BarDropdownToggle.razor.cs
@@ -28,7 +28,7 @@ public partial class BarDropdownToggle : BaseLinkComponent, ICloseActivator, IAs
 
     private double indentation = 1.5d;
 
-    private bool? toggleIconVisible;
+    private bool? showToggleIcon;
 
     private Theme theme;
 
@@ -371,7 +371,7 @@ public partial class BarDropdownToggle : BaseLinkComponent, ICloseActivator, IAs
     /// <summary>
     /// Should the toggle icon be drawn
     /// </summary>
-    protected bool IsToggleIconVisible => ToggleIconVisible.GetValueOrDefault( Theme?.BarOptions?.DropdownOptions?.ToggleIconVisible ?? true );
+    protected bool IsToggleIconVisible => ShowToggleIcon.GetValueOrDefault( Theme?.BarOptions?.DropdownOptions?.ToggleIconVisible ?? true );
 
     /// <summary>
     /// Gets the icon name for the expanded state of the dropdown.
@@ -540,18 +540,32 @@ public partial class BarDropdownToggle : BaseLinkComponent, ICloseActivator, IAs
     /// </value>
     /// <remarks>Default: True</remarks>
     [Parameter]
-    public bool? ToggleIconVisible
+    public bool? ShowToggleIcon
     {
-        get => toggleIconVisible;
+        get => showToggleIcon;
         set
         {
-            if ( toggleIconVisible == value )
+            if ( showToggleIcon == value )
                 return;
 
-            toggleIconVisible = value;
+            showToggleIcon = value;
 
             DirtyClasses();
         }
+    }
+
+    /// <summary>
+    /// Specifies a value indicating whether the dropdown toggle icon is visible.
+    /// </summary>
+    /// <remarks>
+    /// This parameter is retained for source compatibility. Use <see cref="ShowToggleIcon"/> instead.
+    /// </remarks>
+    [Obsolete( "Use ShowToggleIcon instead." )]
+    [Parameter]
+    public bool? ToggleIconVisible
+    {
+        get => ShowToggleIcon;
+        set => ShowToggleIcon = value;
     }
 
     /// <summary>

--- a/Source/Blazorise/Components/Dropdown/DropdownToggle.razor.cs
+++ b/Source/Blazorise/Components/Dropdown/DropdownToggle.razor.cs
@@ -271,7 +271,7 @@ public partial class DropdownToggle : BaseComponent, ICloseActivator, IAsyncDisp
     /// <summary>
     /// Should the toggle icon be drawn
     /// </summary>
-    protected bool IsToggleIconVisible => ToggleIconVisible.GetValueOrDefault( Theme?.DropdownOptions?.ToggleIconVisible ?? true );
+    protected bool IsToggleIconVisible => ShowToggleIcon.GetValueOrDefault( Theme?.DropdownOptions?.ToggleIconVisible ?? true );
 
     /// <summary>
     /// Gets the size based on the theme settings.
@@ -385,7 +385,21 @@ public partial class DropdownToggle : BaseComponent, ICloseActivator, IAsyncDisp
     /// <c>true</c> if [show toggle]; otherwise, <c>false</c>.
     /// </value>
     /// <remarks>Default: True</remarks>
-    [Parameter] public bool? ToggleIconVisible { get; set; }
+    [Parameter] public bool? ShowToggleIcon { get; set; }
+
+    /// <summary>
+    /// Specifies a value indicating whether the dropdown toggle icon is visible.
+    /// </summary>
+    /// <remarks>
+    /// This parameter is retained for source compatibility. Use <see cref="ShowToggleIcon"/> instead.
+    /// </remarks>
+    [Obsolete( "Use ShowToggleIcon instead." )]
+    [Parameter]
+    public bool? ToggleIconVisible
+    {
+        get => ShowToggleIcon;
+        set => ShowToggleIcon = value;
+    }
 
     /// <summary>
     /// If defined, indicates that its element can be focused and can participates in sequential keyboard navigation.

--- a/Source/Extensions/Blazorise.DataGrid/Internal/_DataGridMenuFilter.razor
+++ b/Source/Extensions/Blazorise.DataGrid/Internal/_DataGridMenuFilter.razor
@@ -2,7 +2,7 @@
 @typeparam TItem
 
 <Dropdown @bind-Visible="@Column.DropdownFilterVisible">
-    <DropdownToggle Size="Size.Small" Border="BorderIs0" Background="BackgroundTransparent" Shadow="Shadow.Remove" ToggleIconVisible="false" @onclick:stopPropagation>
+    <DropdownToggle Size="Size.Small" Border="BorderIs0" Background="BackgroundTransparent" Shadow="Shadow.Remove" ShowToggleIcon="false" @onclick:stopPropagation>
         <Icon Name="@IconName.Filter" Margin="MarginIs1FromStart" Clicked="() => { }" TextColor="@(IsFiltering() ? TextColor.Primary : TextColor.Default)" />
     </DropdownToggle>
     <DropdownMenu>

--- a/Source/Extensions/Blazorise.Reporting/Components/ReportToolbarPanesMenu.razor
+++ b/Source/Extensions/Blazorise.Reporting/Components/ReportToolbarPanesMenu.razor
@@ -8,7 +8,7 @@
         <DropdownToggle Color="@Color"
                         Size="@Size"
                         Outline
-                        ToggleIconVisible="false"
+                        ShowToggleIcon="false"
                         title="@Text"
                         aria-label="@Text">
             @if ( ShowCaption )

--- a/Source/Helpers/Blazorise.Analyzers/BlazoriseMigrationMappings.cs
+++ b/Source/Helpers/Blazorise.Analyzers/BlazoriseMigrationMappings.cs
@@ -307,6 +307,26 @@ public static partial class BlazoriseMigrationMappings
             "Dropdown uses EndAligned instead of RightAligned." ) );
 
         list.Add( new ComponentMapping(
+            "Blazorise.DropdownToggle",
+            "Blazorise.DropdownToggle",
+            new Dictionary<string, string>
+            {
+                ["ToggleIconVisible"] = "ShowToggleIcon",
+            },
+            TValueShape.Any,
+            "DropdownToggle uses ShowToggleIcon instead of ToggleIconVisible." ) );
+
+        list.Add( new ComponentMapping(
+            "Blazorise.BarDropdownToggle",
+            "Blazorise.BarDropdownToggle",
+            new Dictionary<string, string>
+            {
+                ["ToggleIconVisible"] = "ShowToggleIcon",
+            },
+            TValueShape.Any,
+            "BarDropdownToggle uses ShowToggleIcon instead of ToggleIconVisible." ) );
+
+        list.Add( new ComponentMapping(
             "Blazorise.Components.Autocomplete`2",
             "Blazorise.Components.Autocomplete`2",
             new Dictionary<string, string>

--- a/Tests/Blazorise.Analyzers.Tests/ComponentMigrationAnalyzerTests.cs
+++ b/Tests/Blazorise.Analyzers.Tests/ComponentMigrationAnalyzerTests.cs
@@ -637,6 +637,40 @@ public class MyComponent : Microsoft.AspNetCore.Components.ComponentBase
     }
 
     [Fact]
+    public async Task Reports_dropdown_toggle_icon_parameter_renames()
+    {
+        var source = @"
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace Blazorise
+{
+    public class DropdownToggle : Microsoft.AspNetCore.Components.ComponentBase { }
+    public class BarDropdownToggle : Microsoft.AspNetCore.Components.ComponentBase { }
+}
+
+public class MyComponent : Microsoft.AspNetCore.Components.ComponentBase
+{
+    public void Build( RenderTreeBuilder builder )
+    {
+        builder.OpenComponent<Blazorise.DropdownToggle>( 0 );
+        builder.AddAttribute( 1, ""ToggleIconVisible"", false );
+        builder.CloseComponent();
+
+        builder.OpenComponent<Blazorise.BarDropdownToggle>( 2 );
+        builder.AddAttribute( 3, ""ToggleIconVisible"", false );
+        builder.CloseComponent();
+    }
+}";
+
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync( source );
+
+        var renameDiagnostics = diagnostics.Where( d => d.Id == "BLZP001" ).ToArray();
+        Assert.Equal( 2, renameDiagnostics.Length );
+        Assert.Contains( renameDiagnostics, d => d.GetMessage() == "Parameter 'ToggleIconVisible' was renamed to 'ShowToggleIcon' for component 'DropdownToggle'" );
+        Assert.Contains( renameDiagnostics, d => d.GetMessage() == "Parameter 'ToggleIconVisible' was renamed to 'ShowToggleIcon' for component 'BarDropdownToggle'" );
+    }
+
+    [Fact]
     public async Task Reports_datagridcolumn_width_type_change()
     {
         var source = @"


### PR DESCRIPTION
Closes #6760

Renames the parameter on DropdownToggle and BarDropdownToggle, retains obsolete aliases, updates usages, adds analyzer migration rules, and documents the new parameter.