### PR TITLE
Autocomplete: optimize keyboard navigation rendering

### DIFF
--- a/Source/Extensions/Blazorise.Components/Autocomplete.razor
+++ b/Source/Extensions/Blazorise.Components/Autocomplete.razor
@@ -1,5 +1,6 @@
 @using Blazorise.Extensions
 @using Blazorise
+@using Blazorise.Components.Internal
 @using Microsoft.AspNetCore.Components.Web.Virtualization
 @inherits BaseInputComponent<TValue, AutocompleteClasses<TItem, TValue>, AutocompleteStyles<TItem, TValue>>
 @typeparam TItem
@@ -59,20 +60,21 @@
             @if ( VirtualizeManualReadMode )
             {
                 <Virtualize @ref="virtualizeRef" TItem="TItem" Context="item" ItemsProvider="VirtualizeItemsProviderHandler">
-                    @itemFragment( item )
+                    @RenderItem( item, FilteredData.IndexOf( item ) )
                 </Virtualize>
             }
             else if ( Virtualize )
             {
                 <Virtualize @ref="virtualizeRef" TItem="TItem" Context="item" Items="@FilteredData">
-                    @itemFragment( item )
+                    @RenderItem( item, FilteredData.IndexOf( item ) )
                 </Virtualize>
             }
             else
             {
-                @foreach ( var item in FilteredData ?? Enumerable.Empty<TItem>() )
+                @for ( int itemIndex = 0; itemIndex < FilteredData.Count; itemIndex++ )
                 {
-                    @itemFragment( item )
+                    TItem item = FilteredData[itemIndex];
+                    @RenderItem( item, itemIndex )
                 }
             }
         }
@@ -96,41 +98,27 @@
 </Dropdown>
 @Feedback
 @code {
-    protected RenderFragment<TItem> itemFragment => item => __builder =>
+    protected RenderFragment RenderItem( TItem item, int itemIndex ) => __builder =>
     {
         var isActiveItem = IsSuggestedActiveItem( item );
-        var itemIndex = FilteredData.IndexOf( item );
         var isFocusedItem = itemIndex == ActiveItemIndex;
         var disabled = GetItemDisabled( item );
-
-        var isCheckbox = SelectionMode == AutocompleteSelectionMode.Checkbox;
-
         var text = GetItemText( item );
         var value = GetItemValue( item );
         var itemContext = CreateItemContext( item, value, text, itemIndex, isActiveItem, isFocusedItem, disabled );
 
-        <DropdownItem @key="@item" ElementId="@DropdownItemId( itemIndex )" Active="@isActiveItem" Checked=@isActiveItem ShowCheckbox=@isCheckbox TabIndex="-1" Class="@DropdownItemClassNames( itemContext )" Style="@DropdownItemStyleNames( itemContext )" Value="@value"
-                      Disabled="@disabled"
-                      CloseParentDropdowns="@CloseParentDropdowns"
-                      @onmousedown="@(() => clickFromCheck = true)"
-                      @onpointerdown="@(() => clickFromCheck = true)"
-                      Clicked="() => isCheckbox ? Task.CompletedTask : OnDropdownItemSelected(value)"
-                      CheckedChanged="() => isCheckbox ? OnDropdownItemSelected(value) : Task.CompletedTask">
-            @if ( ItemContent is not null )
-            {
-                @ItemContent( itemContext )
-            }
-            else
-            {
-                @if ( HighlightSearch && Search?.Length > 0 )
-                {
-                    <Highlighter Text="@text" HighlightedText="@Search" />
-                }
-                else
-                {
-                    @text
-                }
-            }
-        </DropdownItem>
+        <_AutocompleteItem @key="@item"
+                           TItem="TItem"
+                           TValue="TValue"
+                           Context="@itemContext"
+                           ElementId="@DropdownItemId( itemIndex )"
+                           Class="@DropdownItemClassNames( itemContext )"
+                           Style="@DropdownItemStyleNames( itemContext )"
+                           CloseParentDropdowns="@CloseParentDropdowns"
+                           HighlightSearch="@HighlightSearch"
+                           Search="@Search"
+                           ItemContent="@ItemContent"
+                           PointerDown="@(() => clickFromCheck = true)"
+                           Selected="@OnDropdownItemSelected" />
     };
 }

