### PR TITLE
Base input: capture value changes before first render completes

### DIFF
--- a/Source/Blazorise/Base/BaseInputComponent.cs
+++ b/Source/Blazorise/Base/BaseInputComponent.cs
@@ -130,7 +130,7 @@ public abstract class BaseInputComponent<TValue, TClasses, TStyles> : BaseCompon
     protected virtual void CaptureParameters( ParameterView parameters )
     {
         // Capture synchronously since ParameterView is not safe after awaits.
-        if ( Rendered )
+        if ( Rendered || hasInitializedParameters )
             parameters.TryGetParameter( Value, IsSameAsInternalValue, out paramValue );
         else
             paramValue = new ComponentParameterInfo<TValue>( default );


### PR DESCRIPTION
Closes #6781

Fixes a race where values assigned during asynchronous initialization could be ignored while first-render JS initialization was still pending. Subsequent parameter updates are now captured once input parameters have been initialized.