### PR TITLE
BarDropdown: fix JavaScript initialization for wrapperless dropdowns

### DIFF
--- a/Source/Blazorise/Components/Bar/BarDropdown.razor.cs
+++ b/Source/Blazorise/Components/Bar/BarDropdown.razor.cs
@@ -81,7 +81,11 @@ public partial class BarDropdown : BaseComponent, IAsyncDisposable
             if ( !string.IsNullOrWhiteSpace( dropdownToggleClassNames )
                  && !string.IsNullOrWhiteSpace( dropdownMenuClassNames ) )
             {
-                JSModule.Initialize( ElementRef, ElementId, targetElementId: null, menuElementId: null,
+                ElementReference elementRef = string.IsNullOrEmpty( ElementRef.Id )
+                    ? ParentBarItem?.ElementRef ?? ElementRef
+                    : ElementRef;
+
+                JSModule.Initialize( elementRef, ElementId, targetElementId: null, menuElementId: null,
                     options: new()
                     {
                         Direction = GetFloatingDirection().ToString( "g" ),

--- a/Source/Blazorise/wwwroot/utilities.js
+++ b/Source/Blazorise/wwwroot/utilities.js
@@ -440,7 +440,7 @@ function estimateNumberInputCaret(element, clientX) {
 }
 
 export function getRequiredElement(element, elementId) {
-    if (element)
+    if (element instanceof Element)
         return element;
 
     return document.getElementById(elementId);


### PR DESCRIPTION
Use the parent BarItem element when BarDropdown has no wrapper, and validate DOM references before using them. Fixes `element.querySelector` is not a function.