--- a/Source/Extensions/Blazorise.Components/Internal/_AutocompleteItem.razor
+++ b/Source/Extensions/Blazorise.Components/Internal/_AutocompleteItem.razor
@@ -1,0 +1,32 @@
+@namespace Blazorise.Components.Internal
+@using Blazorise.Components.Autocomplete
+@typeparam TItem
+@typeparam TValue
+
+<DropdownItem ElementId="@ElementId"
+              Active="@Context.Active"
+              Checked="@Context.Active"
+              ShowCheckbox="@Context.Checkbox"
+              TabIndex="-1"
+              Class="@Class"
+              Style="@Style"
+              Value="@Context.Value"
+              Disabled="@Context.Disabled"
+              CloseParentDropdowns="@CloseParentDropdowns"
+              @onmousedown="@OnPointerDown"
+              @onpointerdown="@OnPointerDown"
+              Clicked="@OnClicked"
+              CheckedChanged="@OnCheckedChanged">
+    @if ( ItemContent is not null )
+    {
+        @ItemContent( Context )
+    }
+    else if ( HighlightSearch && Search?.Length > 0 )
+    {
+        <Highlighter Text="@Context.Text" HighlightedText="@Search" />
+    }
+    else
+    {
+        @Context.Text
+    }
+</DropdownItem>

--- a/Source/Extensions/Blazorise.Components/Internal/_AutocompleteItem.razor.cs
+++ b/Source/Extensions/Blazorise.Components/Internal/_AutocompleteItem.razor.cs
@@ -18,6 +18,7 @@ public partial class _AutocompleteItem<TItem, TValue> : ComponentBase
     #region Members
 
     private bool rendered;
+
     private bool shouldRender = true;
 
     #endregion

--- a/Source/Extensions/Blazorise.Components/Internal/_AutocompleteItem.razor.cs
+++ b/Source/Extensions/Blazorise.Components/Internal/_AutocompleteItem.razor.cs
@@ -1,0 +1,151 @@
+#region Using directives
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Blazorise.Components.Autocomplete;
+using Microsoft.AspNetCore.Components;
+#endregion
+
+namespace Blazorise.Components.Internal;
+
+/// <summary>
+/// Internal renderer for a single Autocomplete suggestion.
+/// </summary>
+/// <typeparam name="TItem">Type of the suggested item.</typeparam>
+/// <typeparam name="TValue">Type of the suggested value.</typeparam>
+public partial class _AutocompleteItem<TItem, TValue> : ComponentBase
+{
+    #region Members
+
+    private bool rendered;
+    private bool shouldRender = true;
+
+    #endregion
+
+    #region Methods
+
+    /// <inheritdoc />
+    public override Task SetParametersAsync( ParameterView parameters )
+    {
+        var contextChanged = parameters.TryGetValue<ItemContext<TItem, TValue>>( nameof( Context ), out ItemContext<TItem, TValue> newContext ) && !AreEqual( Context, newContext );
+        var elementIdChanged = parameters.TryGetValue<string>( nameof( ElementId ), out string newElementId ) && ElementId != newElementId;
+        var classChanged = parameters.TryGetValue<string>( nameof( Class ), out string newClass ) && Class != newClass;
+        var styleChanged = parameters.TryGetValue<string>( nameof( Style ), out string newStyle ) && Style != newStyle;
+        var closeParentDropdownsChanged = parameters.TryGetValue<bool>( nameof( CloseParentDropdowns ), out bool newCloseParentDropdowns ) && CloseParentDropdowns != newCloseParentDropdowns;
+        var highlightSearchChanged = parameters.TryGetValue<bool>( nameof( HighlightSearch ), out bool newHighlightSearch ) && HighlightSearch != newHighlightSearch;
+        var searchChanged = parameters.TryGetValue<string>( nameof( Search ), out string newSearch ) && Search != newSearch;
+        var itemContentChanged = parameters.TryGetValue<RenderFragment<ItemContext<TItem, TValue>>>( nameof( ItemContent ), out RenderFragment<ItemContext<TItem, TValue>> newItemContent ) && !Equals( ItemContent, newItemContent );
+
+        shouldRender = shouldRender
+            || !rendered
+            || contextChanged
+            || elementIdChanged
+            || classChanged
+            || styleChanged
+            || closeParentDropdownsChanged
+            || highlightSearchChanged
+            || searchChanged
+            || itemContentChanged;
+
+        return base.SetParametersAsync( parameters );
+    }
+
+    /// <inheritdoc />
+    protected override bool ShouldRender()
+        => shouldRender;
+
+    /// <inheritdoc />
+    protected override Task OnAfterRenderAsync( bool firstRender )
+    {
+        rendered = true;
+        shouldRender = false;
+        return base.OnAfterRenderAsync( firstRender );
+    }
+
+    private Task OnPointerDown()
+        => PointerDown.InvokeAsync();
+
+    private Task OnClicked( object value )
+        => Context.Checkbox || !Selected.HasDelegate
+            ? Task.CompletedTask
+            : Selected.InvokeAsync( value );
+
+    private Task OnCheckedChanged( bool _ )
+        => Context.Checkbox && Selected.HasDelegate
+            ? Selected.InvokeAsync( Context.Value )
+            : Task.CompletedTask;
+
+    private static bool AreEqual( ItemContext<TItem, TValue> first, ItemContext<TItem, TValue> second )
+    {
+        if ( ReferenceEquals( first, second ) )
+            return true;
+
+        if ( first is null || second is null )
+            return false;
+
+        return EqualityComparer<TItem>.Default.Equals( first.Item, second.Item )
+            && EqualityComparer<TValue>.Default.Equals( first.Value, second.Value )
+            && first.Text == second.Text
+            && first.Index == second.Index
+            && first.Active == second.Active
+            && first.Focused == second.Focused
+            && first.Disabled == second.Disabled
+            && first.Checkbox == second.Checkbox;
+    }
+
+    #endregion
+
+    #region Properties
+
+    /// <summary>
+    /// Gets or sets the suggestion context.
+    /// </summary>
+    [Parameter] public ItemContext<TItem, TValue> Context { get; set; }
+
+    /// <summary>
+    /// Gets or sets the rendered suggestion element identifier.
+    /// </summary>
+    [Parameter] public string ElementId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the rendered suggestion classes.
+    /// </summary>
+    [Parameter] public string Class { get; set; }
+
+    /// <summary>
+    /// Gets or sets the rendered suggestion styles.
+    /// </summary>
+    [Parameter] public string Style { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether selecting the suggestion closes parent dropdowns.
+    /// </summary>
+    [Parameter] public bool CloseParentDropdowns { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether matching search text is highlighted.
+    /// </summary>
+    [Parameter] public bool HighlightSearch { get; set; }
+
+    /// <summary>
+    /// Gets or sets the current search text.
+    /// </summary>
+    [Parameter] public string Search { get; set; }
+
+    /// <summary>
+    /// Gets or sets the custom suggestion content.
+    /// </summary>
+    [Parameter] public RenderFragment<ItemContext<TItem, TValue>> ItemContent { get; set; }
+
+    /// <summary>
+    /// Gets or sets the pointer-down callback.
+    /// </summary>
+    [Parameter] public EventCallback PointerDown { get; set; }
+
+    /// <summary>
+    /// Gets or sets the selection callback.
+    /// </summary>
+    [Parameter] public EventCallback<object> Selected { get; set; }
+
+    #endregion
+}

--- a/Tests/Blazorise.Tests/Components/AutoCompleteComponentTest.cs
+++ b/Tests/Blazorise.Tests/Components/AutoCompleteComponentTest.cs
@@ -3,8 +3,10 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Blazorise;
 using Blazorise.Components;
+using Blazorise.Components.Autocomplete;
 using Blazorise.Shared.Models;
 using Bunit;
+using Microsoft.AspNetCore.Components;
 using Xunit;
 #endregion
 
@@ -121,6 +123,37 @@ public class AutocompleteComponentTest : AutocompleteBaseComponentTest
         await autoComplete.KeyDownAsync( Key.Get( 'S' ) );
 
         Assert.Equal( 1, changedCount );
+    }
+
+    [Fact]
+    public async Task KeyboardNavigation_ShouldOnlyRenderRowsWhoseFocusChanged()
+    {
+        int itemContentRenderCount = 0;
+        RenderFragment<ItemContext<string, string>> itemContent = context => builder =>
+        {
+            itemContentRenderCount++;
+            builder.AddContent( 0, context.Text );
+        };
+        IRenderedComponent<Autocomplete<string, string>> comp = Render<Autocomplete<string, string>>( parameters => parameters
+            .Add( x => x.Data, new List<string> { "Alpha", "Beta", "Gamma" } )
+            .Add( x => x.TextField, x => x )
+            .Add( x => x.ValueField, x => x )
+            .Add( x => x.MinSearchLength, 0 )
+            .Add( x => x.AutoPreSelect, false )
+            .Add( x => x.ItemContent, itemContent ) );
+
+        AngleSharp.Dom.IElement autoComplete = comp.Find( ".b-is-autocomplete input" );
+        await autoComplete.FocusAsync( new() );
+        int initialRenderCount = itemContentRenderCount;
+        Assert.Equal( 3, initialRenderCount );
+
+        await autoComplete.KeyDownAsync( Key.Down );
+
+        Assert.Equal( initialRenderCount + 1, itemContentRenderCount );
+
+        await autoComplete.KeyDownAsync( Key.Down );
+
+        Assert.Equal( initialRenderCount + 3, itemContentRenderCount );
     }
 
     [Fact]


### PR DESCRIPTION
Closes #6772

Isolates suggestion rows so keyboard navigation rerenders only items whose focus changed, improving performance for large or templated result sets.